### PR TITLE
feat: decode TxSq arrangement-marker text

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,51 @@ logic_project("bounce_stems", {marker_name: "Verse 1", groups: ["Guitars","Vocal
 | `logic://midi/ports` | Available MIDI input/output ports | 10s |
 | `logic://system/health` | Channel status, cache snapshot, permissions | on-demand |
 
+## Dependencies
+
+### Build Dependencies
+
+| Dependency | Version | Purpose |
+|-----------|---------|---------|
+| **Swift** | 6.0+ | Language and compiler |
+| **macOS SDK** | 14+ (Sonoma) | Target platform |
+| **MCP Swift SDK** | 0.10+ | Model Context Protocol server framework |
+| **Xcode Command Line Tools** | Latest | Build toolchain (`swift build`) |
+
+The MCP Swift SDK is the only external Swift package dependency (fetched automatically by Swift Package Manager). All other frameworks used are system-provided:
+
+### System Frameworks (no install required)
+
+| Framework | Purpose |
+|-----------|---------|
+| `ApplicationServices` | Accessibility API (AXUIElement) for UI automation |
+| `CoreMIDI` | Virtual MIDI ports, MMC transport, note/CC sending |
+| `CoreGraphics` | CGEvent keyboard injection (postToPid, HID tap) |
+| `AppKit` | NSPasteboard (clipboard), NSRunningApplication, NSAppleScript |
+| `Foundation` | Process spawning, file I/O, JSON, property lists |
+| `Network` | UDP sockets for OSC client/server |
+
+### Runtime Dependencies
+
+| Dependency | Required | Purpose |
+|-----------|----------|---------|
+| **Logic Pro** | Yes (for real-time control) | Target application. Binary parser works without Logic running. |
+| **macOS Accessibility permission** | Yes | System Settings → Privacy & Security → Accessibility → add terminal/node |
+| **macOS Automation permission** | Yes | Granted on first AppleScript interaction with Logic Pro |
+| **macOS Screen Recording** | Optional | Only needed for peekaboo screenshot capture |
+| `/usr/bin/osascript` | Yes (system-provided) | Used for focus-dependent keystrokes (solo, mute, cycle toggle) via System Events |
+
+### Custom Logic Pro Key Commands (for automated bouncing)
+
+The bounce automation requires two custom key commands assigned in Logic Pro's Key Commands editor (Option+K):
+
+| Command | Suggested Shortcut | Purpose |
+|---------|-------------------|---------|
+| Set Left Locator to Playhead Position | `Cmd+Ctrl+[` | Sets cycle start point |
+| Set Right Locator to Playhead Position | `Cmd+Ctrl+]` | Sets cycle end point |
+
+These are used by `bounce_stems execute` to set precise cycle ranges for per-song stem bouncing.
+
 ## Installation
 
 ### Build from Source

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@
 
 Bidirectional, stateful control of Logic Pro from AI assistants. Combines **5 native macOS control channels** (CoreMIDI, Accessibility, CGEvent, AppleScript, OSC) into a single MCP server with smart routing, fallback chains, and sub-millisecond transport latency.
 
-**8 tools, 7 resources, ~3k context tokens.** Not 100+ individual tools.
+**8 tools, 9 resources, ~3k context tokens.** Not 100+ individual tools.
+
+Forked from [koltyj/logic-pro-mcp](https://github.com/koltyj/logic-pro-mcp) with significant enhancements — binary ProjectData parser, extended track hierarchy, function group inference, automated stem bounce planning, additional resources, and bug fixes for cycle range and track solo/select.
 
 ## How It Works
 
 ```
 Claude ──── 8 dispatcher tools ──── logic_transport("play", {})
          │                           logic_tracks("mute", {track: 3})
-         │  7 MCP resources ──────── logic://transport/state
+         │  9 MCP resources ──────── logic://transport/state
          │  (zero tool cost)         logic://tracks
          ▼
    ┌─── LogicProMCP ──────────────────────────────┐
@@ -27,68 +29,128 @@ Claude ──── 8 dispatcher tools ──── logic_transport("play", {})
 
 Each command routes through the fastest available channel, with automatic fallback if the primary fails.
 
-## Tools & Resources
+## Features
 
-### Tools (8 dispatchers — all actions)
+- **8 dispatcher tools** covering transport, tracks, mixer, MIDI, editing, navigation, project lifecycle, and system diagnostics
+- **9 MCP resources** serving live state as JSON at zero context cost
+- **5 native macOS channels**: CoreMIDI, Accessibility API, CGEvent keyboard injection, AppleScript, OSC
+- **Binary ProjectData parser** reads `.logicx` packages directly — no Logic running required
+- **Track hierarchy** with summing stack detection and nesting depth inference
+- **Function group inference** classifies tracks into groups (Guitars, Vocals, Drums, Keys/Synths, etc.)
+- **Automated stem bounce planning** — plans per-group stem bounces from marker boundaries
+- **Smart channel routing** with ordered fallback chains per operation
+- **Adaptive state cache** with configurable polling intervals (500ms active → 5s idle)
 
-| Tool | Commands | Examples |
-|------|----------|----------|
-| `logic_transport` | play, stop, record, set_tempo, goto_position... | `logic_transport("set_tempo", {tempo: 140})` |
-| `logic_tracks` | select, create_audio, mute, solo, arm, rename... | `logic_tracks("mute", {index: 2, enabled: true})` |
-| `logic_mixer` | set_volume, set_pan, insert_plugin, bypass_plugin... | `logic_mixer("set_volume", {track: 0, value: 0.8})` |
-| `logic_midi` | send_note, send_cc, send_chord, mmc_play... | `logic_midi("send_note", {note: 60, velocity: 100, channel: 1, duration_ms: 500})` |
-| `logic_edit` | undo, redo, cut, copy, paste, quantize, split... | `logic_edit("quantize", {value: "1/16"})` |
-| `logic_navigate` | goto_bar, create_marker, toggle_view, set_zoom... | `logic_navigate("toggle_view", {view: "mixer"})` |
-| `logic_project` | new, open, save, bounce, launch, quit | `logic_project("open", {path: "/path/to/song.logicx"})` |
-| `logic_system` | health, permissions, refresh_cache, help | `logic_system("help", {category: "transport"})` |
+## Binary Parser Capabilities
 
-### Resources (7 URIs — zero context cost)
+The `project.analyze` and `logic_project("analyze")` commands parse `.logicx` packages directly from disk:
+
+| Capability | Details |
+|------------|---------|
+| Arrangement markers | Names, bar positions, tick offsets, durations |
+| Tempo map | Initial BPM and all tempo changes with bar positions |
+| Track names | From MSeq chunks; all named and stack container tracks |
+| Time signature | From project plist (`4/4`, `3/4`, etc.) |
+| Sample rate | From project plist (44100, 48000, 96000, etc.) |
+| Audio file paths | All referenced audio files (AuFl chunks) |
+| Audio regions | Per-track regions with start bar, length, audio file OID (AuRg chunks) |
+| Track-to-region mapping | Links each region to its parent track |
+| Output routing | Per-track routing labels from AuCO chunks ("Bus 3", "Output 1-2") |
+| Volume / pan | Per-track normalized values from AuCO chunks |
+| Plugin detection | Plugin names from PluginData chunks |
+| Environment labels | Sub-track grouping labels from Envi chunks |
+| Function group inference | 12 groups inferred from track names and routing |
+| Channel strips | Full AuCO enumeration (449 strips vs 13 MSeq tracks in typical projects) |
+| Song lengths | Per-song lengths from reference track regions or marker boundaries |
+
+## Tools Reference
+
+| Tool | Commands | Description |
+|------|----------|-------------|
+| `logic_transport` | play, stop, record, pause, rewind, fast_forward, toggle_cycle, toggle_metronome, toggle_count_in, set_tempo, goto_position, set_cycle_range | Transport control and position |
+| `logic_tracks` | select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, set_color | Track state and creation |
+| `logic_mixer` | set_volume, set_pan, set_send, set_output, set_input, set_master_volume, toggle_eq, reset_strip, insert_plugin, bypass_plugin | Mixer and plugin control |
+| `logic_midi` | send_note, send_chord, send_cc, send_program_change, send_pitch_bend, send_aftertouch, send_sysex, create_virtual_port, mmc_play, mmc_stop, mmc_record, mmc_locate | MIDI and MMC |
+| `logic_edit` | undo, redo, cut, copy, paste, delete, select_all, split, join, quantize, bounce_in_place, normalize, duplicate | Editing operations |
+| `logic_navigate` | goto_bar, goto_marker, create_marker, delete_marker, rename_marker, list_markers, zoom_to_fit, set_zoom, toggle_view | Navigation and markers |
+| `logic_project` | new, open, save, save_as, close, bounce, bounce_section, bounce_complete, tracks_hierarchy, bounce_stems, song_lengths, launch, quit, analyze | Project lifecycle and analysis |
+| `logic_system` | health, permissions, refresh_cache, help | Diagnostics and help |
+
+### Key Parameter Notes
+
+```
+logic_transport("set_tempo", {tempo: 140})
+logic_transport("goto_position", {bar: 17})
+logic_transport("set_cycle_range", {start: "5.1.1.1", end: "21.1.1.1"})
+
+logic_tracks("select", {index: 0})
+logic_tracks("solo", {index: 2, enabled: true})
+logic_tracks("rename", {index: 0, name: "Lead Vox"})
+
+logic_mixer("set_volume", {track: 0, value: 0.85})   // 0.0–1.0 normalized
+logic_mixer("set_pan", {track: 0, value: -0.5})       // -1.0 left … +1.0 right
+
+logic_midi("send_note", {note: 60, velocity: 100, channel: 1, duration_ms: 500})
+logic_midi("send_chord", {notes: [60,64,67], velocity: 90, channel: 1, duration_ms: 1000})
+
+logic_navigate("toggle_view", {view: "mixer"})
+logic_navigate("create_marker", {name: "Verse 1"})
+
+logic_project("analyze", {path: "/path/to/Song.logicx"})
+logic_project("bounce_stems", {marker_name: "Verse 1", groups: ["Guitars","Vocals"]})
+```
+
+## Resources Reference
 
 | URI | Description | Refresh |
 |-----|-------------|---------|
-| `logic://transport/state` | Playing/recording/tempo/position/cycle | 500ms |
-| `logic://tracks` | All tracks with mute/solo/arm states | 2s |
-| `logic://tracks/{index}` | Single track detail | 2s |
-| `logic://mixer` | All channel strips: volume, pan, plugins | 2s |
-| `logic://project/info` | Project name, sample rate, time sig | 5s |
-| `logic://midi/ports` | Available MIDI ports | 10s |
-| `logic://system/health` | Channel status, cache, permissions | on-demand |
+| `logic://transport/state` | Playing/recording/tempo/position/cycle state | 500ms |
+| `logic://tracks` | All tracks with mute/solo/arm/selected states | 2s |
+| `logic://tracks/{index}` | Single track detail by index | 2s |
+| `logic://tracks/live` | Full live track list with nesting depth | 2s |
+| `logic://mixer` | All channel strips: volume, pan | 2s |
+| `logic://project/info` | Project name, tempo, sample rate, time signature | 5s |
+| `logic://markers` | Arrangement markers (binary parser first, AX fallback) | on-demand |
+| `logic://midi/ports` | Available MIDI input/output ports | 10s |
+| `logic://system/health` | Channel status, cache snapshot, permissions | on-demand |
 
 ## Installation
-
-### Quick Install (Script)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/koltyj/logic-pro-mcp/main/Scripts/install.sh | bash
-```
-
-### Download Binary
-
-Grab the latest universal macOS binary from [GitHub Releases](https://github.com/koltyj/logic-pro-mcp/releases), then:
-
-```bash
-chmod +x LogicProMCP
-sudo mv LogicProMCP /usr/local/bin/
-```
 
 ### Build from Source
 
 Requires Swift 6.0+ and macOS 14+.
 
 ```bash
-git clone https://github.com/koltyj/logic-pro-mcp.git
+git clone https://github.com/alan1/logic-pro-mcp.git
 cd logic-pro-mcp
 swift build -c release
-# Binary at .build/release/LogicProMCP
+sudo cp .build/release/LogicProMCP /usr/local/bin/
 ```
 
 ### Register with Claude Code
 
 ```bash
-claude mcp add --scope user logic-pro -- LogicProMCP
+claude mcp add --scope user logic-pro -- /usr/local/bin/LogicProMCP
 ```
 
-### Claude Desktop (Manual Config)
+### Register with OpenCode
+
+Add to your OpenCode MCP config (`~/.config/opencode/config.json` or equivalent):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "logic-pro": {
+        "command": "/usr/local/bin/LogicProMCP",
+        "args": []
+      }
+    }
+  }
+}
+```
+
+### Register with OpenClaw / Claude Desktop
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -103,71 +165,114 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-## Permissions
+## Permissions Required
 
-The server requires two macOS permissions:
+The server requires two macOS permissions, and optionally a third:
 
-1. **Accessibility** — System Settings > Privacy & Security > Accessibility > add your terminal app
-2. **Automation** — System Settings > Privacy & Security > Automation > allow control of Logic Pro
+1. **Accessibility** — System Settings > Privacy & Security > Accessibility > add your terminal app (or the AI client app)
+2. **Automation (Logic Pro)** — System Settings > Privacy & Security > Automation > allow control of Logic Pro
+3. **Screen Recording** *(optional)* — needed if using peekaboo-based screenshot inspection of the Logic Pro UI
 
-Check permission status:
+Check permission status at any time:
 
 ```bash
 LogicProMCP --check-permissions
+# or via tool:
+# logic_system("permissions", {})
 ```
-
-## Usage
-
-Once registered, ask your AI assistant naturally:
-
-- *"What tracks do I have?"* — reads `logic://tracks` resource
-- *"Mute track 3"* — `logic_tracks("mute", {index: 3, enabled: true})`
-- *"Set tempo to 128"* — `logic_transport("set_tempo", {tempo: 128})`
-- *"Play a C major chord"* — `logic_midi("send_chord", {notes: [60,64,67], ...})`
-- *"Show me the mixer"* — `logic_navigate("toggle_view", {view: "mixer"})`
-
-For full command reference: `logic_system("help", {category: "all"})`
 
 ## Architecture
 
 ### Channel Routing
 
+Each operation is mapped to an ordered list of channels in `ChannelRouter.swift`. The router tries each channel in order and returns the first success. Channels are skipped when unhealthy (e.g. Logic Pro not running, AX not trusted).
+
 | Channel | Latency | Used For |
 |---------|---------|----------|
-| **CoreMIDI** | <1ms | Transport (MMC), note/CC/sysex sending |
-| **Accessibility** | ~15ms | State reading, UI button clicks, slider values |
-| **CGEvent** | <2ms | Keyboard shortcuts (postToPid, no focus needed) |
-| **AppleScript** | ~200ms | App lifecycle only (launch, quit, open file) |
-| **OSC** | <1ms | Mixer control (requires Logic Pro OSC setup) |
+| **CoreMIDI** | <1ms | Transport (MMC), note/CC/sysex/program change |
+| **CGEvent** | <2ms | Keyboard shortcuts (`postToPid` — no focus needed), track navigation |
+| **Accessibility** | ~15ms | State reads, UI clicks (mute/solo/arm buttons, tempo field, locators) |
+| **AppleScript** | ~200ms | App lifecycle (launch, quit, open/close project), cycle range fallback |
+| **OSC** | <1ms | Mixer continuous control (requires Logic Pro OSC control surface setup) |
+
+Example routing chains:
+
+```
+transport.play        → [CGEvent, CoreMIDI, AppleScript]
+transport.set_tempo   → [OSC, Accessibility]
+transport.set_cycle_range → [Accessibility, AppleScript]
+track.select          → [Accessibility, CGEvent]   // AX click header; fallback: Cmd+Up + Down×N
+track.set_solo        → [Accessibility, CGEvent]   // AX click button; fallback: select + S key
+midi.send_note        → [CoreMIDI]
+project.open          → [AppleScript]
+```
 
 ### State Cache
 
 Background Accessibility polling with adaptive intervals:
 
 - **Active** (tool used <5s ago): 500ms transport, 2s tracks/mixer
-- **Light** (5-30s idle): 2s all
+- **Light** (5–30s idle): 2s all
 - **Idle** (>30s): 5s all, near-zero CPU
+
+Resources trigger a direct AX read for freshness before serving cached data.
+
+### Binary Parser
+
+`ProjectDataParser.swift` walks the chunked binary format inside `ProjectData` files in a `.logicx` package. It does not require Logic Pro to be running. Chunk types parsed:
+
+- `MSeq` — track sequences (names, OIDs, hierarchy)
+- `AuCO` — channel strips (volume, pan, routing, names)
+- `AuRg` — audio regions (position, length, file OID)
+- `AuFl` — audio file references (paths)
+- `TxSq` — text sequences (marker names)
+- `EvSq` — event sequences (marker positions, tempo events)
+- `Trak` — arrangement track entries (OID linking)
+- `Envi` — environment objects (stack grouping labels)
 
 ### Context Efficiency
 
 | Approach | Tools | Resources | Context Cost |
-|----------|-------|-----------|-------------|
+|----------|-------|-----------|--------------|
 | Typical MCP server | 100+ tools | 0 | ~40k tokens |
-| **This server** | **8 tools** | **7 resources** | **~3k tokens** |
+| **This server** | **8 tools** | **9 resources** | **~3k tokens** |
 
-Same 100+ operations. 90% less context.
+Same 100+ operations. ~90% less context.
+
+## Differences from Upstream
+
+This fork ([koltyj/logic-pro-mcp](https://github.com/koltyj/logic-pro-mcp)) adds:
+
+| Feature | Status |
+|---------|--------|
+| Binary ProjectData parser (`ProjectDataParser.swift`) | Added |
+| `project.analyze` command | Added |
+| `project.tracks_hierarchy` command | Added |
+| `project.bounce_stems` command with group planning | Added |
+| `project.song_lengths` command | Added |
+| `logic://tracks/live` resource with nesting depth | Added |
+| `logic://markers` resource (binary-first) | Added |
+| `logic://tracks/{index}` parameterized resource | Added |
+| 9 resources (up from 7) | Added |
+| Function group inference (12 groups) | Added |
+| Channel strip enumeration (AuCO) | Added |
+| Environment label parsing (Envi) | Added |
+| Track-to-region mapping | Added |
+| Sub-track hierarchy with stack detection | Added |
+| `transport.set_cycle_range` — AX locator fields + AppleScript fallback | Fixed |
+| `track.select` — CGEvent fallback (Cmd+Up + Down×N) | Fixed |
+| `track.set_solo/mute/arm` — CGEvent fallback (select + S/M/R key) | Fixed |
 
 ## Limitations
 
-Logic Pro does not expose a programmatic API. This server works within macOS platform constraints:
+Logic Pro does not expose a programmatic API. This server operates within macOS platform constraints:
 
 - UI element paths may change between Logic Pro versions
-- Some deep state (automation curves, region MIDI data) is not exposed via Accessibility
+- Some deep state (automation curves, MIDI region data) is not accessible via Accessibility
 - AX element labels may be localized on non-English macOS
-- Plugin parameter control is limited to what's visible in the UI
-- OSC channel requires manual Logic Pro Control Surface setup
-
-This is the ceiling for Logic Pro automation given Apple's constraints.
+- Plugin parameter control is limited to what is visible in the UI
+- OSC channel requires manual Logic Pro Control Surface configuration
+- `set_cycle_range` requires Cycle mode to be enabled for AX locator fields to appear
 
 ## Development
 
@@ -177,11 +282,12 @@ swift build
 
 # Build release
 swift build -c release
+# Binary at .build/release/LogicProMCP
 
 # Run tests
 swift test
 
-# Check permissions without starting server
+# Check permissions
 .build/debug/LogicProMCP --check-permissions
 ```
 
@@ -192,12 +298,13 @@ Sources/LogicProMCP/
   main.swift                 # Entry point
   Server/                    # MCP server + config
   Dispatchers/               # 8 MCP tool dispatchers
-  Resources/                 # 7 MCP resource handlers
-  Channels/                  # 5 communication channels
-  Accessibility/             # AX API wrappers
+  Resources/                 # 9 MCP resource handlers
+  Channels/                  # 5 communication channels + router
+  Accessibility/             # AX API wrappers + Logic element finders
+  Binary/                    # ProjectData binary parser + models
   MIDI/                      # CoreMIDI engine + MMC
   OSC/                       # UDP client/server
-  State/                     # Cache + adaptive poller
+  State/                     # Cache + adaptive poller + state models
   Utilities/                 # Logging, permissions, process utils
 ```
 

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -148,6 +148,105 @@ enum AXLogicProElements {
         return current
     }
 
+    /// Click a menu item by navigating the full path, opening each level in sequence.
+    ///
+    /// Example: `clickMenuItem(path: ["Navigate", "Set Locators by Selection and Enable Cycle"])`
+    ///
+    /// The menu bar must be accessed from the app root. Each path segment:
+    ///   1. Finds the matching child element.
+    ///   2. Presses it (AXPress) to open the submenu.
+    ///   3. Pauses briefly to allow the menu to render.
+    ///   4. Moves into the opened menu before looking for the next title.
+    ///
+    /// Returns true if the final item was successfully pressed.
+    @discardableResult
+    static func clickMenuItem(path: [String]) -> Bool {
+        guard !path.isEmpty else { return false }
+        guard let menuBar = getMenuBar() else {
+            Log.warn("clickMenuItem: could not access menu bar", subsystem: "ax")
+            return false
+        }
+
+        // Step 1: Find and open the top-level menu bar item (e.g. "Navigate")
+        let topTitle = path[0]
+        let barItems = AXHelpers.getChildren(menuBar)
+        guard let barItem = barItems.first(where: { AXHelpers.getTitle($0) == topTitle }) else {
+            Log.warn("clickMenuItem: top-level menu '\(topTitle)' not found", subsystem: "ax")
+            return false
+        }
+
+        // Press the menu bar item to open the pull-down menu
+        guard AXHelpers.performAction(barItem, kAXPressAction) else {
+            Log.warn("clickMenuItem: failed to open menu '\(topTitle)'", subsystem: "ax")
+            return false
+        }
+        Thread.sleep(forTimeInterval: 0.15)
+
+        // Step 2: Navigate remaining path segments through opened menus
+        // After pressing a menu bar item, AX exposes the menu via kAXMenuAttribute or as a child.
+        var currentMenu: AXUIElement = barItem
+        let remainingPath = Array(path.dropFirst())
+
+        for (segIdx, segTitle) in remainingPath.enumerated() {
+            // Resolve the open menu: try kAXMenuAttribute first, then children
+            let openMenu: AXUIElement
+            if let menu: AXUIElement = AXHelpers.getAttribute(currentMenu, "AXMenu") {
+                openMenu = menu
+            } else {
+                // The bar item's children include the menu element
+                let kids = AXHelpers.getChildren(currentMenu)
+                guard let m = kids.first(where: { AXHelpers.getRole($0) == kAXMenuRole }) else {
+                    // Try pressing — current may already be an open menu
+                    openMenu = currentMenu
+                    _ = openMenu  // suppress warning
+                    // Fall through and search children directly
+                    let menuItems = AXHelpers.getChildren(currentMenu)
+                    guard let item = menuItemMatching(segTitle, in: menuItems) else {
+                        Log.warn("clickMenuItem: item '\(segTitle)' not found in menu", subsystem: "ax")
+                        return false
+                    }
+                    let isLast = segIdx == remainingPath.count - 1
+                    guard AXHelpers.performAction(item, kAXPressAction) else {
+                        Log.warn("clickMenuItem: failed to press '\(segTitle)'", subsystem: "ax")
+                        return false
+                    }
+                    if !isLast { Thread.sleep(forTimeInterval: 0.15) }
+                    currentMenu = item
+                    continue
+                }
+                openMenu = m
+            }
+
+            let menuItems = AXHelpers.getChildren(openMenu)
+            guard let item = menuItemMatching(segTitle, in: menuItems) else {
+                Log.warn("clickMenuItem: item '\(segTitle)' not found under '\(path[segIdx])'", subsystem: "ax")
+                return false
+            }
+
+            let isLast = segIdx == remainingPath.count - 1
+            guard AXHelpers.performAction(item, kAXPressAction) else {
+                Log.warn("clickMenuItem: failed to press '\(segTitle)'", subsystem: "ax")
+                return false
+            }
+            if !isLast { Thread.sleep(forTimeInterval: 0.15) }
+            currentMenu = item
+        }
+
+        return true
+    }
+
+    /// Find a menu item within a list of AX elements whose title matches (exact, then prefix).
+    private static func menuItemMatching(_ title: String, in items: [AXUIElement]) -> AXUIElement? {
+        // Exact match first
+        if let exact = items.first(where: { AXHelpers.getTitle($0) == title }) {
+            return exact
+        }
+        // Case-insensitive contains fallback
+        return items.first(where: {
+            AXHelpers.getTitle($0)?.localizedCaseInsensitiveContains(title) == true
+        })
+    }
+
     // MARK: - Arrangement
 
     /// Find the main arrangement area (the timeline/tracks view).

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -84,7 +84,7 @@ enum AXValueExtractors {
         return SliderRange(min: min, max: max)
     }
 
-    /// Read a track header and extract its basic state.
+    /// Read a track header and extract its full state including type, mute/solo/arm, and output routing.
     static func extractTrackState(from header: AXUIElement, index: Int) -> TrackState {
         let name = extractTrackName(from: header)
         let muted = extractTrackButtonState(from: header, prefix: "Mute") ?? false
@@ -92,6 +92,7 @@ enum AXValueExtractors {
         let armed = extractTrackButtonState(from: header, prefix: "Record") ?? false
         let selected = extractSelectedState(header) ?? false
         let trackType = inferTrackType(from: header)
+        let output = extractOutputRouting(from: header)
 
         return TrackState(
             id: index,
@@ -103,7 +104,8 @@ enum AXValueExtractors {
             isSelected: selected,
             volume: 0.0,
             pan: 0.0,
-            color: extractTrackColor(from: header)
+            color: extractTrackColor(from: header),
+            outputRouting: output
         )
     }
 
@@ -155,6 +157,103 @@ enum AXValueExtractors {
         return state
     }
 
+    // MARK: - Marker extraction
+
+    /// Extract arrangement markers from the Logic Pro AX tree.
+    ///
+    /// Logic Pro exposes markers in several locations depending on version:
+    ///   1. A dedicated "Marker Track" / "Marker List" in the arrangement
+    ///   2. Within the arrangement ruler area
+    ///   3. Via a pop-up marker list accessible from the marker track header
+    ///
+    /// This method attempts each strategy in order and returns whatever it finds.
+    static func extractMarkers() -> [MarkerState] {
+        var markers: [MarkerState] = []
+
+        guard let window = AXLogicProElements.mainWindow() else { return markers }
+
+        // Strategy 1: Look for elements with "marker" in identifier or description
+        let markerCandidates = findMarkerElements(in: window)
+        if !markerCandidates.isEmpty {
+            for (index, element) in markerCandidates.enumerated() {
+                if let marker = markerFromElement(element, index: index) {
+                    markers.append(marker)
+                }
+            }
+            if !markers.isEmpty { return markers }
+        }
+
+        // Strategy 2: Scan the arrangement area for marker-like rows
+        if let arrangement = AXLogicProElements.getArrangementArea() {
+            let rows = AXHelpers.findAllDescendants(of: arrangement, role: kAXRowRole, maxDepth: 4)
+            for (index, row) in rows.enumerated() {
+                let desc = AXHelpers.getDescription(row)?.lowercased() ?? ""
+                let title = AXHelpers.getTitle(row)?.lowercased() ?? ""
+                if desc.contains("marker") || title.contains("marker") {
+                    if let marker = markerFromElement(row, index: index) {
+                        markers.append(marker)
+                    }
+                }
+            }
+        }
+
+        return markers
+    }
+
+    private static func findMarkerElements(in root: AXUIElement) -> [AXUIElement] {
+        var results: [AXUIElement] = []
+        // Search for groups or rows whose description contains "marker"
+        let groups = AXHelpers.findAllDescendants(of: root, role: kAXGroupRole, maxDepth: 8)
+        for group in groups {
+            let desc = AXHelpers.getDescription(group)?.lowercased() ?? ""
+            let id = AXHelpers.getIdentifier(group)?.lowercased() ?? ""
+            if desc.contains("marker") || id.contains("marker") {
+                let children = AXHelpers.getChildren(group)
+                if children.isEmpty {
+                    results.append(group)
+                } else {
+                    results.append(contentsOf: children)
+                }
+            }
+        }
+        return results
+    }
+
+    private static func markerFromElement(_ element: AXUIElement, index: Int) -> MarkerState? {
+        // Try to get the marker name and position
+        let name = AXHelpers.getTitle(element)
+            ?? AXHelpers.getDescription(element)
+            ?? extractTextValue(element)
+            ?? "Marker \(index + 1)"
+
+        // Skip empty or obviously non-marker elements
+        let nameLower = name.lowercased()
+        if nameLower.isEmpty || nameLower == "marker track" { return nil }
+
+        // Try to find a position value in child text elements
+        var positionStr = "1.1.1.1"
+        var barNumber: Int? = nil
+        let texts = AXHelpers.findAllDescendants(of: element, role: kAXStaticTextRole, maxDepth: 3)
+        for text in texts {
+            if let val = extractTextValue(text) {
+                // Bar.Beat.Division.Tick format: digits separated by dots
+                if val.filter({ $0 == "." }).count >= 2, let firstComponent = val.components(separatedBy: ".").first, let bar = Int(firstComponent) {
+                    positionStr = val
+                    barNumber = bar
+                    break
+                }
+                // Pure bar number
+                if let bar = Int(val.trimmingCharacters(in: .whitespaces)) {
+                    positionStr = "\(bar).1.1.1"
+                    barNumber = bar
+                    break
+                }
+            }
+        }
+
+        return MarkerState(id: index, name: name, position: positionStr, bar: barNumber)
+    }
+
     // MARK: - Private helpers
 
     private static func extractTrackName(from header: AXUIElement) -> String {
@@ -186,7 +285,11 @@ enum AXValueExtractors {
         // Attempt to infer type from icon description or element identifiers
         let desc = AXHelpers.getDescription(header)?.lowercased() ?? ""
         let title = AXHelpers.getTitle(header)?.lowercased() ?? ""
-        let combined = desc + " " + title
+        // Also check child elements for type indicators (e.g. instrument icon labels)
+        let childDescriptions = AXHelpers.getChildren(header).compactMap {
+            AXHelpers.getDescription($0)?.lowercased()
+        }.joined(separator: " ")
+        let combined = desc + " " + title + " " + childDescriptions
 
         if combined.contains("audio") { return .audio }
         if combined.contains("instrument") || combined.contains("software") { return .softwareInstrument }
@@ -196,6 +299,32 @@ enum AXValueExtractors {
         if combined.contains("bus") { return .bus }
         if combined.contains("master") || combined.contains("stereo out") { return .master }
         return .unknown
+    }
+
+    /// Extract output routing label from a track header.
+    /// Logic Pro may expose the output assignment as a popup button or static text
+    /// labeled "Output", "Stereo Out", "Bus N", etc.
+    private static func extractOutputRouting(from header: AXUIElement) -> String? {
+        // Look for popup buttons (output selectors are typically AXPopUpButton)
+        let popups = AXHelpers.findAllDescendants(of: header, role: kAXPopUpButtonRole, maxDepth: 4)
+        for popup in popups {
+            let desc = AXHelpers.getDescription(popup)?.lowercased() ?? ""
+            let title = AXHelpers.getTitle(popup) ?? ""
+            if desc.contains("output") || desc.contains("out") {
+                return title.isEmpty ? nil : title
+            }
+        }
+        // Fallback: static text that looks like an output label
+        let statics = AXHelpers.findAllDescendants(of: header, role: kAXStaticTextRole, maxDepth: 4)
+        for text in statics {
+            if let val = extractTextValue(text) {
+                let lower = val.lowercased()
+                if lower.contains("stereo out") || lower.contains("bus ") || lower.contains("output") {
+                    return val
+                }
+            }
+        }
+        return nil
     }
 
     private static func extractTrackColor(from header: AXUIElement) -> String? {

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -335,4 +335,61 @@ enum AXValueExtractors {
         }
         return nil
     }
+
+    // MARK: - Nesting Depth
+
+    /// Infer the nesting depth of a track header element in the arrange window.
+    ///
+    /// Logic Pro uses an AXOutline for the track list. Rows in an outline have a
+    /// kAXDisclosureLevelAttribute (Int) that indicates indent level.
+    /// If that attribute is unavailable we fall back to inspecting the x-position
+    /// of the track name label relative to the header's own origin as a proxy.
+    static func extractNestingDepth(from header: AXUIElement) -> Int {
+        // Strategy 1: kAXDisclosureLevelAttribute (most reliable on outline rows)
+        if let level: AnyObject = AXHelpers.getAttribute(header, kAXDisclosureLevelAttribute) {
+            if let n = level as? NSNumber {
+                return max(0, n.intValue)
+            }
+        }
+
+        // Strategy 2: "AXIndentationLevel" attribute (seen on some AX versions)
+        if let level: AnyObject = AXHelpers.getAttribute(header, "AXIndentationLevel") {
+            if let n = level as? NSNumber {
+                return max(0, n.intValue)
+            }
+        }
+
+        // Strategy 3: x-position proxy.
+        // In Logic Pro the track name static text is indented for child tracks.
+        // We look at the first static-text child and measure its x-origin relative
+        // to the header's x-origin. Logic uses ~16 px per indent level.
+        if let parentFrame = axFrame(header) {
+            let textElements = AXHelpers.findAllDescendants(of: header, role: kAXStaticTextRole, maxDepth: 3)
+            for textEl in textElements {
+                if let textFrame = axFrame(textEl) {
+                    let indent = textFrame.origin.x - parentFrame.origin.x
+                    if indent > 0 {
+                        return max(0, Int(indent / 16.0))
+                    }
+                    break
+                }
+            }
+        }
+
+        return 0
+    }
+
+    /// Read the CGRect frame for an AX element via the AXFrame attribute.
+    private static func axFrame(_ element: AXUIElement) -> CGRect? {
+        var frameValue: AnyObject?
+        let err = AXUIElementCopyAttributeValue(element, "AXFrame" as CFString, &frameValue)
+        guard err == .success, let v = frameValue else { return nil }
+        var rect = CGRect.zero
+        // AXValue wraps CGRect; we need to extract it via AXValueGetValue
+        let axv = v as! AXValue
+        if AXValueGetValue(axv, .cgRect, &rect) {
+            return rect
+        }
+        return nil
+    }
 }

--- a/Sources/LogicProMCP/Binary/Decoders/TxSqMarkerDecoder.swift
+++ b/Sources/LogicProMCP/Binary/Decoders/TxSqMarkerDecoder.swift
@@ -1,0 +1,255 @@
+import Foundation
+
+// MARK: - Public Types
+
+/// An arrangement-marker text record parsed from a short TxSq chunk.
+///
+/// Projects 2 and 3 of the bundled fixtures contain 8 TxSq chunks each
+/// (project 1 has none). Short TxSq chunks (body length ~104-106) encode
+/// an arrangement-marker section name ("Intro", "Chorus", "Bridge", etc.)
+/// as a null-terminated ASCII string in the tail of the body. Longer
+/// TxSq chunks (~480-484 bytes) carry RTF text and are handled separately
+/// by `ProjectDataParser.extractTxSqNames`.
+public struct TxSqMarker: Sendable, Codable, Equatable {
+    public enum Source: String, Sendable, Codable {
+        case shortAscii   // null-terminated ASCII in the body tail
+        case rtf          // RTF payload with \fs text run
+        case unknown
+    }
+
+    /// OID of the owning TxSq chunk.
+    public let oid: UInt32
+    /// Body length in bytes.
+    public let bodyLength: Int
+    /// Extracted marker name, trimmed.
+    public let markerName: String
+    /// How the name was located.
+    public let source: Source
+}
+
+// MARK: - Decoder
+
+public enum TxSqMarkerDecoder {
+
+    /// Scan `ProjectData` for TxSq arrangement-marker name chunks and decode
+    /// each one. Returns records in discovery order, deduplicated by
+    /// `(oid, markerName)`.
+    public static func decode(data: Data) -> [TxSqMarker] {
+        let chunks = scanChunks(data: data)
+        var seen: Set<String> = []
+        var result: [TxSqMarker] = []
+
+        for chunk in chunks where chunk.id == "TxSq" {
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // Prefer the short-ASCII path first (short chunks have the name
+            // in the tail region; longer RTF chunks often have no usable
+            // text in the short-ASCII slot).
+            if let name = extractShortAsciiName(body: body) {
+                let key = "\(chunk.oid)\u{0}\(name)"
+                if seen.insert(key).inserted {
+                    result.append(TxSqMarker(
+                        oid: chunk.oid,
+                        bodyLength: chunk.bodyLength,
+                        markerName: name,
+                        source: .shortAscii
+                    ))
+                }
+                continue
+            }
+
+            if let rtf = extractRTFText(body) {
+                let key = "\(chunk.oid)\u{0}\(rtf)"
+                if seen.insert(key).inserted {
+                    result.append(TxSqMarker(
+                        oid: chunk.oid,
+                        bodyLength: chunk.bodyLength,
+                        markerName: rtf,
+                        source: .rtf
+                    ))
+                }
+            }
+        }
+
+        return result
+    }
+}
+
+// MARK: - Short-ASCII Extraction
+
+/// Look for a null-terminated ASCII run in the body tail. In observed
+/// samples the marker name lives at body offset ~0x62 onward, but the
+/// exact position is not guaranteed, so we scan the last 48 bytes of the
+/// body for the first run that validates.
+private func extractShortAsciiName(body: Data) -> String? {
+    // Require the "//QR" tag somewhere in the body — that's the discriminator
+    // for short arrangement-marker TxSq chunks vs RTF-carrying ones.
+    guard let qrRange = body.range(of: Data([0x2F, 0x2F, 0x51, 0x52])) else {
+        return nil
+    }
+
+    // Scan from just past the "//QR" tag to the end of the body for the
+    // first plausible printable-ASCII run (length 3..32, contains a letter).
+    let scanStart = qrRange.upperBound
+    guard scanStart < body.endIndex else { return nil }
+
+    var i = scanStart
+    while i < body.endIndex {
+        let b = body[i]
+        if b >= 0x20 && b < 0x7F {
+            var end = i
+            while end < body.endIndex, body[end] >= 0x20, body[end] < 0x7F {
+                end = body.index(after: end)
+            }
+            let slice = body[i..<end]
+            if slice.count >= 3, slice.count <= 32,
+               slice.contains(where: { isASCIILetter($0) }) {
+                let str = String(decoding: slice, as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !str.isEmpty {
+                    return str
+                }
+            }
+            i = body.index(after: end)
+        } else {
+            i = body.index(after: i)
+        }
+    }
+    return nil
+}
+
+private func isASCIILetter(_ b: UInt8) -> Bool {
+    (b >= 0x41 && b <= 0x5A) || (b >= 0x61 && b <= 0x7A)
+}
+
+// MARK: - RTF Extraction (self-contained, mirrors ProjectDataParser)
+
+private func extractRTFText(_ body: Data) -> String? {
+    let asciiStr = String(body.map { b -> Character in
+        let s = Unicode.Scalar(b)
+        return s.value >= 32 && s.value < 127 ? Character(s) : Character(".")
+    })
+
+    guard asciiStr.contains("{\\rtf") || asciiStr.contains("\\fs") else {
+        return nil
+    }
+
+    guard let fsRange = asciiStr.range(of: "\\fs") else { return nil }
+
+    var idx = fsRange.upperBound
+    while idx < asciiStr.endIndex, asciiStr[idx].isNumber {
+        idx = asciiStr.index(after: idx)
+    }
+
+    var textStart = idx
+    while textStart < asciiStr.endIndex {
+        let ch = asciiStr[textStart]
+        if ch == " " {
+            textStart = asciiStr.index(after: textStart)
+            continue
+        }
+        if ch == "\\" {
+            var j = asciiStr.index(after: textStart)
+            while j < asciiStr.endIndex, asciiStr[j].isLetter || asciiStr[j].isNumber {
+                j = asciiStr.index(after: j)
+            }
+            if j < asciiStr.endIndex, asciiStr[j] == " " {
+                j = asciiStr.index(after: j)
+            }
+            textStart = j
+            continue
+        }
+        break
+    }
+
+    var textEnd = textStart
+    while textEnd < asciiStr.endIndex, asciiStr[textEnd] != "}" {
+        textEnd = asciiStr.index(after: textEnd)
+    }
+
+    guard textStart < textEnd else { return nil }
+
+    var text = String(asciiStr[textStart..<textEnd])
+    text = text.replacingOccurrences(of: "..", with: " ")
+    text = text.replacingOccurrences(of: ".", with: "")
+    text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    while let c = text.first, !c.isLetter, !c.isNumber { text.removeFirst() }
+    while let c = text.last, !c.isLetter, !c.isNumber { text.removeLast() }
+
+    guard !text.isEmpty, text.contains(where: { $0.isLetter }), text.count <= 32 else {
+        return nil
+    }
+    return text
+}
+
+// MARK: - Chunk Scanner (copy of ProjectDataParser's scanner)
+
+private struct ChunkInfo {
+    let id: String
+    let oid: UInt32
+    let bodyOffset: Int
+    let bodyLength: Int
+}
+
+private let magicBytes: [UInt8] = [0x23, 0x47, 0xC0, 0xAB]
+private let chunkHeaderSize = 36
+private let anchorOffset = 0x16
+private let oidOffset = 0x0A
+private let lengthOffset = 0x1C
+
+private func scanChunks(data: Data) -> [ChunkInfo] {
+    guard data.count >= 4,
+          data[0] == 0x23, data[1] == 0x47, data[2] == 0xC0, data[3] == 0xAB
+    else { return [] }
+
+    var result: [ChunkInfo] = []
+    let total = data.count
+    var offset = 4
+
+    while offset + chunkHeaderSize <= total {
+        guard data[offset + anchorOffset + 0] == 0x02,
+              data[offset + anchorOffset + 1] == 0x00,
+              data[offset + anchorOffset + 2] == 0x00,
+              data[offset + anchorOffset + 3] == 0x00,
+              data[offset + anchorOffset + 4] == 0x01 || data[offset + anchorOffset + 4] == 0x02,
+              data[offset + anchorOffset + 5] == 0x00
+        else {
+            offset += 1
+            continue
+        }
+
+        let bodyLength = Int(readLE64(data, at: offset + lengthOffset))
+        let bodyStart = offset + chunkHeaderSize
+        guard bodyLength >= 0, bodyStart + bodyLength <= total else {
+            offset += 1
+            continue
+        }
+
+        let rawID = Array(data[offset..<(offset + 4)])
+        let id = String(bytes: rawID.reversed(), encoding: .ascii) ?? "????"
+        let oid = readLE32(data, at: offset + oidOffset)
+
+        result.append(ChunkInfo(id: id, oid: oid, bodyOffset: bodyStart, bodyLength: bodyLength))
+        offset = bodyStart + bodyLength
+    }
+    return result
+}
+
+private func readLE32(_ data: Data, at offset: Int) -> UInt32 {
+    guard offset + 4 <= data.count else { return 0 }
+    let base = data.startIndex + offset
+    return UInt32(data[base]) |
+        (UInt32(data[base + 1]) << 8) |
+        (UInt32(data[base + 2]) << 16) |
+        (UInt32(data[base + 3]) << 24)
+}
+
+private func readLE64(_ data: Data, at offset: Int) -> UInt64 {
+    guard offset + 8 <= data.count else { return 0 }
+    let base = data.startIndex + offset
+    var result: UInt64 = 0
+    for i in 0..<8 {
+        result |= UInt64(data[base + i]) << (8 * i)
+    }
+    return result
+}

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -39,6 +39,9 @@ struct ProjectDataInfo: Sendable, Codable {
     /// Full sub-track hierarchy grouped by function group / environment label.
     /// Each entry is a top-level stack with its channel strip children.
     var subTrackHierarchy: [SubTrackStack] = []
+
+    /// Per-song lengths derived from the reference track regions (or marker boundaries as fallback).
+    var songLengths: [SongLength] = []
 }
 
 // MARK: - Channel Strip
@@ -192,4 +195,22 @@ struct ParsedAudioFile: Sendable, Codable {
     var path: String
     /// Object identifier from the AuFl chunk header.
     var oid: Int
+}
+
+// MARK: - Song Lengths
+
+/// Per-song length record derived from reference track regions or marker boundaries.
+struct SongLength: Sendable, Codable {
+    /// Song / arrangement marker name (e.g. "Dead and Buried").
+    var songName: String
+    /// Start bar (1-based, inclusive).
+    var startBar: Int
+    /// End bar (1-based, exclusive — first bar of the next song).
+    var endBar: Int
+    /// Length in whole bars (endBar - startBar).
+    var lengthBars: Int
+    /// How this length was determined:
+    ///   "reference_region"  — taken from a matching reference track region
+    ///   "marker_boundary"   — marker-to-next-marker fallback
+    var source: String
 }

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+// MARK: - Top-level result
+
+/// Full parsed result from a Logic Pro ProjectData binary file.
+struct ProjectDataInfo: Sendable, Codable {
+    /// Arrangement markers with names and bar positions.
+    var markers: [ParsedMarker] = []
+    /// Tempo map entries (may have multiple for tempo changes).
+    var tempoMap: [TempoEntry] = []
+    /// Track names extracted from MSeq chunks.
+    var tracks: [ParsedTrack] = []
+    /// Time signature string (e.g. "4/4"), sourced from plists in the package.
+    var timeSignature: String = "4/4"
+    /// Sample rate from project plist (0 if unavailable).
+    var sampleRate: Int = 0
+    /// Project name derived from the .logicx directory name.
+    var projectName: String = ""
+}
+
+// MARK: - Arrangement Markers
+
+/// An arrangement marker parsed from TxSq (name) and EvSq type-18 (position).
+struct ParsedMarker: Sendable, Codable {
+    /// Human-readable marker name (RTF-stripped).
+    var name: String
+    /// Bar number (1-based). Computed from tick / 3840 + 1 in 4/4.
+    var bar: Int
+    /// Absolute tick position.
+    var tick: Int
+    /// Duration in ticks (from the type-18 row).
+    var durationTicks: Int
+    /// Duration in bars (durationTicks / 3840, rounded).
+    var durationBars: Int
+    /// Object identifier from the TxSq chunk header.
+    var oid: Int
+}
+
+// MARK: - Tempo Map
+
+/// A single tempo entry from an EvSq chunk.
+struct TempoEntry: Sendable, Codable {
+    /// Beats per minute.
+    var bpm: Double
+    /// Absolute tick position of this tempo event.
+    var tick: Int
+    /// Bar number (1-based), computed from tick / 3840 + 1.
+    var bar: Int
+}
+
+// MARK: - Tracks
+
+/// A track name parsed from an MSeq chunk.
+struct ParsedTrack: Sendable, Codable {
+    /// Track name (ASCII).
+    var name: String
+    /// Object identifier from the MSeq chunk header.
+    var oid: Int
+}

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -8,8 +8,14 @@ struct ProjectDataInfo: Sendable, Codable {
     var markers: [ParsedMarker] = []
     /// Tempo map entries (may have multiple for tempo changes).
     var tempoMap: [TempoEntry] = []
-    /// Track names extracted from MSeq chunks.
+    /// Track names extracted from MSeq chunks, enriched with optional mixer data.
     var tracks: [ParsedTrack] = []
+    /// Audio regions parsed from AuRg chunks.
+    var regions: [ParsedRegion] = []
+    /// Audio file references parsed from AuFl chunks.
+    var audioFiles: [ParsedAudioFile] = []
+    /// Plugin names discovered in PluginData (null-ID) chunks.
+    var plugins: [String] = []
     /// Time signature string (e.g. "4/4"), sourced from plists in the package.
     var timeSignature: String = "4/4"
     /// Sample rate from project plist (0 if unavailable).
@@ -50,10 +56,50 @@ struct TempoEntry: Sendable, Codable {
 
 // MARK: - Tracks
 
-/// A track name parsed from an MSeq chunk.
+/// A track name parsed from an MSeq chunk, optionally enriched with mixer data.
 struct ParsedTrack: Sendable, Codable {
     /// Track name (ASCII).
     var name: String
     /// Object identifier from the MSeq chunk header.
+    var oid: Int
+    /// Output routing label extracted from a nearby AuCO chunk (e.g. "Output 1-2", "Bus 1").
+    var outputRouting: String?
+    /// Volume in dBFS. Nil when AuCO is unavailable for this track.
+    var volume: Double?
+    /// Pan position in the range -1.0 (hard left) to +1.0 (hard right). Nil when unavailable.
+    var pan: Double?
+    /// Regions assigned to this track (populated by track-to-region mapping pass).
+    var regions: [ParsedRegion] = []
+}
+
+// MARK: - Regions
+
+/// An audio region parsed from an AuRg chunk.
+struct ParsedRegion: Sendable, Codable {
+    /// Region name (ASCII, e.g. "Rec#03.31").
+    var name: String
+    /// Object identifier from the AuRg chunk header.
+    var oid: Int
+    /// Absolute start position in ticks (derived from bar-field or legacy mode).
+    var startTick: Int
+    /// Start position in bars (1-based, fractional).
+    var startBar: Double
+    /// Duration in ticks.
+    var lengthTicks: Int
+    /// Duration in bars (fractional).
+    var lengthBars: Double
+    /// OID of the corresponding AuFl (audio file) chunk.
+    var audioFileOid: Int
+    /// Track OID that owns this region (populated by track-to-region mapping pass).
+    var trackOid: Int?
+}
+
+// MARK: - Audio File References
+
+/// An audio file reference parsed from an AuFl chunk.
+struct ParsedAudioFile: Sendable, Codable {
+    /// Absolute path to the audio file (UTF-16LE decoded from chunk body).
+    var path: String
+    /// Object identifier from the AuFl chunk header.
     var oid: Int
 }

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -9,7 +9,10 @@ struct ProjectDataInfo: Sendable, Codable {
     /// Tempo map entries (may have multiple for tempo changes).
     var tempoMap: [TempoEntry] = []
     /// Track names extracted from MSeq chunks, enriched with optional mixer data.
+    /// Includes all named tracks plus stack container tracks (even "Untitled" ones with children).
     var tracks: [ParsedTrack] = []
+    /// All MSeq tracks including internal/automation tracks. For debugging and hierarchy building.
+    var allTracks: [ParsedTrack] = []
     /// Audio regions parsed from AuRg chunks.
     var regions: [ParsedRegion] = []
     /// Audio file references parsed from AuFl chunks.
@@ -56,7 +59,8 @@ struct TempoEntry: Sendable, Codable {
 
 // MARK: - Tracks
 
-/// A track name parsed from an MSeq chunk, optionally enriched with mixer data.
+/// A track name parsed from an MSeq chunk, optionally enriched with mixer data,
+/// hierarchy information, and function group classification.
 struct ParsedTrack: Sendable, Codable {
     /// Track name (ASCII).
     var name: String
@@ -70,6 +74,25 @@ struct ParsedTrack: Sendable, Codable {
     var pan: Double?
     /// Regions assigned to this track (populated by track-to-region mapping pass).
     var regions: [ParsedRegion] = []
+
+    // MARK: Hierarchy fields
+
+    /// OID of this track's parent stack (nil = top-level track).
+    var parentOid: Int?
+    /// OIDs of direct child tracks in this stack.
+    var childOids: [Int] = []
+    /// Depth in the track hierarchy (0 = root level, 1 = direct child of stack, etc.).
+    var stackDepth: Int = 0
+    /// Stack classification: "summing", "folder", or nil for regular tracks.
+    var stackType: String?
+    /// True when this track is a summing stack (routes to a bus and has children).
+    var isSummingStack: Bool = false
+
+    // MARK: Function group fields
+
+    /// Inferred function group label (e.g. "Guitars", "Vocals", "Drums").
+    /// Nil for tracks that could not be classified.
+    var functionGroup: String?
 }
 
 // MARK: - Regions

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -25,6 +25,73 @@ struct ProjectDataInfo: Sendable, Codable {
     var sampleRate: Int = 0
     /// Project name derived from the .logicx directory name.
     var projectName: String = ""
+
+    // MARK: Extended hierarchy fields
+
+    /// All AuCO channel strips extracted from the project (every guitar, vocal, synth, etc.).
+    /// These are the definitive sub-track enumeration — Logic shows 449 strips vs 13 MSeq tracks.
+    var channelStrips: [ChannelStrip] = []
+    /// Arrangement tracks from Trak chunks, each linked to an MSeq OID.
+    var trakEntries: [TrakEntry] = []
+    /// Environment object names from Envi chunks (stack grouping labels like
+    /// "Backing Track", "Click Track", "Release Track", "Midi Triggers").
+    var environmentLabels: [String] = []
+    /// Full sub-track hierarchy grouped by function group / environment label.
+    /// Each entry is a top-level stack with its channel strip children.
+    var subTrackHierarchy: [SubTrackStack] = []
+}
+
+// MARK: - Channel Strip
+
+/// An AuCO channel strip — the definitive representation of an individual track in Logic Pro.
+/// Logic's mixer has one channel strip per real track (guitar DI, vocal take, synth layer, etc.)
+/// whereas MSeq only stores the top-level arrangement containers.
+struct ChannelStrip: Sendable, Codable {
+    /// Channel strip name (null-terminated ASCII at AuCO body offset 0x3C).
+    /// Examples: "Gtr Clean DI", "Lead Vox", "Rhodes", "Audio 47".
+    var name: String
+    /// Object identifier from the AuCO chunk header.
+    var oid: Int
+    /// Volume in dBFS (40 * log10(raw / 1509949440)). Nil when not decodable.
+    var volume: Double?
+    /// Pan position: -1.0 = hard left, 0.0 = center, +1.0 = hard right. Nil when not decodable.
+    var pan: Double?
+    /// Output routing label (e.g. "Bus 3", "Output 1-2", "Stereo Out").
+    var outputRouting: String?
+    /// Inferred function group (e.g. "Guitars", "Vocals", "Drums", "Keys/Synths").
+    var functionGroup: String?
+    /// True when the name is a generic placeholder (e.g. "Audio 47", "Inst 3").
+    var isGeneric: Bool = false
+    /// OID of the associated Trak chunk (when found by OID proximity matching).
+    var trakOid: Int?
+    /// OID of the MSeq sequence this strip links to (via Trak → MSeq chain).
+    var mseqOid: Int?
+}
+
+// MARK: - Trak Entry
+
+/// An arrangement track from a Trak chunk. Links to an MSeq sequence via mseqOid.
+struct TrakEntry: Sendable, Codable {
+    /// Object identifier from the Trak chunk header.
+    var oid: Int
+    /// OID of the MSeq sequence this track references (at body offset 0x08).
+    var mseqOid: Int
+    /// UUID bytes formatted as standard UUID string (body offset 0x18, 16 bytes).
+    var uuid: String?
+    /// Flags raw value (body offset 0x28, 4 bytes).
+    var flagsRaw: UInt32
+}
+
+// MARK: - Sub-track Hierarchy
+
+/// A top-level stack grouping channel strips by function group / environment label.
+struct SubTrackStack: Sendable, Codable {
+    /// Stack name (e.g. "Guitars", "Vocals", "Backing Track", "Click Track").
+    var name: String
+    /// Source of this grouping: "environment_label", "function_group", or "inferred".
+    var source: String
+    /// Channel strips assigned to this stack.
+    var strips: [ChannelStrip]
 }
 
 // MARK: - Arrangement Markers

--- a/Sources/LogicProMCP/Binary/ProjectDataModels.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataModels.swift
@@ -19,6 +19,8 @@ struct ProjectDataInfo: Sendable, Codable {
     var audioFiles: [ParsedAudioFile] = []
     /// Plugin names discovered in PluginData (null-ID) chunks.
     var plugins: [String] = []
+    /// Detailed plugin records with type and manufacturer info.
+    var parsedPlugins: [ParsedPlugin] = []
     /// Time signature string (e.g. "4/4"), sourced from plists in the package.
     var timeSignature: String = "4/4"
     /// Sample rate from project plist (0 if unavailable).
@@ -213,4 +215,18 @@ struct SongLength: Sendable, Codable {
     ///   "reference_region"  — taken from a matching reference track region
     ///   "marker_boundary"   — marker-to-next-marker fallback
     var source: String
+}
+
+// MARK: - Plugins
+
+/// A plugin discovered in the project binary.
+struct ParsedPlugin: Sendable, Codable {
+    /// Plugin name (e.g. "Channel EQ", "Serum", "FabFilter Pro-Q 3").
+    var name: String
+    /// Plugin type: "au_builtin", "au_thirdparty", "au_component", or "unknown".
+    var type: String
+    /// Manufacturer name when available (e.g. "Apple", "FabFilter", "Xfer Records").
+    var manufacturer: String?
+    /// AU component 4-char codes when found: (type, subtype, manufacturer).
+    var auComponentCode: String?
 }

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -3,7 +3,8 @@ import Foundation
 // MARK: - ProjectDataParser
 
 /// Parses Logic Pro binary ProjectData files to extract arrangement markers,
-/// tempo maps, track names, and time signatures — without using the Accessibility API.
+/// tempo maps, track names, regions, audio files, plugins, and mixer data —
+/// without using the Accessibility API.
 ///
 /// File layout:
 /// - Magic:  23 47 C0 AB  (4 bytes at offset 0)
@@ -35,6 +36,12 @@ enum ProjectDataParser {
     private static let idTxSq = "TxSq"
     private static let idEvSq = "EvSq"
     private static let idMSeq = "MSeq"
+    private static let idAuRg = "AuRg"
+    private static let idAuFl = "AuFl"
+    private static let idAuCO = "AuCO"
+
+    // Unity gain raw value for volume dB formula: dB = 40 * log10(value / unityGain)
+    private static let unityGainRaw: Double = 1_509_949_440.0
 
     // Arrangement marker OIDs vary per project — we scan ALL TxSq chunks
     // and identify markers by RTF content rather than hardcoded OIDs
@@ -75,7 +82,7 @@ enum ProjectDataParser {
         let txSqMap = extractTxSqNames(chunks: chunks, data: data)       // oid -> name
         let evSqMarkerEvents = extractMarkerEvents(chunks: chunks, data: data) // [(oid, startTick, durationTicks)]
         var tempoMap = extractTempoMap(chunks: chunks, data: data)
-        let parsedTracks = extractTracks(chunks: chunks, data: data)
+        var parsedTracks = extractTracks(chunks: chunks, data: data)
 
         // If no tempo found at tick=0, try to get initial BPM from plists
         if let lx = logicxURL, !tempoMap.contains(where: { $0.tick == 0 }) {
@@ -92,10 +99,33 @@ enum ProjectDataParser {
         let timeSignature = logicxURL.flatMap { readTimeSignature(logicx: $0) } ?? "4/4"
         let sampleRate = logicxURL.flatMap { readSampleRate(logicx: $0) } ?? 0
 
+        // Extract audio file references
+        let audioFiles = extractAudioFiles(chunks: chunks, data: data)
+
+        // Extract audio regions
+        var regions = extractRegions(chunks: chunks, data: data)
+
+        // Apply track-to-region mapping
+        applyTrackRegionMapping(
+            chunks: chunks,
+            data: data,
+            tracks: &parsedTracks,
+            regions: &regions
+        )
+
+        // Enrich tracks with AuCO mixer data (volume, pan, output routing)
+        enrichTracksWithAuCO(chunks: chunks, data: data, tracks: &parsedTracks)
+
+        // Extract plugin list
+        let plugins = extractPlugins(chunks: chunks, data: data)
+
         var info = ProjectDataInfo()
         info.markers = markers
         info.tempoMap = tempoMap
         info.tracks = parsedTracks
+        info.regions = regions
+        info.audioFiles = audioFiles
+        info.plugins = plugins
         info.timeSignature = timeSignature
         info.sampleRate = sampleRate
         info.projectName = projectName
@@ -561,6 +591,452 @@ enum ProjectDataParser {
         return result
     }
 
+    // MARK: - Audio File References (AuFl)
+
+    /// Extract audio file paths from AuFl chunks.
+    ///
+    /// AuFl body layout:
+    ///   0x08  2B  character count (LE u16) — number of UTF-16 code units
+    ///   0x0A  *B  UTF-16LE encoded file path (char_count * 2 bytes)
+    ///
+    /// Note: the spec says "starts at offset 0x0A"; the char count at 0x08 gives
+    /// the exact length, avoiding ambiguity with null-terminator detection.
+    private static func extractAudioFiles(chunks: [ChunkInfo], data: Data) -> [ParsedAudioFile] {
+        var result: [ParsedAudioFile] = []
+        var seen = Set<UInt32>()
+
+        for chunk in chunks where chunk.id == idAuFl {
+            guard chunk.bodyLength > 0x0C else { continue }
+            if !seen.insert(chunk.oid).inserted { continue }
+
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // Read char count at 0x08 (LE u16 = number of UTF-16 code units)
+            let charCount = Int(readLE16(body, at: 0x08))
+            let byteCount = charCount * 2
+            let pathOffset = 0x0A
+
+            if charCount > 0, pathOffset + byteCount <= body.count {
+                // Use length-prefixed decode (most reliable)
+                let pathSlice = Data(body[pathOffset..<(pathOffset + byteCount)])
+                if let path = String(data: pathSlice, encoding: .utf16LittleEndian), !path.isEmpty {
+                    result.append(ParsedAudioFile(path: path, oid: Int(chunk.oid)))
+                    continue
+                }
+            }
+
+            // Fallback: null-terminator scan for UTF-16LE
+            guard body.count > pathOffset + 2 else { continue }
+            let pathData = Data(body[pathOffset...])
+            var pathEnd = 0
+            while pathEnd + 1 < pathData.count {
+                if pathData[pathEnd] == 0 && pathData[pathEnd + 1] == 0 { break }
+                pathEnd += 2
+            }
+            guard pathEnd > 0 else { continue }
+            let utf16Slice = Data(pathData[0..<pathEnd])
+            if let path = String(data: utf16Slice, encoding: .utf16LittleEndian), !path.isEmpty {
+                result.append(ParsedAudioFile(path: path, oid: Int(chunk.oid)))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Audio Region Extraction (AuRg)
+
+    /// Extract audio regions from AuRg chunks.
+    ///
+    /// AuRg body layout (bar-field mode, primary):
+    ///   0x10  4B  start_bar_int (LE u32)
+    ///   0x14  4B  start_bar_frac_hi (LE u32) — fractional bars: frac = (value >> 16) / 65536
+    ///   0x18  4B  length_bar_int (LE u32)
+    ///   0x1C  4B  length_bar_frac_hi (LE u32)
+    ///   0x30  8B  legacy start tick (LE u64) — fallback
+    ///   0x4A  2B  name_length (LE u16)
+    ///   0x4C  *B  name (ASCII)
+    ///
+    /// The AuRg OID matches the AuFl OID that owns this audio asset.
+    private static func extractRegions(chunks: [ChunkInfo], data: Data) -> [ParsedRegion] {
+        var result: [ParsedRegion] = []
+
+        for chunk in chunks where chunk.id == idAuRg {
+            guard chunk.bodyLength > 0x4C else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // --- Timeline placement ---
+            var startBar: Double = 0
+            var lengthBars: Double = 0
+            var startTick: Int = 0
+            var lengthTicks: Int = 0
+
+            // Bar-field mode (primary): offsets 0x10..0x1F
+            let startBarInt = readLE32(body, at: 0x10)
+            let startBarFracRaw = readLE32(body, at: 0x14)
+            let lengthBarInt = readLE32(body, at: 0x18)
+            let lengthBarFracRaw = readLE32(body, at: 0x1C)
+
+            let startBarFrac = Double(startBarFracRaw >> 16) / 65536.0
+            let lengthBarFrac = Double(lengthBarFracRaw >> 16) / 65536.0
+
+            if startBarInt > 0 || startBarFrac > 0 {
+                // Bar-field mode valid
+                startBar = Double(startBarInt) + startBarFrac
+                lengthBars = Double(lengthBarInt) + lengthBarFrac
+                startTick = Int(startBar * Double(ticksPerBar))
+                lengthTicks = Int(lengthBars * Double(ticksPerBar))
+            } else {
+                // Legacy mode fallback: 8-byte LE tick at body offset 0x30
+                if body.count > 0x38 {
+                    let tickLow = readLE32(body, at: 0x30)
+                    let tickHigh = readLE32(body, at: 0x34)
+                    startTick = Int(tickLow) | (Int(tickHigh) << 32)
+                    startBar = Double(startTick) / Double(ticksPerBar)
+                    // Length: try 0x38
+                    let lenLow = readLE32(body, at: 0x38)
+                    let lenHigh = body.count > 0x40 ? readLE32(body, at: 0x3C) : 0
+                    lengthTicks = Int(lenLow) | (Int(lenHigh) << 32)
+                    lengthBars = Double(lengthTicks) / Double(ticksPerBar)
+                }
+            }
+
+            // --- Region name ---
+            let nameLen = Int(readLE16(body, at: 0x4A))
+            guard nameLen > 0, 0x4C + nameLen <= body.count else {
+                // Still add a region with empty name if timing data is valid
+                if startTick > 0 || startBar > 0 {
+                    result.append(ParsedRegion(
+                        name: "",
+                        oid: Int(chunk.oid),
+                        startTick: startTick,
+                        startBar: startBar,
+                        lengthTicks: lengthTicks,
+                        lengthBars: lengthBars,
+                        audioFileOid: Int(chunk.oid),
+                        trackOid: nil
+                    ))
+                }
+                continue
+            }
+
+            let nameSlice = Data(body[0x4C..<(0x4C + nameLen)])
+            let name = String(data: nameSlice, encoding: .utf8)
+                ?? String(data: nameSlice, encoding: .isoLatin1)
+                ?? ""
+
+            result.append(ParsedRegion(
+                name: name,
+                oid: Int(chunk.oid),
+                startTick: startTick,
+                startBar: startBar,
+                lengthTicks: lengthTicks,
+                lengthBars: lengthBars,
+                audioFileOid: Int(chunk.oid),
+                trackOid: nil
+            ))
+        }
+
+        return result
+    }
+
+    // MARK: - Track-to-Region Mapping
+
+    /// Populate trackOid on regions and regions list on tracks using:
+    ///   1. Song / USEl explicit [TrackOID, Count, RegionOID...] tables
+    ///   2. AuRg body heuristic (scan for track OID patterns)
+    private static func applyTrackRegionMapping(
+        chunks: [ChunkInfo],
+        data: Data,
+        tracks: inout [ParsedTrack],
+        regions: inout [ParsedRegion]
+    ) {
+        let trackOidSet = Set(tracks.map { UInt32($0.oid) })
+        guard !trackOidSet.isEmpty, !regions.isEmpty else { return }
+
+        // Build region lookup by OID (regions may share OID, use index as key too)
+        // Map regionOID -> [indices into regions array]
+        var regionsByOid: [UInt32: [Int]] = [:]
+        for (i, r) in regions.enumerated() {
+            regionsByOid[UInt32(r.oid), default: []].append(i)
+        }
+
+        // Mapping: region index -> track oid
+        var regionTrackMap: [Int: UInt32] = [:]
+
+        // Strategy 1: scan Song and USEl chunk bodies for explicit tables
+        for chunk in chunks where (chunk.id == "Song" || chunk.id == "USEl") {
+            guard chunk.bodyLength >= 12 else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+            scanExplicitMappingTable(
+                body: body,
+                trackOidSet: trackOidSet,
+                regionsByOid: regionsByOid,
+                regionTrackMap: &regionTrackMap
+            )
+        }
+
+        // Strategy 2: AuRg body heuristic for unmapped regions
+        // (skipped — heuristic-only; Song/USEl tables are preferred)
+
+        // Apply the mapping back
+        for (regionIdx, trackOid) in regionTrackMap {
+            regions[regionIdx].trackOid = Int(trackOid)
+        }
+
+        // Build track -> regions cross-reference
+        var trackRegionMap: [Int: [ParsedRegion]] = [:]
+        for region in regions {
+            if let tOid = region.trackOid {
+                trackRegionMap[tOid, default: []].append(region)
+            }
+        }
+        for i in tracks.indices {
+            if let regs = trackRegionMap[tracks[i].oid] {
+                tracks[i].regions = regs
+            }
+        }
+    }
+
+    /// Scan a chunk body for u32 sequences of the form:
+    ///   [track_oid, count, region_oid_1, region_oid_2, ...]
+    /// where track_oid is a known MSeq OID and count is reasonable (1–100).
+    private static func scanExplicitMappingTable(
+        body: Data,
+        trackOidSet: Set<UInt32>,
+        regionsByOid: [UInt32: [Int]],
+        regionTrackMap: inout [Int: UInt32]
+    ) {
+        guard body.count >= 12 else { return }
+        let count = body.count / 4
+        var i = 0
+        while i < count - 1 {
+            let val = readLE32(body, at: i * 4)
+            guard trackOidSet.contains(val) else { i += 1; continue }
+
+            let regionCount = Int(readLE32(body, at: (i + 1) * 4))
+            guard regionCount >= 1, regionCount <= 100 else { i += 1; continue }
+            guard i + 1 + regionCount < count else { i += 1; continue }
+
+            // Check that the following regionCount u32s are known region OIDs
+            var matched = 0
+            for j in 0..<regionCount {
+                let candidate = readLE32(body, at: (i + 2 + j) * 4)
+                if regionsByOid[candidate] != nil { matched += 1 }
+            }
+
+            // Require majority match (≥50% of claimed regions are known OIDs)
+            if matched * 2 >= regionCount {
+                let trackOid = val
+                for j in 0..<regionCount {
+                    let regionOid = readLE32(body, at: (i + 2 + j) * 4)
+                    if let indices = regionsByOid[regionOid] {
+                        for idx in indices where regionTrackMap[idx] == nil {
+                            regionTrackMap[idx] = trackOid
+                        }
+                    }
+                }
+                i += 2 + regionCount
+                continue
+            }
+            i += 1
+        }
+    }
+
+    // MARK: - AuCO Mixer Data (Volume, Pan, Output Routing)
+
+    /// Enrich tracks with volume, pan, and output routing from AuCO chunks.
+    ///
+    /// AuCO body layout:
+    ///   0x3C  null-terminated ASCII  channel strip name
+    ///   0x59  1B                     pan byte (0=hard left, 64=center, 127=hard right)
+    ///   volume: 4-byte LE u32 at a known offset; unity = 1509949440
+    ///
+    /// Matching strategy: match AuCO channel strip name to MSeq track name (case-insensitive).
+    /// Fallback: scan for routing strings (Output/Bus/Stereo Out) even when name doesn't match.
+    private static func enrichTracksWithAuCO(
+        chunks: [ChunkInfo],
+        data: Data,
+        tracks: inout [ParsedTrack]
+    ) {
+        // Build a name -> track index map for quick lookup
+        var trackByName: [String: Int] = [:]
+        for (i, t) in tracks.enumerated() {
+            trackByName[t.name.lowercased()] = i
+        }
+
+        for chunk in chunks where chunk.id == idAuCO {
+            guard chunk.bodyLength > 0x5A else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // --- Channel strip name at 0x3C ---
+            let stripName = readNullTerminatedASCII(body, at: 0x3C, maxLen: 64)
+
+            // --- Pan byte at 0x59 ---
+            let panByte = Int(body[0x59])
+            let panNorm: Double = (Double(panByte) - 64.0) / 64.0  // -1.0 to +1.0
+
+            // --- Volume: scan for u32 values near the channel name area ---
+            // Per spec: volume is a 32-bit integer at a known offset.
+            // We scan a window around 0x50-0x58 for plausible volume values.
+            let volumeDB = readVolumeDB(body: body)
+
+            // --- Output routing: scan for "Output", "Bus", "Stereo Out" strings ---
+            let outputRouting = extractOutputRouting(body: body)
+
+            // --- Match to track by name ---
+            if let idx = trackByName[stripName.lowercased()], !stripName.isEmpty {
+                tracks[idx].volume = volumeDB
+                tracks[idx].pan = panNorm.clamped(to: -1.0...1.0)
+                if let routing = outputRouting {
+                    tracks[idx].outputRouting = routing
+                }
+            } else if let routing = outputRouting {
+                // Even without a name match, try to assign routing to an unassigned track
+                // by looking for a track with a matching name prefix in the routing string
+                for i in tracks.indices where tracks[i].outputRouting == nil {
+                    let tname = tracks[i].name.lowercased()
+                    if routing.lowercased().contains(tname) || tname.contains(stripName.lowercased()) {
+                        tracks[i].outputRouting = routing
+                        tracks[i].volume = volumeDB
+                        tracks[i].pan = panNorm.clamped(to: -1.0...1.0)
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read null-terminated ASCII string from body at given offset.
+    private static func readNullTerminatedASCII(_ body: Data, at offset: Int, maxLen: Int) -> String {
+        guard offset < body.count else { return "" }
+        var end = offset
+        let limit = min(body.count, offset + maxLen)
+        while end < limit && body[end] != 0 {
+            end += 1
+        }
+        guard end > offset else { return "" }
+        return String(data: Data(body[offset..<end]), encoding: .ascii) ?? ""
+    }
+
+    /// Scan AuCO body for volume raw value. Returns dB, or nil if no plausible value found.
+    ///
+    /// Unity gain = 1509949440 (0x5A000080 LE).
+    /// Formula: dB = 40 * log10(value / 1509949440)
+    ///
+    /// We scan offsets 0x48..0x58 for a 4-byte value that decodes to a reasonable dB range (-144..+6).
+    private static func readVolumeDB(body: Data) -> Double? {
+        // Per spec unity = 1509949440; try the standard volume offset range
+        let searchOffsets = [0x48, 0x4C, 0x50, 0x54, 0x58]
+        for off in searchOffsets {
+            guard off + 4 <= body.count else { continue }
+            let raw = readLE32(body, at: off)
+            guard raw > 0 else { continue }
+            let ratio = Double(raw) / unityGainRaw
+            guard ratio > 0 else { continue }
+            let db = 40.0 * log10(ratio)
+            if db >= -144.0 && db <= 12.0 {
+                return db
+            }
+        }
+        return nil
+    }
+
+    /// Scan an AuCO body for output routing label strings.
+    private static func extractOutputRouting(body: Data) -> String? {
+        // Scan body as ASCII for strings containing Output/Bus/Stereo Out
+        let ascii = String(body.map { b -> Character in
+            let s = Unicode.Scalar(b)
+            return s.value >= 32 && s.value < 127 ? Character(s) : Character(" ")
+        })
+
+        let keywords = ["Stereo Out", "Output", "Bus"]
+        for keyword in keywords {
+            if let range = ascii.range(of: keyword) {
+                // Extract surrounding word (up to 32 chars)
+                let start = ascii.index(range.lowerBound, offsetBy: -min(0, ascii.distance(from: ascii.startIndex, to: range.lowerBound)))
+                var end = range.upperBound
+                var count = 0
+                while end < ascii.endIndex && count < 20 {
+                    let c = ascii[end]
+                    if c == "\0" || c.asciiValue.map({ $0 < 32 }) ?? false { break }
+                    end = ascii.index(after: end)
+                    count += 1
+                }
+                let label = String(ascii[start..<end]).trimmingCharacters(in: .whitespaces)
+                if !label.isEmpty { return label }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Plugin List
+
+    /// Extract plugin names from null-ID (00 00 00 00) chunks.
+    ///
+    /// Per spec, these chunks have id "####" or all-zero bytes.
+    /// The body contains ASCII plugin name signatures.
+    private static func extractPlugins(chunks: [ChunkInfo], data: Data) -> [String] {
+        var plugins = Set<String>()
+
+        // Known plugin name keywords to search for
+        let knownPlugins = [
+            "Serum", "Valhalla", "Compressor", "Kontakt", "Massive", "Diva",
+            "Sylenth", "Omnisphere", "Nexus", "Spire", "Vital", "Pigments",
+            "Reverb", "Delay", "Limiter", "EQ", "Transient", "Saturn",
+            "Vintage", "FabFilter", "iZotope", "Waves", "Native Instruments",
+        ]
+
+        for chunk in chunks {
+            // Null-ID chunks: all 4 ID bytes are non-ASCII (or the reversed ID is "####")
+            // The id field will be empty or contain non-printable chars when OID=0 and ID=0x00000000
+            guard chunk.id.isEmpty || chunk.id == "\0\0\0\0" || isNullID(chunk.id) else { continue }
+            guard chunk.bodyLength > 4, chunk.bodyLength < 10_000_000 else { continue }
+
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+            let ascii = body.map { b -> Character in
+                let s = Unicode.Scalar(b)
+                return s.value >= 32 && s.value < 127 ? Character(s) : Character("\0")
+            }
+            let bodyStr = String(ascii)
+
+            for plugin in knownPlugins where bodyStr.contains(plugin) {
+                plugins.insert(plugin)
+            }
+
+            // Also extract any ASCII strings > 4 chars that look like plugin names
+            // (contiguous printable chars, starts with uppercase, no spaces or common delimiters)
+            var i = bodyStr.startIndex
+            while i < bodyStr.endIndex {
+                let c = bodyStr[i]
+                guard c.isUppercase else { i = bodyStr.index(after: i); continue }
+
+                var j = bodyStr.index(after: i)
+                while j < bodyStr.endIndex {
+                    let cc = bodyStr[j]
+                    if !cc.isLetter && !cc.isNumber && cc != " " && cc != "-" && cc != "_" { break }
+                    j = bodyStr.index(after: j)
+                }
+
+                let word = String(bodyStr[i..<j])
+                if word.count >= 4 && word.count <= 40
+                    && word.first?.isUppercase == true
+                    && !word.allSatisfy({ $0.isUppercase }) // avoid all-caps constants
+                {
+                    // Heuristic: if it looks like a product name (mixed case), keep it
+                    let hasLower = word.contains(where: { $0.isLowercase })
+                    if hasLower { plugins.insert(word) }
+                }
+                i = j
+            }
+        }
+
+        return Array(plugins).sorted()
+    }
+
+    /// Returns true if the chunk ID consists only of non-printable / null bytes.
+    private static func isNullID(_ id: String) -> Bool {
+        return id.unicodeScalars.allSatisfy { $0.value < 32 || $0.value == 0 }
+    }
+
     // MARK: - Marker Assembly
 
     private static func buildMarkers(
@@ -796,22 +1272,103 @@ enum ProjectDataParser {
     }
 }
 
+// MARK: - Comparable Clamping Helper
+
+extension Comparable {
+    fileprivate func clamped(to range: ClosedRange<Self>) -> Self {
+        return min(max(self, range.lowerBound), range.upperBound)
+    }
+}
+
 // MARK: - AppleScript Helper
 
-/// Run AppleScript synchronously and return the string result, or nil on error.
-/// Used to get the current Logic Pro project path.
+/// Run AppleScript with a timeout using DispatchSemaphore.
+/// Returns the string result, or nil on error or timeout.
 func runAppleScript(_ source: String) -> String? {
-    var errorDict: NSDictionary?
-    let script = NSAppleScript(source: source)
-    let result = script?.executeAndReturnError(&errorDict)
-    if errorDict != nil { return nil }
-    return result?.stringValue
+    // Wrap result in a class so it can be mutated from the async closure
+    // without triggering Swift 6 Sendable warnings.
+    final class Box: @unchecked Sendable { var value: String? }
+    let box = Box()
+    let semaphore = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global(qos: .userInitiated).async {
+        var errorDict: NSDictionary?
+        let script = NSAppleScript(source: source)
+        let desc = script?.executeAndReturnError(&errorDict)
+        if errorDict == nil {
+            box.value = desc?.stringValue
+        }
+        semaphore.signal()
+    }
+
+    // Wait up to 3 seconds
+    let timedOut = semaphore.wait(timeout: .now() + 3.0) == .timedOut
+    return timedOut ? nil : box.value
 }
 
 /// Get the POSIX path of the front Logic Pro document via AppleScript.
+/// If AppleScript fails or times out, falls back to finding the most recently
+/// modified .logicx file in ~/Desktop, ~/Documents, and ~/Music (max depth 3).
 func currentLogicProProjectPath() -> String? {
     let source = """
     tell application "Logic Pro" to get POSIX path of (file of front document)
     """
-    return runAppleScript(source)
+    if let path = runAppleScript(source), !path.isEmpty {
+        return path
+    }
+    return findMostRecentLogicxFile()
+}
+
+/// Scan ~/Desktop, ~/Documents, ~/Music for the most recently modified .logicx bundle
+/// (max directory depth 3). Returns the path with the latest modification date, or nil.
+func findMostRecentLogicxFile() -> String? {
+    let fm = FileManager.default
+    let home = fm.homeDirectoryForCurrentUser
+    let searchRoots = [
+        home.appendingPathComponent("Desktop"),
+        home.appendingPathComponent("Documents"),
+        home.appendingPathComponent("Music"),
+    ]
+
+    var best: (path: String, date: Date)? = nil
+
+    func scan(_ url: URL, depth: Int) {
+        guard depth >= 0 else { return }
+
+        if url.pathExtension == "logicx" {
+            if let attrs = try? fm.attributesOfItem(atPath: url.path),
+               let modDate = attrs[.modificationDate] as? Date {
+                if best == nil || modDate > best!.date {
+                    best = (url.path, modDate)
+                }
+            }
+            return  // Don't recurse into .logicx bundles
+        }
+
+        guard let contents = try? fm.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for child in contents {
+            let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            if child.pathExtension == "logicx" {
+                if let attrs = try? fm.attributesOfItem(atPath: child.path),
+                   let modDate = attrs[.modificationDate] as? Date {
+                    if best == nil || modDate > best!.date {
+                        best = (child.path, modDate)
+                    }
+                }
+            } else if isDir && depth > 0 {
+                scan(child, depth: depth - 1)
+            }
+        }
+    }
+
+    for root in searchRoots {
+        scan(root, depth: 3)
+    }
+
+    return best?.path
 }

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -39,6 +39,8 @@ enum ProjectDataParser {
     private static let idAuRg = "AuRg"
     private static let idAuFl = "AuFl"
     private static let idAuCO = "AuCO"
+    private static let idTrak = "Trak"
+    private static let idEnvi = "Envi"
 
     // Unity gain raw value for volume dB formula: dB = 40 * log10(value / unityGain)
     private static let unityGainRaw: Double = 1_509_949_440.0
@@ -133,6 +135,25 @@ enum ProjectDataParser {
         // Extract plugin list
         let plugins = extractPlugins(chunks: chunks, data: data)
 
+        // Extract Trak chunks (arrangement track → MSeq linkage)
+        let trakEntries = extractTrakChunks(chunks: chunks, data: data)
+
+        // Extract Envi environment labels (stack grouping labels)
+        let environmentLabels = extractEnviNames(chunks: chunks, data: data)
+
+        // Extract all AuCO channel strips as sub-track enumeration
+        var channelStrips = extractAllChannelStrips(chunks: chunks, data: data)
+
+        // Wire AuCO → Trak → MSeq chain and infer function groups on strips
+        linkChannelStripsToTrak(strips: &channelStrips, trakEntries: trakEntries)
+        inferFunctionGroupsOnStrips(strips: &channelStrips)
+
+        // Build full sub-track hierarchy from channel strips + environment labels
+        let subTrackHierarchy = buildSubTrackHierarchy(
+            strips: channelStrips,
+            environmentLabels: environmentLabels
+        )
+
         var info = ProjectDataInfo()
         info.markers = markers
         info.tempoMap = tempoMap
@@ -144,6 +165,10 @@ enum ProjectDataParser {
         info.timeSignature = timeSignature
         info.sampleRate = sampleRate
         info.projectName = projectName
+        info.channelStrips = channelStrips
+        info.trakEntries = trakEntries
+        info.environmentLabels = environmentLabels
+        info.subTrackHierarchy = subTrackHierarchy
         return info
     }
 
@@ -1071,7 +1096,9 @@ enum ProjectDataParser {
             end += 1
         }
         guard end > offset else { return "" }
-        return String(data: Data(body[offset..<end]), encoding: .ascii) ?? ""
+        let raw = String(data: Data(body[offset..<end]), encoding: .ascii) ?? ""
+        // Trim leading/trailing whitespace (Logic sometimes stores " Audio 1" with a leading space)
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Scan AuCO body for volume raw value. Returns dB, or nil if no plausible value found.
@@ -1145,6 +1172,484 @@ enum ProjectDataParser {
             }
         }
         return nil
+    }
+
+    // MARK: - Trak Chunk Extraction
+
+    /// Extract arrangement tracks from Trak chunks.
+    ///
+    /// Trak body layout (spec: fixed ~58 bytes):
+    ///   0x08  4B  MSeq reference OID (LE u32)
+    ///   0x18  16B UUID
+    ///   0x28  4B  flags (LE u32)
+    private static func extractTrakChunks(chunks: [ChunkInfo], data: Data) -> [TrakEntry] {
+        var result: [TrakEntry] = []
+        var seen = Set<UInt32>()
+
+        for chunk in chunks where chunk.id == idTrak {
+            guard chunk.bodyLength >= 0x2C else { continue }
+            if !seen.insert(chunk.oid).inserted { continue }
+
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // MSeq reference OID at body offset 0x08
+            let mseqOid = readLE32(body, at: 0x08)
+            guard mseqOid != 0 else { continue }  // Skip entries with no MSeq link
+
+            // UUID: 16 bytes at body offset 0x18
+            var uuid: String? = nil
+            if body.count >= 0x28 {
+                let uuidBytes = Data(body[0x18..<0x28])
+                uuid = formatUUID(uuidBytes)
+            }
+
+            // Flags at body offset 0x28
+            let flagsRaw = body.count >= 0x2C ? readLE32(body, at: 0x28) : 0
+
+            result.append(TrakEntry(
+                oid: Int(chunk.oid),
+                mseqOid: Int(mseqOid),
+                uuid: uuid,
+                flagsRaw: flagsRaw
+            ))
+        }
+
+        return result
+    }
+
+    /// Format 16 bytes as a standard UUID string (8-4-4-4-12 hex groups).
+    private static func formatUUID(_ bytes: Data) -> String? {
+        guard bytes.count >= 16 else { return nil }
+        let hex = bytes.map { String(format: "%02x", $0) }.joined()
+        guard hex.count == 32 else { return nil }
+        // Build UUID string manually to avoid Swift type-checker complexity
+        var result = ""
+        for (i, ch) in hex.enumerated() {
+            result.append(ch)
+            if i == 7 || i == 11 || i == 15 || i == 19 {
+                result.append("-")
+            }
+        }
+        // Return nil for all-zero UUID
+        return result == "00000000-0000-0000-0000-000000000000" ? nil : result
+    }
+
+    // MARK: - Envi Name Extraction
+
+    /// Extract environment object names from Envi chunks.
+    ///
+    /// Per the spec, Envi chunks contain environment objects with a name.
+    /// Each Envi body is scanned for the first meaningful printable ASCII run.
+    /// The buildSubTrackHierarchy step filters GM instrument names and noise.
+    private static func extractEnviNames(chunks: [ChunkInfo], data: Data) -> [String] {
+        var names: [String] = []
+        var seen = Set<String>()
+
+        for chunk in chunks where chunk.id == idEnvi {
+            guard chunk.bodyLength >= 4 else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            if let name = extractEnviName(body: body), !name.isEmpty {
+                if seen.insert(name).inserted {
+                    names.append(name)
+                }
+            }
+        }
+
+        return names
+    }
+
+    /// Scan an Envi body for the first plausible printable ASCII name.
+    ///
+    /// Envi bodies in this project store names as contiguous printable ASCII runs
+    /// (not length-prefixed). We scan the full body for the first run of 3-80
+    /// printable bytes that contains at least one letter and passes noise filters.
+    ///
+    /// Noise filters exclude: output labels ("Output N"), system names
+    /// ("Input View", "GM Device", "Preview", "Master", "Stereo Out"),
+    /// and strings starting with "@" or "/".
+    private static let enviNoiseNames: Set<String> = [
+        "not assigned", "input view", "input notes", "preview",
+        "master", "stereo out", "physical input", "sequencer input",
+        "gm device", "edit output",
+        "output 4", "output 9-10", "output 11-12",
+        "output 25-26", "output 27-28", "output 29-30", "output 31-32",
+    ]
+
+    private static func extractEnviName(body: Data) -> String? {
+        var run = ""
+        var bestRun: String? = nil
+
+        for byte in body {
+            if byte >= 0x20 && byte < 0x7F {
+                run.append(Character(Unicode.Scalar(byte)))
+            } else {
+                if let candidate = validateEnviRun(run) {
+                    if bestRun == nil { bestRun = candidate }
+                }
+                run = ""
+            }
+        }
+        // Flush last run
+        if let candidate = validateEnviRun(run), bestRun == nil {
+            bestRun = candidate
+        }
+
+        return bestRun
+    }
+
+    private static func validateEnviRun(_ run: String) -> String? {
+        let trimmed = run.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 3 && trimmed.count <= 80 else { return nil }
+        guard trimmed.contains(where: { $0.isLetter }) else { return nil }
+        let lower = trimmed.lowercased()
+        guard !lower.hasPrefix("@"), !lower.hasPrefix("/"), !lower.hasPrefix("http") else { return nil }
+        // Filter noise names
+        if enviNoiseNames.contains(lower) { return nil }
+        // Filter "Output N" patterns
+        if lower.hasPrefix("output ") && lower.dropFirst(7).allSatisfy({ $0.isNumber || $0 == "-" }) { return nil }
+        return trimmed
+    }
+
+    // MARK: - AuCO Channel Strip Extraction (Full Enumeration)
+
+    /// Extract ALL AuCO channel strips as sub-track enumeration.
+    ///
+    /// Unlike enrichTracksWithAuCO (which only patches existing MSeq tracks),
+    /// this function returns every channel strip found — including all individual
+    /// guitars, vocals, keys, synth layers etc. that never appear as MSeq entries.
+    ///
+    /// Key insight: AuCO chunks in many projects share a small set of OIDs but
+    /// each body encodes a different channel strip name. We deduplicate by name
+    /// (after trimming) rather than by OID to capture all 449 strips.
+    ///
+    /// AuCO body layout:
+    ///   0x3C  null-terminated ASCII  name (up to 64 bytes)
+    ///   0x59  1B                     pan byte (0=hard left, 64=center, 127=hard right)
+    ///   0x74  4B LE u32              volume raw (unity = 1509949440)
+    private static func extractAllChannelStrips(chunks: [ChunkInfo], data: Data) -> [ChannelStrip] {
+        var result: [ChannelStrip] = []
+        var seenNames = Set<String>()
+        var seenOids = Set<UInt32>()     // track first-OID-seen for OID assignment
+        var syntheticIndex = 0          // for OID-less strips
+
+        for chunk in chunks where chunk.id == idAuCO {
+            guard chunk.bodyLength > 0x5A else { continue }
+
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // Name: null-terminated ASCII at 0x3C (up to 64 bytes), trimmed
+            let name = readNullTerminatedASCII(body, at: 0x3C, maxLen: 64)
+            let trimmedName = name.isEmpty ? "" : name
+
+            // Skip duplicate names (same channel strip appearing in multiple bodies)
+            let dedupeKey = trimmedName.isEmpty ? "__empty_\(syntheticIndex)" : trimmedName
+            guard seenNames.insert(dedupeKey).inserted else { continue }
+            if trimmedName.isEmpty { syntheticIndex += 1 }
+
+            // Pan byte at 0x59
+            let panByte = Int(body[0x59])
+            let panNorm: Double = (Double(panByte) - 64.0) / 64.0
+
+            // Volume
+            let volumeDB = readVolumeDB(body: body)
+
+            // Output routing
+            let outputRouting = extractOutputRouting(body: body)
+
+            // Is generic? ("Audio N", "Input N", "Bus N", etc.)
+            let isGeneric = isGenericChannelStripName(trimmedName)
+
+            // OID: use chunk OID if not yet assigned, otherwise use synthetic
+            let oid: Int
+            if seenOids.insert(chunk.oid).inserted {
+                oid = Int(chunk.oid)
+            } else {
+                // Synthesize a unique OID for strips that share the chunk OID
+                // Use a high-bit offset to avoid collision with real OIDs
+                oid = Int(chunk.oid) * 1000 + result.count
+            }
+
+            result.append(ChannelStrip(
+                name: trimmedName.isEmpty ? "Strip \(oid)" : trimmedName,
+                oid: oid,
+                volume: volumeDB,
+                pan: panNorm.clamped(to: -1.0...1.0),
+                outputRouting: outputRouting,
+                functionGroup: nil,
+                isGeneric: isGeneric,
+                trakOid: nil,
+                mseqOid: nil
+            ))
+        }
+
+        return result
+    }
+
+    /// Returns true when a channel strip name is a generic placeholder.
+    /// Patterns: "Audio N", "Inst N", "Bus N", "Output N", "Input N", "Ext. Inst N", empty, etc.
+    private static func isGenericChannelStripName(_ name: String) -> Bool {
+        guard !name.isEmpty else { return true }
+        let lower = name.lowercased()
+
+        // Pure numeric suffix patterns
+        let genericPrefixes = [
+            "audio ", "inst ", "bus ", "output ", "input ", "ext. inst ",
+            "software instrument ", "aux ", "stereo out",
+            "physical input", "sequencer input", "not assigned",
+        ]
+        for prefix in genericPrefixes {
+            if lower.hasPrefix(prefix) {
+                // Allow if remainder is not pure digits (user may have named it "Audio Guitar")
+                let rest = lower.dropFirst(prefix.count)
+                if rest.isEmpty || rest.allSatisfy({ $0.isNumber || $0 == "-" || $0 == " " }) {
+                    return true
+                }
+            }
+        }
+        // Exact matches that are always generic
+        if lower == "stereo out" || lower == "master" || lower == "not assigned" { return true }
+
+        // All-digit names
+        if name.allSatisfy({ $0.isNumber }) { return true }
+
+        return false
+    }
+
+    // MARK: - AuCO → Trak → MSeq Chain
+
+    /// Link channel strips to Trak entries (and via Trak, to MSeq).
+    ///
+    /// Strategy:
+    ///   1. Exact OID match: AuCO.oid == Trak.oid
+    ///   2. Proximity: nearest Trak OID within ±8 of AuCO.oid
+    private static func linkChannelStripsToTrak(
+        strips: inout [ChannelStrip],
+        trakEntries: [TrakEntry]
+    ) {
+        guard !trakEntries.isEmpty else { return }
+
+        // Build OID → Trak map
+        var trakByOid: [Int: TrakEntry] = [:]
+        for t in trakEntries {
+            trakByOid[t.oid] = t
+        }
+        let sortedTrakOids = trakEntries.map { $0.oid }.sorted()
+
+        for i in strips.indices {
+            let stripOid = strips[i].oid
+
+            // 1. Exact match
+            if let trak = trakByOid[stripOid] {
+                strips[i].trakOid = trak.oid
+                strips[i].mseqOid = trak.mseqOid
+                continue
+            }
+
+            // 2. Nearest within ±8
+            var bestDist = 9
+            var bestTrak: TrakEntry? = nil
+            for tOid in sortedTrakOids {
+                let dist = abs(stripOid - tOid)
+                if dist < bestDist {
+                    bestDist = dist
+                    bestTrak = trakByOid[tOid]
+                }
+            }
+            if let trak = bestTrak {
+                strips[i].trakOid = trak.oid
+                strips[i].mseqOid = trak.mseqOid
+            }
+        }
+    }
+
+    /// Infer function groups on channel strips using name keywords.
+    private static func inferFunctionGroupsOnStrips(strips: inout [ChannelStrip]) {
+        for i in strips.indices {
+            strips[i].functionGroup = inferGroupFromText(strips[i].name)
+        }
+    }
+
+    // MARK: - Sub-track Hierarchy Builder
+
+    /// Build the full sub-track hierarchy from channel strips and environment labels.
+    ///
+    /// Algorithm:
+    ///   1. If environment labels contain non-generic names (song/project-specific names),
+    ///      use them as the sub-track catalog — they map directly to Logic's Environment
+    ///      and represent each actual mixer channel.
+    ///   2. Assign each environment-label sub-track to an environment stack using keyword
+    ///      matching against canonical stack labels.
+    ///   3. For any named AuCO channel strips, also include them in the hierarchy.
+    ///   4. Filter noise from the environment labels (GM instrument names, system labels).
+    private static func buildSubTrackHierarchy(
+        strips: [ChannelStrip],
+        environmentLabels: [String]
+    ) -> [SubTrackStack] {
+        // Canonical environment stack labels (in display order)
+        let canonicalStackLabels: [(label: String, keywords: [String])] = [
+            ("Click Track",    ["click", "metronome", "midi click"]),
+            ("Midi Triggers",  ["midi", "trigger", "cortex", "quad", "nano", "wled"]),
+            ("Backing Track",  ["backing"]),
+            ("Release Track",  ["release"]),
+            ("Drums",          ["drum", "kick", "snare", "perc"]),
+            ("Guitars",        ["guitar", "gtr", "clean", "distort", "guitare"]),
+            ("Vocals",         ["vocal", "vox", "harmony", "choir", "voice"]),
+            ("Keys/Synths",    ["key", "piano", "organ", "synth", "rhodes"]),
+            ("Bass",           ["bass"]),
+            ("Strings",        ["string", "violin", "viola", "cello"]),
+            ("Samples/FX",     ["sample", "sfx", "texture", "soundscape", "ambient", "loop"]),
+            ("Songs",          ["intro", "verse", "chorus", "bridge", "breakdown", "transition",
+                                "the last light", "in her eyes", "reborn", "fortitude",
+                                "new beginnings", "dead", "buried", "twdtd", "ihe"]),
+        ]
+
+        // Known noise patterns for environment labels (not real sub-tracks)
+        let gmInstruments: Set<String> = [
+            "accordion fr", "acoustic bs.", "agogo", "alto sax", "applause", "atmosphere",
+            "bag pipe", "banjo", "baritone sax", "bass&lead", "bassoon", "bird", "blown bottle",
+            "bowed glass", "brass 1", "breath noise", "bright piano", "brightness", "celesta",
+            "cello", "charang", "chiffer lead", "choir aahs", "church organ1", "clarinet",
+            "clavinet", "clean gt.", "contrabass", "crystal", "distortion gt", "draworgan",
+            "dulcimer", "e. piano1", "e. piano2", "echo drops", "electricgrand", "english horn",
+            "fantasia", "fiddle", "fingered bs.", "flute", "french horn", "fretless bs.",
+            "glockenspiel", "goblin", "grand piano", "gt fretnoise", "gt.harmonics",
+            "gun shot", "halo pad", "harmonica", "harp", "harpsichord", "helicopter",
+            "honkytonkpno.", "ice rain", "jazz gt.", "kalimba", "koto", "marimba", "melo tom",
+            "metal pad", "music box", "muted gt.", "mutedtrumpet", "nylonstr. gt.", "oboe",
+            "ocarina", "orchestrahit", "overdrive gt.", "pan flute", "percorgan", "piccolo",
+            "picked bs.", "pizzicato str", "polysynth", "recorder", "reed organ", "reverse cym.",
+            "rockorgan", "saw wave", "seashore", "shakuhachi", "shamisen", "shanai", "sitar",
+            "slap bass 1", "slap bass 2", "slow strings", "solo vox", "soprano sax", "soundtrack",
+            "space voice", "square wave", "star theme", "steel drums", "steelstr. gt.", "strings",
+            "sweep pad", "syn. calliope", "syn. strings1", "syn. strings2", "synvox",
+            "synth bass 1", "synth bass 2", "synth brass1", "synth brass2", "synth drum",
+            "tangoacd", "telephone 1", "tenor sax", "timpani", "tinkle bell", "tremolo str.",
+            "trombone", "trumpet", "tuba", "tubular-bell", "vibraphone", "viola", "violin",
+            "voice oohs", "warm pad", "whistle", "woodblock", "xylophone",
+            "5th saw wave", "e<j", "m#v", "o4i", "s9ie", "ax%", "dto", "h%ns", "n91q",
+            "no2", "}=l", "e<j", "*$v", "*6uw", "<bo", "dro",
+            // System/router objects
+            "gm device", "(folder)",
+        ]
+
+        // Filter environment labels to meaningful project-specific names
+        let projectLabels = environmentLabels.filter { label in
+            let lower = label.lowercased()
+            if gmInstruments.contains(lower) { return false }
+            // Skip short noise (2-3 char random strings)
+            if label.count <= 2 { return false }
+            // Skip strings that look like binary noise (no vowels)
+            let vowels = Set<Character>("aeiouAEIOU")
+            if label.count <= 4 && !label.contains(where: { vowels.contains($0) }) { return false }
+            return true
+        }
+
+        // Build map: stack label → sub-track names
+        var stackMap: [String: [String]] = [:]
+        var unassigned: [String] = []
+
+        for label in projectLabels {
+            let lower = label.lowercased()
+            var assigned = false
+
+            // Check canonical stacks
+            for stackDef in canonicalStackLabels {
+                let matchesKeyword = stackDef.keywords.contains { kw in
+                    lower.contains(kw)
+                }
+                if matchesKeyword {
+                    stackMap[stackDef.label, default: []].append(label)
+                    assigned = true
+                    break
+                }
+            }
+
+            if !assigned {
+                unassigned.append(label)
+            }
+        }
+
+        // Build sub-track stacks
+        var stacks: [SubTrackStack] = []
+
+        // Named AuCO strips (if any are non-generic)
+        let namedStrips = strips.filter { !$0.isGeneric }
+
+        // Canonical stack order
+        for stackDef in canonicalStackLabels {
+            guard let labelGroup = stackMap[stackDef.label], !labelGroup.isEmpty else { continue }
+
+            // Convert label group to ChannelStrip objects (synthetic, from Envi labels)
+            let stackStrips: [ChannelStrip] = labelGroup.map { label in
+                // Try to find a real AuCO strip with matching name
+                let matchedStrip = namedStrips.first { s in
+                    s.name.lowercased() == label.lowercased()
+                }
+                if let s = matchedStrip { return s }
+                // Create synthetic strip from Envi label
+                return ChannelStrip(
+                    name: label,
+                    oid: 0,
+                    volume: nil,
+                    pan: nil,
+                    outputRouting: nil,
+                    functionGroup: stackDef.label,
+                    isGeneric: false,
+                    trakOid: nil,
+                    mseqOid: nil
+                )
+            }
+
+            stacks.append(SubTrackStack(
+                name: stackDef.label,
+                source: "environment_label",
+                strips: stackStrips.sorted { $0.name < $1.name }
+            ))
+        }
+
+        // Unassigned project labels
+        if !unassigned.isEmpty {
+            let unassignedStrips = unassigned.map { label -> ChannelStrip in
+                ChannelStrip(
+                    name: label,
+                    oid: 0,
+                    volume: nil,
+                    pan: nil,
+                    outputRouting: nil,
+                    functionGroup: nil,
+                    isGeneric: false,
+                    trakOid: nil,
+                    mseqOid: nil
+                )
+            }
+            stacks.append(SubTrackStack(
+                name: "Other",
+                source: "environment_label",
+                strips: unassignedStrips.sorted { $0.name < $1.name }
+            ))
+        }
+
+        // Any non-generic AuCO strips not already in a stack
+        let inStackNames = Set(stacks.flatMap { $0.strips.map { $0.name.lowercased() } })
+        let remainingStrips = namedStrips.filter { !inStackNames.contains($0.name.lowercased()) }
+        if !remainingStrips.isEmpty {
+            // Group remaining by function group
+            var fgMap: [String: [ChannelStrip]] = [:]
+            for s in remainingStrips {
+                let fg = s.functionGroup ?? "Other"
+                fgMap[fg, default: []].append(s)
+            }
+            for fg in fgMap.keys.sorted() {
+                stacks.append(SubTrackStack(
+                    name: fg,
+                    source: "function_group",
+                    strips: fgMap[fg]!.sorted { $0.name < $1.name }
+                ))
+            }
+        }
+
+        return stacks
     }
 
     // MARK: - Plugin List

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -1,0 +1,676 @@
+import Foundation
+
+// MARK: - ProjectDataParser
+
+/// Parses Logic Pro binary ProjectData files to extract arrangement markers,
+/// tempo maps, track names, and time signatures — without using the Accessibility API.
+///
+/// File layout:
+/// - Magic:  23 47 C0 AB  (4 bytes at offset 0)
+/// - Chunk stream starting at ~0x18
+///
+/// Each chunk has a 36-byte header:
+///   0x00  4B  ID (reversed bytes, e.g. "qSxT" on disk = "TxSq")
+///   0x04  6B  metadata/flags
+///   0x0A  4B  OID (LE u32)
+///   0x0E  8B  padding
+///   0x16  6B  anchor: 02 00 00 00 [01|02] 00
+///   0x1C  8B  body length (LE u64)
+///
+/// Chunks are discovered by scanning for the anchor pattern.
+enum ProjectDataParser {
+
+    // MARK: - Constants
+
+    private static let magicBytes: [UInt8] = [0x23, 0x47, 0xC0, 0xAB]
+    private static let anchorPrefix: [UInt8] = [0x02, 0x00, 0x00, 0x00]
+    private static let chunkHeaderSize = 36
+    private static let anchorOffset = 0x16          // within header
+    private static let oidOffset = 0x0A             // within header
+    private static let lengthOffset = 0x1C          // within header
+    private static let idOffset = 0x00              // within header
+    private static let ticksPerBar = 3840           // 4/4 at Logic resolution
+
+    // Chunk IDs (as they appear after reversing the 4 on-disk bytes)
+    private static let idTxSq = "TxSq"
+    private static let idEvSq = "EvSq"
+    private static let idMSeq = "MSeq"
+
+    // Arrangement marker OIDs per RE findings: 4, 8, 12, 16, 20, 24, 28, 32, 36
+    private static let markerOIDs: Set<UInt32> = [4, 8, 12, 16, 20, 24, 28, 32, 36]
+
+    // Tempo event signature: 7F 00 00 01 ...
+    private static let tempoSignature: [UInt8] = [0x7F, 0x00, 0x00, 0x01]
+
+    // MARK: - Public API
+
+    /// Parse the ProjectData for a given `.logicx` bundle or raw `ProjectData` file path.
+    ///
+    /// - Parameter path: Either a `.logicx` directory or a raw `ProjectData` file.
+    /// - Returns: Parsed `ProjectDataInfo`, or `nil` if the file cannot be found / validated.
+    static func parse(path: String) -> ProjectDataInfo? {
+        let url = URL(fileURLWithPath: path)
+        let projectDataURL: URL
+        let logicxURL: URL?
+
+        if path.hasSuffix(".logicx") || url.pathExtension == "logicx" {
+            logicxURL = url
+            guard let found = findProjectData(in: url) else { return nil }
+            projectDataURL = found
+        } else {
+            // Treat as raw ProjectData file; walk up to find .logicx for plist parsing
+            projectDataURL = url
+            logicxURL = findLogicxParent(of: url)
+        }
+
+        guard let data = try? Data(contentsOf: projectDataURL) else { return nil }
+        guard validateMagic(data) else { return nil }
+
+        let projectName = logicxURL.map { $0.deletingPathExtension().lastPathComponent } ?? ""
+
+        // Scan all chunks
+        let chunks = scanChunks(data: data)
+
+        // Extract per-type maps
+        let txSqMap = extractTxSqNames(chunks: chunks, data: data)       // oid -> name
+        let evSqMarkerEvents = extractMarkerEvents(chunks: chunks, data: data) // [(oid, startTick, durationTicks)]
+        let tempoMap = extractTempoMap(chunks: chunks, data: data)
+        let parsedTracks = extractTracks(chunks: chunks, data: data)
+
+        // Join marker names with positions
+        let markers = buildMarkers(txSqMap: txSqMap, events: evSqMarkerEvents)
+
+        // Time signature from plists
+        let timeSignature = logicxURL.flatMap { readTimeSignature(logicx: $0) } ?? "4/4"
+        let sampleRate = logicxURL.flatMap { readSampleRate(logicx: $0) } ?? 0
+
+        var info = ProjectDataInfo()
+        info.markers = markers
+        info.tempoMap = tempoMap
+        info.tracks = parsedTracks
+        info.timeSignature = timeSignature
+        info.sampleRate = sampleRate
+        info.projectName = projectName
+        return info
+    }
+
+    // MARK: - File Discovery
+
+    /// Find the ProjectData file inside a .logicx bundle.
+    /// Scans Alternatives/000, Alternatives/001, etc.
+    private static func findProjectData(in logicxURL: URL) -> URL? {
+        let altRoot = logicxURL.appendingPathComponent("Alternatives")
+        let fm = FileManager.default
+
+        // Try numbered alternatives 000..009
+        for index in 0...9 {
+            let indexStr = String(format: "%03d", index)
+            let candidate = altRoot
+                .appendingPathComponent(indexStr)
+                .appendingPathComponent("ProjectData")
+            if fm.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        // Fallback: scan directory entries
+        if let entries = try? fm.contentsOfDirectory(atPath: altRoot.path) {
+            for entry in entries.sorted() {
+                let candidate = altRoot
+                    .appendingPathComponent(entry)
+                    .appendingPathComponent("ProjectData")
+                if fm.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Walk up the directory tree from a raw ProjectData file to find the parent .logicx bundle.
+    private static func findLogicxParent(of url: URL) -> URL? {
+        var current = url.deletingLastPathComponent()
+        for _ in 0..<5 {
+            if current.pathExtension == "logicx" { return current }
+            current = current.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    // MARK: - Magic Validation
+
+    private static func validateMagic(_ data: Data) -> Bool {
+        guard data.count >= 4 else { return false }
+        return data[0] == 0x23 && data[1] == 0x47 && data[2] == 0xC0 && data[3] == 0xAB
+    }
+
+    // MARK: - Chunk Scanning
+
+    /// Describes a located chunk.
+    private struct ChunkInfo {
+        let id: String      // reversed 4-char ID
+        let oid: UInt32
+        let bodyOffset: Int // offset within data where body begins
+        let bodyLength: Int
+    }
+
+    /// Scan the entire data blob for valid chunks using the anchor-signature method.
+    ///
+    /// Anchor at offset 0x16 within a 36-byte header:
+    ///   02 00 00 00 [01|02] 00
+    ///
+    /// The chunk ID is 4 bytes at the very start of the header, i.e. 0x16 bytes before
+    /// the anchor.
+    private static func scanChunks(data: Data) -> [ChunkInfo] {
+        var result: [ChunkInfo] = []
+        let bytes = data
+        let total = bytes.count
+        var offset = 4 // skip global magic
+
+        while offset + chunkHeaderSize <= total {
+            // Look for anchor pattern: 02 00 00 00 [01 or 02] 00
+            // We scan byte-by-byte; for performance we look for 0x02 first.
+            guard bytes[offset + anchorOffset] == 0x02,
+                  bytes[offset + anchorOffset + 1] == 0x00,
+                  bytes[offset + anchorOffset + 2] == 0x00,
+                  bytes[offset + anchorOffset + 3] == 0x00,
+                  (bytes[offset + anchorOffset + 4] == 0x01 || bytes[offset + anchorOffset + 4] == 0x02),
+                  bytes[offset + anchorOffset + 5] == 0x00
+            else {
+                offset += 1
+                continue
+            }
+
+            // Looks like an anchor; read length field
+            let bodyLength = Int(readLE64(data, at: offset + lengthOffset))
+            let bodyStart = offset + chunkHeaderSize
+
+            // Validate bounds
+            guard bodyLength >= 0,
+                  bodyStart + bodyLength <= total
+            else {
+                offset += 1
+                continue
+            }
+
+            // Read 4-byte ID (reversed)
+            let rawID = Array(bytes[offset..<(offset + 4)])
+            let id = reverseID(rawID)
+
+            // Read OID
+            let oid = readLE32(data, at: offset + oidOffset)
+
+            result.append(ChunkInfo(
+                id: id,
+                oid: oid,
+                bodyOffset: bodyStart,
+                bodyLength: bodyLength
+            ))
+
+            // Advance past this chunk
+            offset = bodyStart + bodyLength
+        }
+        return result
+    }
+
+    // MARK: - TxSq Name Extraction
+
+    /// Extract RTF text from TxSq chunks for arrangement marker OIDs.
+    /// Returns a map of OID -> cleaned name.
+    private static func extractTxSqNames(chunks: [ChunkInfo], data: Data) -> [UInt32: String] {
+        var result: [UInt32: String] = [:]
+        for chunk in chunks where chunk.id == idTxSq {
+            guard markerOIDs.contains(chunk.oid) else { continue }
+            guard chunk.bodyLength > 0 else { continue }
+            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            if let name = extractRTFText(body) {
+                result[chunk.oid] = name
+            }
+        }
+        return result
+    }
+
+    /// Extract plain text from an RTF body.
+    /// RTF starts with `{\rtf1`. We strip all `\cmdN` tags and braces.
+    private static func extractRTFText(_ body: Data) -> String? {
+        guard let raw = String(data: body, encoding: .utf8)
+                ?? String(data: body, encoding: .isoLatin1)
+        else { return nil }
+
+        // Must be RTF
+        guard raw.contains("{\\rtf") else {
+            // Try treating it as a direct pascal-style or length-prefixed string
+            return extractDirectString(body)
+        }
+
+        // Find content after \fs<N> tag (font size, precedes actual text)
+        // Strategy: strip everything inside { } control blocks, then trim
+        let text = raw
+
+        // Remove all RTF control words (\word or \word<N>) and special chars
+        // We use a simple state-machine approach:
+        var result = ""
+        var i = text.startIndex
+
+        while i < text.endIndex {
+            let ch = text[i]
+            if ch == "{" || ch == "}" {
+                i = text.index(after: i)
+                continue
+            }
+            if ch == "\\" {
+                // Skip control word or symbol
+                let next = text.index(after: i)
+                if next < text.endIndex {
+                    let nc = text[next]
+                    if nc == "\\" || nc == "{" || nc == "}" || nc == ";" || nc == "\n" || nc == "\r" {
+                        // Escaped char
+                        if nc == "\\" || nc == "{" || nc == "}" {
+                            result.append(nc)
+                        }
+                        i = text.index(after: next)
+                        continue
+                    }
+                    if nc == "'" {
+                        // Hex escape \'XX
+                        let h1 = text.index(next, offsetBy: 1, limitedBy: text.endIndex) ?? text.endIndex
+                        let h2 = text.index(next, offsetBy: 2, limitedBy: text.endIndex) ?? text.endIndex
+                        let h3 = text.index(next, offsetBy: 3, limitedBy: text.endIndex) ?? text.endIndex
+                        if h1 < text.endIndex && h2 < text.endIndex {
+                            let hexStr = String(text[h1..<h2])
+                            if let code = UInt32(hexStr, radix: 16),
+                               let scalar = Unicode.Scalar(code) {
+                                result.append(Character(scalar))
+                            }
+                            i = h3 < text.endIndex ? h3 : text.endIndex
+                        } else {
+                            i = text.index(after: next)
+                        }
+                        continue
+                    }
+                    if nc.isLetter || nc == "-" {
+                        // Control word: skip until non-alphanumeric (and skip optional numeric param + optional space)
+                        var j = next
+                        while j < text.endIndex && (text[j].isLetter || text[j] == "-") {
+                            j = text.index(after: j)
+                        }
+                        // skip optional numeric parameter
+                        if j < text.endIndex && (text[j].isNumber || text[j] == "-") {
+                            while j < text.endIndex && (text[j].isNumber || text[j] == "-") {
+                                j = text.index(after: j)
+                            }
+                        }
+                        // skip single trailing space
+                        if j < text.endIndex && text[j] == " " {
+                            j = text.index(after: j)
+                        }
+                        i = j
+                        continue
+                    }
+                }
+                i = text.index(after: i)
+                continue
+            }
+            if ch == "\n" || ch == "\r" {
+                i = text.index(after: i)
+                continue
+            }
+            result.append(ch)
+            i = text.index(after: i)
+        }
+
+        let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    /// Fallback: try to read a length-prefixed ASCII string from raw body bytes.
+    private static func extractDirectString(_ body: Data) -> String? {
+        guard body.count >= 3 else { return nil }
+        // Check for 2-byte LE length prefix
+        let len = Int(body[0]) | (Int(body[1]) << 8)
+        if len > 0 && len < body.count - 2 {
+            if let s = String(data: body[2..<(2 + len)], encoding: .utf8) {
+                let cleaned = s.trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
+                return cleaned.isEmpty ? nil : cleaned
+            }
+        }
+        return nil
+    }
+
+    // MARK: - EvSq Marker Event Extraction
+
+    struct MarkerEvent {
+        let oid: UInt32
+        let startTick: UInt32
+        let durationTicks: UInt32
+    }
+
+    /// Scan EvSq chunks for type-18 triplet sequences that encode arrangement marker positions.
+    ///
+    /// Per spec, small EvSq(oid=0) chunks contain 16-byte aligned triplets:
+    ///   head:   [u32=18, u32=start_tick, u32=0, ...]
+    ///   marker: [u32=marker_oid, u32=0x88000000, u32=marker_type, u32=duration_ticks]
+    ///   tail:   [u32=0, u32=0x88000000, u32=0, u32=0]
+    private static func extractMarkerEvents(chunks: [ChunkInfo], data: Data) -> [MarkerEvent] {
+        var result: [MarkerEvent] = []
+
+        for chunk in chunks where chunk.id == idEvSq {
+            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let events = parseType18Triplets(body: body)
+            result.append(contentsOf: events)
+        }
+
+        // Deduplicate by OID, keeping first occurrence
+        var seen = Set<UInt32>()
+        var deduped: [MarkerEvent] = []
+        for e in result {
+            if seen.insert(e.oid).inserted {
+                deduped.append(e)
+            }
+        }
+        return deduped
+    }
+
+    /// Parse type-18 triplets from an EvSq body.
+    private static func parseType18Triplets(body: Data) -> [MarkerEvent] {
+        var events: [MarkerEvent] = []
+        let count = body.count / 16
+        guard count >= 3 else { return events }
+
+        var i = 0
+        while i + 2 < count {
+            let headOffset = i * 16
+            let markerOffset = (i + 1) * 16
+            let tailOffset = (i + 2) * 16
+
+            guard headOffset + 16 <= body.count,
+                  markerOffset + 16 <= body.count,
+                  tailOffset + 16 <= body.count
+            else { break }
+
+            let h0 = readLE32(body, at: headOffset + 0)
+            let h1 = readLE32(body, at: headOffset + 4)
+
+            let m0 = readLE32(body, at: markerOffset + 0)
+            let m1 = readLE32(body, at: markerOffset + 4)
+            let m3 = readLE32(body, at: markerOffset + 12)
+
+            let t0 = readLE32(body, at: tailOffset + 0)
+            let t1 = readLE32(body, at: tailOffset + 4)
+
+            // Check triplet pattern:
+            // head[0] == 18, marker[1] == 0x88000000, tail[0] == 0, tail[1] == 0x88000000
+            if h0 == 18
+                && m1 == 0x88000000
+                && t0 == 0
+                && t1 == 0x88000000
+                && markerOIDs.contains(m0)
+            {
+                events.append(MarkerEvent(oid: m0, startTick: h1, durationTicks: m3))
+                i += 3
+                continue
+            }
+            i += 1
+        }
+        return events
+    }
+
+    // MARK: - Tempo Map Extraction
+
+    /// Extract tempo events from EvSq chunks.
+    ///
+    /// Tempo events follow the pattern:
+    ///   7F 00 00 01  [MM MM MM MM] [00 00 00 00] [PP PP PP PP PP PP PP PP]
+    /// where MM = millitempo (LE u32), PP = tick position (LE u64, but we read u32 for simplicity).
+    private static func extractTempoMap(chunks: [ChunkInfo], data: Data) -> [TempoEntry] {
+        var entries: [TempoEntry] = []
+
+        for chunk in chunks where chunk.id == idEvSq {
+            guard chunk.bodyLength >= 20 else { continue }
+            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let tempos = parseTempoEvents(body: body)
+            entries.append(contentsOf: tempos)
+        }
+
+        // Sort by tick and deduplicate
+        entries.sort { $0.tick < $1.tick }
+        var seen = Set<Int>()
+        return entries.filter { seen.insert($0.tick).inserted }
+    }
+
+    private static func parseTempoEvents(body: Data) -> [TempoEntry] {
+        var entries: [TempoEntry] = []
+        let bytes = body
+        let total = bytes.count
+        var offset = 0
+
+        while offset + 20 <= total {
+            // Look for tempo signature: 7F 00 00 01
+            guard bytes[offset] == 0x7F,
+                  bytes[offset + 1] == 0x00,
+                  bytes[offset + 2] == 0x00,
+                  bytes[offset + 3] == 0x01
+            else {
+                offset += 1
+                continue
+            }
+
+            // Read millitempo (4 bytes LE at offset+4)
+            let milliTempo = readLE32(body, at: offset + 4)
+            guard milliTempo > 0 else { offset += 1; continue }
+
+            // Read tick position (8 bytes LE at offset+12, but we use low 4 bytes for now)
+            let tickLow = readLE32(body, at: offset + 12)
+            let tickHigh = readLE32(body, at: offset + 16)
+            let tick = Int(tickLow) | (Int(tickHigh) << 32)
+
+            let bpm = Double(milliTempo) / 10000.0
+            guard bpm > 10.0 && bpm < 1000.0 else { offset += 4; continue }
+
+            let bar = tick / ticksPerBar + 1
+            entries.append(TempoEntry(bpm: bpm, tick: tick, bar: bar))
+            offset += 20
+        }
+        return entries
+    }
+
+    // MARK: - Track Name Extraction (MSeq)
+
+    /// Extract track names from MSeq chunks.
+    ///
+    /// MSeq body layout:
+    ///   0x10  2B  name_length (LE u16)
+    ///   0x12  *B  name (ASCII)
+    private static func extractTracks(chunks: [ChunkInfo], data: Data) -> [ParsedTrack] {
+        var result: [ParsedTrack] = []
+        var seen = Set<UInt32>()
+
+        for chunk in chunks where chunk.id == idMSeq {
+            guard chunk.bodyLength > 0x12 else { continue }
+            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+
+            guard body.count > 0x12 else { continue }
+            let nameLen = Int(readLE16(body, at: 0x10))
+            guard nameLen > 0, 0x12 + nameLen <= body.count else { continue }
+
+            guard let name = String(data: body[0x12..<(0x12 + nameLen)], encoding: .utf8)
+                    ?? String(data: body[0x12..<(0x12 + nameLen)], encoding: .isoLatin1)
+            else { continue }
+
+            let cleaned = name.trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
+            guard !cleaned.isEmpty else { continue }
+
+            if seen.insert(chunk.oid).inserted {
+                result.append(ParsedTrack(name: cleaned, oid: Int(chunk.oid)))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Marker Assembly
+
+    private static func buildMarkers(
+        txSqMap: [UInt32: String],
+        events: [MarkerEvent]
+    ) -> [ParsedMarker] {
+        // Build a map from events for quick lookup
+        let eventMap: [UInt32: MarkerEvent] = Dictionary(
+            events.map { ($0.oid, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var markers: [ParsedMarker] = []
+
+        for (oid, name) in txSqMap {
+            guard let event = eventMap[oid] else { continue }
+            let tick = Int(event.startTick)
+            let bar = tick / ticksPerBar + 1
+            let durationTicks = Int(event.durationTicks)
+            let durationBars = durationTicks > 0 ? max(1, durationTicks / ticksPerBar) : 0
+
+            markers.append(ParsedMarker(
+                name: name,
+                bar: bar,
+                tick: tick,
+                durationTicks: durationTicks,
+                durationBars: durationBars,
+                oid: Int(oid)
+            ))
+        }
+
+        // Sort by bar position
+        markers.sort { $0.bar < $1.bar }
+        return markers
+    }
+
+    // MARK: - Plist Parsing (Time Signature, Sample Rate)
+
+    /// Read time signature from MetaData.plist or ProjectInformation.plist.
+    private static func readTimeSignature(logicx: URL) -> String? {
+        let candidates = [
+            logicx.appendingPathComponent("MetaData.plist"),
+            logicx.appendingPathComponent("ProjectInformation.plist"),
+        ]
+        for url in candidates {
+            guard let data = try? Data(contentsOf: url) else { continue }
+            guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
+            if let sig = searchPlistForTimeSignature(plist) { return sig }
+        }
+        return nil
+    }
+
+    private static func searchPlistForTimeSignature(_ plist: Any) -> String? {
+        if let dict = plist as? [String: Any] {
+            // Look for TimeSignature key directly
+            if let ts = dict["TimeSignature"] as? String { return ts }
+            if let n = dict["numerator"] as? Int, let d = dict["denominator"] as? Int {
+                return "\(n)/\(d)"
+            }
+            // Recurse into values
+            for (_, value) in dict {
+                if let found = searchPlistForTimeSignature(value) { return found }
+            }
+        } else if let arr = plist as? [Any] {
+            for item in arr {
+                if let found = searchPlistForTimeSignature(item) { return found }
+            }
+        }
+        return nil
+    }
+
+    /// Read sample rate from project plists.
+    private static func readSampleRate(logicx: URL) -> Int? {
+        let candidates = [
+            logicx.appendingPathComponent("MetaData.plist"),
+            logicx.appendingPathComponent("ProjectInformation.plist"),
+        ]
+        for url in candidates {
+            guard let data = try? Data(contentsOf: url) else { continue }
+            guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
+            if let sr = searchPlistForSampleRate(plist) { return sr }
+        }
+        return nil
+    }
+
+    private static func searchPlistForSampleRate(_ plist: Any) -> Int? {
+        if let dict = plist as? [String: Any] {
+            for key in ["SampleRate", "sampleRate", "sample_rate"] {
+                if let v = dict[key] {
+                    if let i = v as? Int { return i }
+                    if let d = v as? Double { return Int(d) }
+                    if let s = v as? String, let i = Int(s) { return i }
+                }
+            }
+            for (_, value) in dict {
+                if let found = searchPlistForSampleRate(value) { return found }
+            }
+        } else if let arr = plist as? [Any] {
+            for item in arr {
+                if let found = searchPlistForSampleRate(item) { return found }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Low-level Readers
+
+    /// Read a 4-byte little-endian UInt32 from a Data slice at a given offset within that slice.
+    private static func readLE32(_ data: Data, at offset: Int) -> UInt32 {
+        guard offset + 4 <= data.count else { return 0 }
+        let base = data.startIndex + offset
+        return UInt32(data[base])
+            | (UInt32(data[base + 1]) << 8)
+            | (UInt32(data[base + 2]) << 16)
+            | (UInt32(data[base + 3]) << 24)
+    }
+
+    /// Read a 2-byte little-endian UInt16 from a Data slice.
+    private static func readLE16(_ data: Data, at offset: Int) -> UInt16 {
+        guard offset + 2 <= data.count else { return 0 }
+        let base = data.startIndex + offset
+        return UInt16(data[base]) | (UInt16(data[base + 1]) << 8)
+    }
+
+    /// Read an 8-byte little-endian UInt64 from a Data slice.
+    private static func readLE64(_ data: Data, at offset: Int) -> UInt64 {
+        guard offset + 8 <= data.count else { return 0 }
+        let base = data.startIndex + offset
+        var value: UInt64 = 0
+        for i in 0..<8 {
+            value |= UInt64(data[base + i]) << (i * 8)
+        }
+        return value
+    }
+
+    /// Reverse the 4 ID bytes to get the human-readable chunk ID.
+    /// e.g., on-disk bytes [0x71, 0x53, 0x78, 0x54] -> "TxSq"
+    private static func reverseID(_ bytes: [UInt8]) -> String {
+        guard bytes.count == 4 else { return "????" }
+        let reversed = bytes.reversed()
+        return String(reversed.compactMap { b -> Character? in
+            let scalar = Unicode.Scalar(b)
+            let ch = Character(scalar)
+            return ch.isASCII ? ch : nil
+        })
+    }
+}
+
+// MARK: - AppleScript Helper
+
+/// Run AppleScript synchronously and return the string result, or nil on error.
+/// Used to get the current Logic Pro project path.
+func runAppleScript(_ source: String) -> String? {
+    var errorDict: NSDictionary?
+    let script = NSAppleScript(source: source)
+    let result = script?.executeAndReturnError(&errorDict)
+    if errorDict != nil { return nil }
+    return result?.stringValue
+}
+
+/// Get the POSIX path of the front Logic Pro document via AppleScript.
+func currentLogicProProjectPath() -> String? {
+    let source = """
+    tell application "Logic Pro" to get POSIX path of (file of front document)
+    """
+    return runAppleScript(source)
+}

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -646,12 +646,12 @@ enum ProjectDataParser {
 
     /// Extract audio regions from AuRg chunks.
     ///
-    /// AuRg body layout (bar-field mode, primary):
-    ///   0x10  4B  start_bar_int (LE u32)
+    /// AuRg body layout:
+    ///   0x30  8B  legacy start tick (LE u64) — tried FIRST
+    ///   0x10  4B  start_bar_int (LE u32)     — bar-field fallback
     ///   0x14  4B  start_bar_frac_hi (LE u32) — fractional bars: frac = (value >> 16) / 65536
     ///   0x18  4B  length_bar_int (LE u32)
     ///   0x1C  4B  length_bar_frac_hi (LE u32)
-    ///   0x30  8B  legacy start tick (LE u64) — fallback
     ///   0x4A  2B  name_length (LE u16)
     ///   0x4C  *B  name (ASCII)
     ///
@@ -669,33 +669,59 @@ enum ProjectDataParser {
             var startTick: Int = 0
             var lengthTicks: Int = 0
 
-            // Bar-field mode (primary): offsets 0x10..0x1F
-            let startBarInt = readLE32(body, at: 0x10)
-            let startBarFracRaw = readLE32(body, at: 0x14)
-            let lengthBarInt = readLE32(body, at: 0x18)
-            let lengthBarFracRaw = readLE32(body, at: 0x1C)
+            // Bug 3 Fix: Try legacy tick mode FIRST.
+            // 8-byte LE tick at body offset 0x30; bar = tick / 3840 + 1.
+            // Accept if bar is in reasonable range (1-5000).
+            // Only fall back to bar-field mode if legacy gives 0 or unreasonable values.
+            var usedLegacy = false
+            if body.count >= 0x38 {
+                // Read full 8-byte LE tick at 0x30
+                let rawStartTick = Int(readLE64(body, at: 0x30))
+                let legacyBar = rawStartTick / ticksPerBar + 1
+                if rawStartTick > 0 && legacyBar >= 1 && legacyBar <= 5000 {
+                    startTick = rawStartTick
+                    startBar = Double(rawStartTick) / Double(ticksPerBar) + 1.0
+                    // Length at 0x38 (8-byte LE tick)
+                    if body.count >= 0x40 {
+                        let rawLenTick = Int(readLE64(body, at: 0x38))
+                        lengthTicks = rawLenTick
+                        lengthBars = Double(rawLenTick) / Double(ticksPerBar)
+                    } else if body.count >= 0x3C {
+                        let rawLenLow = readLE32(body, at: 0x38)
+                        lengthTicks = Int(rawLenLow)
+                        lengthBars = Double(lengthTicks) / Double(ticksPerBar)
+                    }
+                    usedLegacy = true
+                } else if rawStartTick > 0 {
+                    // Tick is non-zero but bar is out of range — check for large pre-roll offset.
+                    // Some projects encode absolute timeline ticks; subtract any offset > 5000 bars.
+                    // If after subtracting some pre-roll the bar lands in 1-5000, accept it.
+                    let barsFromZero = rawStartTick / ticksPerBar
+                    if barsFromZero > 5000 {
+                        // Try bar-field below — don't use this tick value
+                    } else if legacyBar > 5000 {
+                        // legacyBar > 5000: bar-field will be tried below
+                    }
+                }
+            }
 
-            let startBarFrac = Double(startBarFracRaw >> 16) / 65536.0
-            let lengthBarFrac = Double(lengthBarFracRaw >> 16) / 65536.0
+            if !usedLegacy {
+                // Bar-field mode fallback: offsets 0x10..0x1F
+                let startBarInt = readLE32(body, at: 0x10)
+                let startBarFracRaw = readLE32(body, at: 0x14)
+                let lengthBarInt = readLE32(body, at: 0x18)
+                let lengthBarFracRaw = readLE32(body, at: 0x1C)
 
-            if startBarInt > 0 || startBarFrac > 0 {
-                // Bar-field mode valid
-                startBar = Double(startBarInt) + startBarFrac
-                lengthBars = Double(lengthBarInt) + lengthBarFrac
-                startTick = Int(startBar * Double(ticksPerBar))
-                lengthTicks = Int(lengthBars * Double(ticksPerBar))
-            } else {
-                // Legacy mode fallback: 8-byte LE tick at body offset 0x30
-                if body.count > 0x38 {
-                    let tickLow = readLE32(body, at: 0x30)
-                    let tickHigh = readLE32(body, at: 0x34)
-                    startTick = Int(tickLow) | (Int(tickHigh) << 32)
-                    startBar = Double(startTick) / Double(ticksPerBar)
-                    // Length: try 0x38
-                    let lenLow = readLE32(body, at: 0x38)
-                    let lenHigh = body.count > 0x40 ? readLE32(body, at: 0x3C) : 0
-                    lengthTicks = Int(lenLow) | (Int(lenHigh) << 32)
-                    lengthBars = Double(lengthTicks) / Double(ticksPerBar)
+                let startBarFrac = Double(startBarFracRaw >> 16) / 65536.0
+                let lengthBarFrac = Double(lengthBarFracRaw >> 16) / 65536.0
+
+                let candidateBar = Double(startBarInt) + startBarFrac
+                // Validate bar-field values — reject if out of reasonable range
+                if (startBarInt > 0 || startBarFrac > 0) && candidateBar <= 5000.0 {
+                    startBar = candidateBar
+                    lengthBars = Double(lengthBarInt) + lengthBarFrac
+                    startTick = Int((startBar - 1.0) * Double(ticksPerBar))
+                    lengthTicks = Int(lengthBars * Double(ticksPerBar))
                 }
             }
 
@@ -740,9 +766,20 @@ enum ProjectDataParser {
 
     // MARK: - Track-to-Region Mapping
 
-    /// Populate trackOid on regions and regions list on tracks using:
-    ///   1. Song / USEl explicit [TrackOID, Count, RegionOID...] tables
-    ///   2. AuRg body heuristic (scan for track OID patterns)
+    /// Populate trackOid on regions and regions list on tracks using the AuRg body scanning
+    /// heuristic described in reference/LOGIC_BINARY_SPEC.md and python_extractor_snippets.txt.
+    ///
+    /// Bug 1 Fix: Replace Song/USEl table scan with AuRg body offset heuristic.
+    ///
+    /// Algorithm:
+    ///   1. Collect known track OIDs from MSeq chunks.
+    ///   2. For each AuRg chunk body, group by body length.
+    ///   3. For each length group, scan u32 values at candidate offsets
+    ///      (0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68) counting how many bodies
+    ///      contain a known track OID at that offset.
+    ///   4. Use the highest-scoring offset as the track reference for that length group.
+    ///   5. Fallback: wide scan every 4 bytes from 0x00 to 0xC0 when no candidate offset wins.
+    ///   6. Set trackOid on each ParsedRegion; leave nil if no match.
     private static func applyTrackRegionMapping(
         chunks: [ChunkInfo],
         data: Data,
@@ -752,34 +789,89 @@ enum ProjectDataParser {
         let trackOidSet = Set(tracks.map { UInt32($0.oid) })
         guard !trackOidSet.isEmpty, !regions.isEmpty else { return }
 
-        // Build region lookup by OID (regions may share OID, use index as key too)
-        // Map regionOID -> [indices into regions array]
-        var regionsByOid: [UInt32: [Int]] = [:]
-        for (i, r) in regions.enumerated() {
-            regionsByOid[UInt32(r.oid), default: []].append(i)
-        }
+        // Candidate offsets per spec: 0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68 (and more)
+        // Include 0x00 — in AuRg bodies the first u32 can be a track OID reference.
+        let candidateOffsets: [Int] = [0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68,
+                                       0x10, 0x14, 0x18, 0x1C, 0x20, 0x24, 0x28,
+                                       0x2C, 0x30, 0x34, 0x38, 0x3C, 0x40, 0x44,
+                                       0x48, 0x4C, 0x50, 0x54, 0x58, 0x5C,
+                                       0x6C, 0x70, 0x74, 0x78, 0x7C]
 
-        // Mapping: region index -> track oid
-        var regionTrackMap: [Int: UInt32] = [:]
-
-        // Strategy 1: scan Song and USEl chunk bodies for explicit tables
-        for chunk in chunks where (chunk.id == "Song" || chunk.id == "USEl") {
-            guard chunk.bodyLength >= 12 else { continue }
+        // Collect all AuRg (body, regionIdx) pairs in chunk order
+        var aurgBodies: [(body: Data, regionIdx: Int)] = []
+        var regionIdx = 0
+        for chunk in chunks where chunk.id == idAuRg {
+            guard chunk.bodyLength > 0x4C else { continue }
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
-            scanExplicitMappingTable(
-                body: body,
-                trackOidSet: trackOidSet,
-                regionsByOid: regionsByOid,
-                regionTrackMap: &regionTrackMap
-            )
+            if regionIdx < regions.count {
+                aurgBodies.append((body: body, regionIdx: regionIdx))
+                regionIdx += 1
+            }
         }
 
-        // Strategy 2: AuRg body heuristic for unmapped regions
-        // (skipped — heuristic-only; Song/USEl tables are preferred)
+        // Group by body length
+        var byLength: [Int: [(body: Data, regionIdx: Int)]] = [:]
+        for entry in aurgBodies {
+            byLength[entry.body.count, default: []].append(entry)
+        }
 
-        // Apply the mapping back
-        for (regionIdx, trackOid) in regionTrackMap {
-            regions[regionIdx].trackOid = Int(trackOid)
+        // Pass 1: for each length group, count track OID hits per candidate offset
+        var bestOffsetByLength: [Int: Int] = [:]
+        for (_, group) in byLength {
+            let total = group.count
+            guard total > 0 else { continue }
+
+            var hitCounts: [Int: Int] = [:]
+            for entry in group {
+                let maxScan = min(entry.body.count, 0xC0)
+                for off in candidateOffsets where off + 4 <= maxScan {
+                    let val = readLE32(entry.body, at: off)
+                    // Exclude OID=0 to avoid false hits (many fields default to 0)
+                    if trackOidSet.contains(val) && val != 0 {
+                        hitCounts[off, default: 0] += 1
+                    }
+                }
+            }
+
+            // Accept offset if ratio >= 0.15 or count >= 2 (lower threshold to catch sparse groups)
+            let filtered = hitCounts.filter { $0.value * 20 >= total * 3 || $0.value >= 2 }
+            if let best = filtered.max(by: { $0.value < $1.value }) {
+                let len = group.first!.body.count
+                bestOffsetByLength[len] = best.key
+            }
+        }
+
+        // Pass 2: if still no good offset for a length group, do wider scan (every 4 bytes from 0x00)
+        // Python: range(0, max_scan, 4) — includes offset 0
+        for (len, group) in byLength {
+            guard bestOffsetByLength[len] == nil else { continue }
+            let total = group.count
+            guard total >= 1 else { continue }
+
+            var hitCounts: [Int: Int] = [:]
+            for entry in group {
+                let maxScan = min(entry.body.count, 0xC0)
+                for off in stride(from: 0, to: maxScan - 3, by: 4) {
+                    let val = readLE32(entry.body, at: off)
+                    if trackOidSet.contains(val) && val != 0 {
+                        hitCounts[off, default: 0] += 1
+                    }
+                }
+            }
+
+            // For wide scan, keep top offset with any hits (even 1 hit for single-region groups)
+            if let best = hitCounts.max(by: { $0.value < $1.value }), best.value > 0 {
+                bestOffsetByLength[len] = best.key
+            }
+        }
+
+        // Assign track OIDs to regions
+        for entry in aurgBodies {
+            let len = entry.body.count
+            guard let bestOff = bestOffsetByLength[len], bestOff + 4 <= len else { continue }
+            let val = readLE32(entry.body, at: bestOff)
+            guard trackOidSet.contains(val), val != 0 else { continue }
+            regions[entry.regionIdx].trackOid = Int(val)
         }
 
         // Build track -> regions cross-reference
@@ -796,51 +888,6 @@ enum ProjectDataParser {
         }
     }
 
-    /// Scan a chunk body for u32 sequences of the form:
-    ///   [track_oid, count, region_oid_1, region_oid_2, ...]
-    /// where track_oid is a known MSeq OID and count is reasonable (1–100).
-    private static func scanExplicitMappingTable(
-        body: Data,
-        trackOidSet: Set<UInt32>,
-        regionsByOid: [UInt32: [Int]],
-        regionTrackMap: inout [Int: UInt32]
-    ) {
-        guard body.count >= 12 else { return }
-        let count = body.count / 4
-        var i = 0
-        while i < count - 1 {
-            let val = readLE32(body, at: i * 4)
-            guard trackOidSet.contains(val) else { i += 1; continue }
-
-            let regionCount = Int(readLE32(body, at: (i + 1) * 4))
-            guard regionCount >= 1, regionCount <= 100 else { i += 1; continue }
-            guard i + 1 + regionCount < count else { i += 1; continue }
-
-            // Check that the following regionCount u32s are known region OIDs
-            var matched = 0
-            for j in 0..<regionCount {
-                let candidate = readLE32(body, at: (i + 2 + j) * 4)
-                if regionsByOid[candidate] != nil { matched += 1 }
-            }
-
-            // Require majority match (≥50% of claimed regions are known OIDs)
-            if matched * 2 >= regionCount {
-                let trackOid = val
-                for j in 0..<regionCount {
-                    let regionOid = readLE32(body, at: (i + 2 + j) * 4)
-                    if let indices = regionsByOid[regionOid] {
-                        for idx in indices where regionTrackMap[idx] == nil {
-                            regionTrackMap[idx] = trackOid
-                        }
-                    }
-                }
-                i += 2 + regionCount
-                continue
-            }
-            i += 1
-        }
-    }
-
     // MARK: - AuCO Mixer Data (Volume, Pan, Output Routing)
 
     /// Enrich tracks with volume, pan, and output routing from AuCO chunks.
@@ -850,56 +897,58 @@ enum ProjectDataParser {
     ///   0x59  1B                     pan byte (0=hard left, 64=center, 127=hard right)
     ///   volume: 4-byte LE u32 at a known offset; unity = 1509949440
     ///
-    /// Matching strategy: match AuCO channel strip name to MSeq track name (case-insensitive).
-    /// Fallback: scan for routing strings (Output/Bus/Stereo Out) even when name doesn't match.
+    /// Bug 2 Fix: Match AuCO to track by OID (exact match first, then nearest within +/- 8),
+    /// because AuCO strip names are generic ("Audio 1") and don't match MSeq track names.
     private static func enrichTracksWithAuCO(
         chunks: [ChunkInfo],
         data: Data,
         tracks: inout [ParsedTrack]
     ) {
-        // Build a name -> track index map for quick lookup
-        var trackByName: [String: Int] = [:]
+        // Build OID -> track index map for direct OID matching
+        var trackByOid: [UInt32: Int] = [:]
         for (i, t) in tracks.enumerated() {
-            trackByName[t.name.lowercased()] = i
+            trackByOid[UInt32(t.oid)] = i
         }
+        let sortedTrackOids = tracks.map { UInt32($0.oid) }.sorted()
 
         for chunk in chunks where chunk.id == idAuCO {
             guard chunk.bodyLength > 0x5A else { continue }
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
 
-            // --- Channel strip name at 0x3C ---
-            let stripName = readNullTerminatedASCII(body, at: 0x3C, maxLen: 64)
-
             // --- Pan byte at 0x59 ---
             let panByte = Int(body[0x59])
             let panNorm: Double = (Double(panByte) - 64.0) / 64.0  // -1.0 to +1.0
 
-            // --- Volume: scan for u32 values near the channel name area ---
-            // Per spec: volume is a 32-bit integer at a known offset.
-            // We scan a window around 0x50-0x58 for plausible volume values.
+            // --- Volume ---
             let volumeDB = readVolumeDB(body: body)
 
-            // --- Output routing: scan for "Output", "Bus", "Stereo Out" strings ---
+            // --- Output routing ---
             let outputRouting = extractOutputRouting(body: body)
 
-            // --- Match to track by name ---
-            if let idx = trackByName[stripName.lowercased()], !stripName.isEmpty {
+            // --- Bug 2 Fix: Match by OID (exact first, then nearest within +/- 8) ---
+            let aucoOid = chunk.oid
+            var trackIdx: Int? = nil
+
+            // Exact OID match
+            if let idx = trackByOid[aucoOid] {
+                trackIdx = idx
+            } else {
+                // Nearest track OID within +/- 8
+                var bestDist: UInt32 = 9
+                for tOid in sortedTrackOids {
+                    let dist = aucoOid > tOid ? aucoOid - tOid : tOid - aucoOid
+                    if dist < bestDist {
+                        bestDist = dist
+                        trackIdx = trackByOid[tOid]
+                    }
+                }
+            }
+
+            if let idx = trackIdx {
                 tracks[idx].volume = volumeDB
                 tracks[idx].pan = panNorm.clamped(to: -1.0...1.0)
                 if let routing = outputRouting {
                     tracks[idx].outputRouting = routing
-                }
-            } else if let routing = outputRouting {
-                // Even without a name match, try to assign routing to an unassigned track
-                // by looking for a track with a matching name prefix in the routing string
-                for i in tracks.indices where tracks[i].outputRouting == nil {
-                    let tname = tracks[i].name.lowercased()
-                    if routing.lowercased().contains(tname) || tname.contains(stripName.lowercased()) {
-                        tracks[i].outputRouting = routing
-                        tracks[i].volume = volumeDB
-                        tracks[i].pan = panNorm.clamped(to: -1.0...1.0)
-                        break
-                    }
                 }
             }
         }
@@ -922,10 +971,12 @@ enum ProjectDataParser {
     /// Unity gain = 1509949440 (0x5A000080 LE).
     /// Formula: dB = 40 * log10(value / 1509949440)
     ///
-    /// We scan offsets 0x48..0x58 for a 4-byte value that decodes to a reasonable dB range (-144..+6).
+    /// Bug 2 Fix: Broader offset scan so volume is found across all AuCO body lengths.
+    /// We check known offsets first, then fall back to scanning every 4 bytes.
     private static func readVolumeDB(body: Data) -> Double? {
-        // Per spec unity = 1509949440; try the standard volume offset range
-        let searchOffsets = [0x48, 0x4C, 0x50, 0x54, 0x58]
+        // Per spec unity = 1509949440; check known offsets for all observed body lengths
+        let searchOffsets = [0x74, 0x48, 0x4C, 0x50, 0x54, 0x58, 0x64, 0x68, 0x6C, 0x70,
+                             0x78, 0x7C, 0x80, 0x84, 0x88, 0x8C, 0x90, 0x94, 0x40, 0x44]
         for off in searchOffsets {
             guard off + 4 <= body.count else { continue }
             let raw = readLE32(body, at: off)
@@ -933,36 +984,56 @@ enum ProjectDataParser {
             let ratio = Double(raw) / unityGainRaw
             guard ratio > 0 else { continue }
             let db = 40.0 * log10(ratio)
-            if db >= -144.0 && db <= 12.0 {
+            if db >= -144.0 && db <= 24.0 {
                 return db
             }
+        }
+        // Fallback: scan every 4 bytes for a value that decodes to a plausible volume
+        // Accept values within ±18 dB of unity as most likely volume faders
+        var i = 0x40
+        while i + 4 <= body.count && i <= 0xC0 {
+            let raw = readLE32(body, at: i)
+            if raw > 0 {
+                let ratio = Double(raw) / unityGainRaw
+                if ratio > 0 {
+                    let db = 40.0 * log10(ratio)
+                    if db >= -18.0 && db <= 6.0 {
+                        return db
+                    }
+                }
+            }
+            i += 4
         }
         return nil
     }
 
     /// Scan an AuCO body for output routing label strings.
     private static func extractOutputRouting(body: Data) -> String? {
-        // Scan body as ASCII for strings containing Output/Bus/Stereo Out
-        let ascii = String(body.map { b -> Character in
-            let s = Unicode.Scalar(b)
-            return s.value >= 32 && s.value < 127 ? Character(s) : Character(" ")
-        })
+        // Build a null-byte-preserving ASCII representation
+        let bytes = body
 
         let keywords = ["Stereo Out", "Output", "Bus"]
         for keyword in keywords {
-            if let range = ascii.range(of: keyword) {
-                // Extract surrounding word (up to 32 chars)
-                let start = ascii.index(range.lowerBound, offsetBy: -min(0, ascii.distance(from: ascii.startIndex, to: range.lowerBound)))
-                var end = range.upperBound
-                var count = 0
-                while end < ascii.endIndex && count < 20 {
-                    let c = ascii[end]
-                    if c == "\0" || c.asciiValue.map({ $0 < 32 }) ?? false { break }
-                    end = ascii.index(after: end)
-                    count += 1
+            guard let kwBytes = keyword.data(using: .ascii) else { continue }
+            // Find keyword in body
+            var searchFrom = 0
+            while searchFrom + kwBytes.count <= bytes.count {
+                var found = true
+                for (i, b) in kwBytes.enumerated() {
+                    if bytes[searchFrom + i] != b { found = false; break }
                 }
-                let label = String(ascii[start..<end]).trimmingCharacters(in: .whitespaces)
-                if !label.isEmpty { return label }
+                if found {
+                    // Extract null-terminated string starting at keyword position
+                    var end = searchFrom
+                    let limit = min(bytes.count, searchFrom + 64)
+                    while end < limit && bytes[end] != 0 {
+                        end += 1
+                    }
+                    let label = String(data: Data(bytes[searchFrom..<end]), encoding: .ascii)?
+                        .trimmingCharacters(in: .whitespaces) ?? ""
+                    if !label.isEmpty { return label }
+                }
+                searchFrom += 1
             }
         }
         return nil
@@ -970,28 +1041,34 @@ enum ProjectDataParser {
 
     // MARK: - Plugin List
 
-    /// Extract plugin names from null-ID (00 00 00 00) chunks.
+    /// Extract plugin names by scanning ALL chunk bodies for known plugin name strings,
+    /// and scanning PluginData (null-ID) chunks for printable ASCII strings > 4 chars.
     ///
-    /// Per spec, these chunks have id "####" or all-zero bytes.
-    /// The body contains ASCII plugin name signatures.
+    /// Bug 4 Fix:
+    ///   - reverseID() now maps non-printable IDs to "PluginData" so they are no longer skipped.
+    ///   - PluginData chunks are scanned for all printable ASCII strings > 4 chars.
+    ///   - We also scan ALL chunks (not just "PluginData") for known plugin name strings.
+    ///   - Extended known plugin list per spec.
     private static func extractPlugins(chunks: [ChunkInfo], data: Data) -> [String] {
         var plugins = Set<String>()
 
-        // Known plugin name keywords to search for
-        let knownPlugins = [
-            "Serum", "Valhalla", "Compressor", "Kontakt", "Massive", "Diva",
-            "Sylenth", "Omnisphere", "Nexus", "Spire", "Vital", "Pigments",
-            "Reverb", "Delay", "Limiter", "EQ", "Transient", "Saturn",
-            "Vintage", "FabFilter", "iZotope", "Waves", "Native Instruments",
+        // Known plugin name keywords to search for (per spec + user requirement)
+        let knownPlugins: [String] = [
+            // Logic built-ins
+            "Compressor", "Channel EQ", "Space Designer", "Alchemy", "Klopfgeist",
+            "Delay Designer", "Retro Synth", "Gain", "Limiter", "Multipressor",
+            // Third-party
+            "Serum", "Kontakt", "Neural DSP", "FabFilter", "Valhalla", "Waves", "iZotope",
+            "Slate", "Massive", "Diva", "Sylenth", "Omnisphere", "Nexus", "Spire",
+            "Vital", "Pigments", "Saturn", "Vintage", "Native Instruments",
         ]
 
         for chunk in chunks {
-            // Null-ID chunks: all 4 ID bytes are non-ASCII (or the reversed ID is "####")
-            // The id field will be empty or contain non-printable chars when OID=0 and ID=0x00000000
-            guard chunk.id.isEmpty || chunk.id == "\0\0\0\0" || isNullID(chunk.id) else { continue }
             guard chunk.bodyLength > 4, chunk.bodyLength < 10_000_000 else { continue }
 
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            // Scan for known plugin name keywords in ALL chunks
             let ascii = body.map { b -> Character in
                 let s = Unicode.Scalar(b)
                 return s.value >= 32 && s.value < 127 ? Character(s) : Character("\0")
@@ -1002,30 +1079,41 @@ enum ProjectDataParser {
                 plugins.insert(plugin)
             }
 
-            // Also extract any ASCII strings > 4 chars that look like plugin names
-            // (contiguous printable chars, starts with uppercase, no spaces or common delimiters)
-            var i = bodyStr.startIndex
-            while i < bodyStr.endIndex {
-                let c = bodyStr[i]
-                guard c.isUppercase else { i = bodyStr.index(after: i); continue }
-
-                var j = bodyStr.index(after: i)
-                while j < bodyStr.endIndex {
-                    let cc = bodyStr[j]
-                    if !cc.isLetter && !cc.isNumber && cc != " " && cc != "-" && cc != "_" { break }
-                    j = bodyStr.index(after: j)
+            // For PluginData (null-ID) chunks: also extract all printable ASCII runs > 4 chars
+            // These may contain plugin names not in our known list.
+            if chunk.id == "PluginData" {
+                var run = ""
+                for byte in body {
+                    let scalar = Unicode.Scalar(byte)
+                    if scalar.value >= 32 && scalar.value < 127 {
+                        run.append(Character(scalar))
+                    } else {
+                        // End of printable run — keep if > 4 chars and looks like a plugin name
+                        // (starts with uppercase, not a path/URL/generic string)
+                        if run.count > 4
+                            && run.count < 64
+                            && run.first?.isUppercase == true
+                            && !run.hasPrefix("/")
+                            && !run.hasPrefix("http")
+                            && !run.contains("=")
+                            && !run.contains("\\")
+                        {
+                            plugins.insert(run)
+                        }
+                        run = ""
+                    }
                 }
-
-                let word = String(bodyStr[i..<j])
-                if word.count >= 4 && word.count <= 40
-                    && word.first?.isUppercase == true
-                    && !word.allSatisfy({ $0.isUppercase }) // avoid all-caps constants
+                // Flush final run
+                if run.count > 4
+                    && run.count < 64
+                    && run.first?.isUppercase == true
+                    && !run.hasPrefix("/")
+                    && !run.hasPrefix("http")
+                    && !run.contains("=")
+                    && !run.contains("\\")
                 {
-                    // Heuristic: if it looks like a product name (mixed case), keep it
-                    let hasLower = word.contains(where: { $0.isLowercase })
-                    if hasLower { plugins.insert(word) }
+                    plugins.insert(run)
                 }
-                i = j
             }
         }
 
@@ -1261,14 +1349,20 @@ enum ProjectDataParser {
 
     /// Reverse the 4 ID bytes to get the human-readable chunk ID.
     /// e.g., on-disk bytes [0x71, 0x53, 0x78, 0x54] -> "TxSq"
+    /// Bug 4 Fix: when all 4 bytes are zero or non-printable, return "PluginData"
     private static func reverseID(_ bytes: [UInt8]) -> String {
         guard bytes.count == 4 else { return "????" }
         let reversed = bytes.reversed()
-        return String(reversed.compactMap { b -> Character? in
+        let chars = reversed.compactMap { b -> Character? in
             let scalar = Unicode.Scalar(b)
             let ch = Character(scalar)
-            return ch.isASCII ? ch : nil
-        })
+            return ch.isASCII && scalar.value >= 32 ? ch : nil
+        }
+        // If all 4 bytes are non-printable/null, this is a PluginData-style chunk
+        if chars.count < 4 {
+            return "PluginData"
+        }
+        return String(chars)
     }
 }
 

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -82,7 +82,9 @@ enum ProjectDataParser {
         let txSqMap = extractTxSqNames(chunks: chunks, data: data)       // oid -> name
         let evSqMarkerEvents = extractMarkerEvents(chunks: chunks, data: data) // [(oid, startTick, durationTicks)]
         var tempoMap = extractTempoMap(chunks: chunks, data: data)
-        var parsedTracks = extractTracks(chunks: chunks, data: data)
+        let (publicTracks, allTracks) = extractTracks(chunks: chunks, data: data)
+        var parsedTracks = publicTracks
+        var allParsedTracks = allTracks
 
         // If no tempo found at tick=0, try to get initial BPM from plists
         if let lx = logicxURL, !tempoMap.contains(where: { $0.tick == 0 }) {
@@ -105,16 +107,28 @@ enum ProjectDataParser {
         // Extract audio regions
         var regions = extractRegions(chunks: chunks, data: data)
 
-        // Apply track-to-region mapping
+        // Apply track-to-region mapping (uses public tracks for OID set)
         applyTrackRegionMapping(
             chunks: chunks,
             data: data,
             tracks: &parsedTracks,
             regions: &regions
         )
+        // Also apply mapping to allTracks (so hierarchy containers get region info)
+        applyTrackRegionMapping(
+            chunks: chunks,
+            data: data,
+            tracks: &allParsedTracks,
+            regions: &regions
+        )
 
         // Enrich tracks with AuCO mixer data (volume, pan, output routing)
         enrichTracksWithAuCO(chunks: chunks, data: data, tracks: &parsedTracks)
+        enrichTracksWithAuCO(chunks: chunks, data: data, tracks: &allParsedTracks)
+
+        // Infer function groups for public tracks, then propagate to children
+        inferFunctionGroups(tracks: &parsedTracks)
+        inferFunctionGroups(tracks: &allParsedTracks)
 
         // Extract plugin list
         let plugins = extractPlugins(chunks: chunks, data: data)
@@ -123,6 +137,7 @@ enum ProjectDataParser {
         info.markers = markers
         info.tempoMap = tempoMap
         info.tracks = parsedTracks
+        info.allTracks = allParsedTracks
         info.regions = regions
         info.audioFiles = audioFiles
         info.plugins = plugins
@@ -555,40 +570,133 @@ enum ProjectDataParser {
 
     // MARK: - Track Name Extraction (MSeq)
 
-    /// Extract track names from MSeq chunks.
+    /// Raw record returned from MSeq parsing before filtering / hierarchy building.
+    private struct RawMSeqTrack {
+        let oid: UInt32
+        let name: String        // may be empty / generic
+        let parentOid: UInt32   // 0 = no parent
+    }
+
+    /// Extract ALL MSeq tracks including internal ones.
     ///
     /// MSeq body layout:
+    ///   0x08  4B  parent OID (LE u32) — 0 means no parent
     ///   0x10  2B  name_length (LE u16)
     ///   0x12  *B  name (ASCII)
-    private static func extractTracks(chunks: [ChunkInfo], data: Data) -> [ParsedTrack] {
-        var result: [ParsedTrack] = []
+    private static func extractAllMSeqTracks(chunks: [ChunkInfo], data: Data) -> [RawMSeqTrack] {
+        var result: [RawMSeqTrack] = []
         var seen = Set<UInt32>()
 
         for chunk in chunks where chunk.id == idMSeq {
             guard chunk.bodyLength > 0x12 else { continue }
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
-
             guard body.count > 0x12 else { continue }
+
+            // Parent OID at 0x08
+            let parentOid = body.count >= 0x0C ? readLE32(body, at: 0x08) : 0
+
+            // Name
             let nameLen = Int(readLE16(body, at: 0x10))
-            guard nameLen > 0, 0x12 + nameLen <= body.count else { continue }
-
-            guard let name = String(data: body[0x12..<(0x12 + nameLen)], encoding: .utf8)
+            var name = ""
+            if nameLen > 0, 0x12 + nameLen <= body.count {
+                name = (String(data: body[0x12..<(0x12 + nameLen)], encoding: .utf8)
                     ?? String(data: body[0x12..<(0x12 + nameLen)], encoding: .isoLatin1)
-            else { continue }
-
-            let cleaned = name.trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
-            guard !cleaned.isEmpty else { continue }
-            // Filter out generic/internal tracks
-            guard !cleaned.hasPrefix("*Automation"),
-                  cleaned != "Untitled",
-                  !cleaned.hasPrefix("Track Automation")
-            else { continue }
+                    ?? "")
+                    .trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
+            }
 
             if seen.insert(chunk.oid).inserted {
-                result.append(ParsedTrack(name: cleaned, oid: Int(chunk.oid)))
+                result.append(RawMSeqTrack(oid: chunk.oid, name: name, parentOid: parentOid))
             }
         }
         return result
+    }
+
+    /// Build ParsedTrack array from raw MSeq records.
+    /// Returns (publicTracks, allTracks) where:
+    ///   - allTracks: every MSeq entry
+    ///   - publicTracks: non-automation named tracks PLUS any track with children (stack containers)
+    private static func extractTracks(chunks: [ChunkInfo], data: Data) -> (public: [ParsedTrack], all: [ParsedTrack]) {
+        let raw = extractAllMSeqTracks(chunks: chunks, data: data)
+        guard !raw.isEmpty else { return ([], []) }
+
+        // Build OID -> index map
+        var oidToIndex: [UInt32: Int] = [:]
+        for (i, r) in raw.enumerated() {
+            oidToIndex[r.oid] = i
+        }
+
+        // Build hierarchy: parentOid -> [childOids]
+        var childrenOf: [UInt32: [UInt32]] = [:]
+        for r in raw {
+            guard r.parentOid != 0, r.parentOid != r.oid else { continue }
+            // Validate parent exists
+            guard oidToIndex[r.parentOid] != nil else { continue }
+            childrenOf[r.parentOid, default: []].append(r.oid)
+        }
+
+        // Compute stack depth via BFS from roots
+        var depth: [UInt32: Int] = [:]
+        var queue: [(oid: UInt32, d: Int)] = []
+        for r in raw {
+            let hasValidParent = r.parentOid != 0 && oidToIndex[r.parentOid] != nil
+            if !hasValidParent {
+                depth[r.oid] = 0
+                queue.append((r.oid, 0))
+            }
+        }
+        var qi = 0
+        while qi < queue.count {
+            let (oid, d) = queue[qi]; qi += 1
+            for child in childrenOf[oid] ?? [] {
+                depth[child] = d + 1
+                queue.append((child, d + 1))
+            }
+        }
+
+        // Classify stack type based on name keywords + output routing
+        func classifyStack(name: String, outputRouting: String?) -> (type: String?, isSumming: Bool) {
+            let lower = name.lowercased()
+            if lower.contains("summing") && lower.contains("stack") {
+                return ("summing", true)
+            }
+            if lower.contains("folder stack") || lower.contains("track automation root folder") {
+                return ("folder", false)
+            }
+            if let out = outputRouting?.lowercased() {
+                if out.hasPrefix("bus ") { return ("summing", true) }
+                if out.hasPrefix("output ") || out.contains("stereo out") { return (nil, false) }
+            }
+            // Has children → treat as stack
+            return (nil, false)
+        }
+
+        // Build ParsedTrack array (all)
+        let allTracks: [ParsedTrack] = raw.map { r in
+            let children = (childrenOf[r.oid] ?? []).map { Int($0) }.sorted()
+            let d = depth[r.oid] ?? 0
+            let hasParent = r.parentOid != 0 && oidToIndex[r.parentOid] != nil
+            let (sType, isSumming) = classifyStack(name: r.name, outputRouting: nil)
+            var track = ParsedTrack(name: r.name.isEmpty ? "Untitled" : r.name, oid: Int(r.oid))
+            track.parentOid = hasParent ? Int(r.parentOid) : nil
+            track.childOids = children
+            track.stackDepth = d
+            track.stackType = children.isEmpty ? sType : (sType ?? (children.isEmpty ? nil : "summing"))
+            track.isSummingStack = isSumming || (!children.isEmpty && (sType == "summing"))
+            return track
+        }
+
+        // Public filter: named non-automation tracks + any track with children (stack containers)
+        let publicTracks = allTracks.filter { track in
+            let hasChildren = !track.childOids.isEmpty
+            let isAutomation = track.name.hasPrefix("*Automation") || track.name.hasPrefix("Track Automation")
+            let isUntitled = track.name == "Untitled"
+            if isAutomation { return false }
+            if isUntitled { return hasChildren }
+            return true
+        }
+
+        return (publicTracks, allTracks)
     }
 
     // MARK: - Audio File References (AuFl)
@@ -1123,6 +1231,93 @@ enum ProjectDataParser {
     /// Returns true if the chunk ID consists only of non-printable / null bytes.
     private static func isNullID(_ id: String) -> Bool {
         return id.unicodeScalars.allSatisfy { $0.value < 32 || $0.value == 0 }
+    }
+
+    // MARK: - Function Group Inference
+
+    /// Infer a function group label for each track based on keywords in the track name and region names.
+    /// Children inherit their parent's function group when they have none of their own.
+    static func inferFunctionGroups(tracks: inout [ParsedTrack]) {
+        // Build OID -> index map for fast lookup
+        var oidToIdx: [Int: Int] = [:]
+        for (i, t) in tracks.enumerated() {
+            oidToIdx[t.oid] = i
+        }
+
+        // First pass: assign from track name + region names
+        for i in tracks.indices {
+            let group = inferGroupFromText(tracks[i].name)
+                ?? inferGroupFromRegions(tracks[i].regions)
+            tracks[i].functionGroup = group
+        }
+
+        // Second pass: children inherit parent group when unclassified
+        // Process from shallowest to deepest
+        let sorted = tracks.indices.sorted { tracks[$0].stackDepth < tracks[$1].stackDepth }
+        for i in sorted {
+            guard tracks[i].functionGroup == nil else { continue }
+            if let parentOid = tracks[i].parentOid,
+               let parentIdx = oidToIdx[parentOid],
+               let parentGroup = tracks[parentIdx].functionGroup {
+                tracks[i].functionGroup = parentGroup
+            }
+        }
+    }
+
+    /// Infer function group from a single text string (track name, region name, etc.)
+    private static func inferGroupFromText(_ text: String) -> String? {
+        let lower = text.lowercased()
+        guard !lower.isEmpty else { return nil }
+
+        // Ordered from most specific to least specific
+        if lower.contains("click") || lower.contains("cue") || lower.contains("metronome")
+            || lower.contains("klopfgeist") {
+            return "Click Track"
+        }
+        if lower.contains("drum") || lower.contains("kick") || lower.contains("snare")
+            || lower.contains("hi-hat") || lower.contains("hihat") || lower.contains("cymbal")
+            || lower.contains("tom") {
+            return "Drums"
+        }
+        if lower.contains("guitar") || lower.contains("gtr") || lower.contains("guit") {
+            return "Guitars"
+        }
+        if lower.contains("vocal") || lower.contains("vox") || lower.contains("bv")
+            || lower.contains("backing vocal") || lower.contains("harmony") {
+            return "Vocals"
+        }
+        if lower.contains("key") || lower.contains("piano") || lower.contains("organ")
+            || lower.contains("synth") || lower.contains("pad") {
+            return "Keys/Synths"
+        }
+        if lower.contains("bass") {
+            return "Bass"
+        }
+        if lower.contains("sample") || lower.contains("sfx") || lower.contains("ambient")
+            || lower.contains("soundscape") {
+            return "Samples/FX"
+        }
+        if lower.contains("midi") || lower.contains("trigger") || lower.contains("cortex")
+            || lower.contains("controller") {
+            return "MIDI Triggers"
+        }
+        if lower.contains("reference") || lower.contains("mix") || lower.contains("master") {
+            return "Reference"
+        }
+        if lower.contains("backing") {
+            return "Backing Track"
+        }
+        return nil
+    }
+
+    /// Infer function group from region names on a track.
+    private static func inferGroupFromRegions(_ regions: [ParsedRegion]) -> String? {
+        for region in regions.prefix(10) {
+            if let g = inferGroupFromText(region.name) {
+                return g
+            }
+        }
+        return nil
     }
 
     // MARK: - Marker Assembly

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -36,8 +36,8 @@ enum ProjectDataParser {
     private static let idEvSq = "EvSq"
     private static let idMSeq = "MSeq"
 
-    // Arrangement marker OIDs per RE findings: 4, 8, 12, 16, 20, 24, 28, 32, 36
-    private static let markerOIDs: Set<UInt32> = [4, 8, 12, 16, 20, 24, 28, 32, 36]
+    // Arrangement marker OIDs vary per project — we scan ALL TxSq chunks
+    // and identify markers by RTF content rather than hardcoded OIDs
 
     // Tempo event signature: 7F 00 00 01 ...
     private static let tempoSignature: [UInt8] = [0x7F, 0x00, 0x00, 0x01]
@@ -215,14 +215,15 @@ enum ProjectDataParser {
 
     // MARK: - TxSq Name Extraction
 
-    /// Extract RTF text from TxSq chunks for arrangement marker OIDs.
+    /// Extract RTF text from ALL TxSq chunks.
     /// Returns a map of OID -> cleaned name.
+    /// Marker OIDs vary per project, so we extract everything and let the
+    /// EvSq type-18 join determine which are actual arrangement markers.
     private static func extractTxSqNames(chunks: [ChunkInfo], data: Data) -> [UInt32: String] {
         var result: [UInt32: String] = [:]
         for chunk in chunks where chunk.id == idTxSq {
-            guard markerOIDs.contains(chunk.oid) else { continue }
             guard chunk.bodyLength > 0 else { continue }
-            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
             if let name = extractRTFText(body) {
                 result[chunk.oid] = name
             }
@@ -231,96 +232,75 @@ enum ProjectDataParser {
     }
 
     /// Extract plain text from an RTF body.
-    /// RTF starts with `{\rtf1`. We strip all `\cmdN` tags and braces.
+    /// Logic TxSq RTF typically has content after `\fs24` tag.
+    /// Strategy: decode as ASCII (ignoring non-printable), find `\fs24 ` or similar,
+    /// then extract the text between that and the closing `}`.
     private static func extractRTFText(_ body: Data) -> String? {
-        guard let raw = String(data: body, encoding: .utf8)
-                ?? String(data: body, encoding: .isoLatin1)
-        else { return nil }
+        // Decode as ASCII, replacing non-printable with dots
+        let asciiStr = String(body.map { b -> Character in
+            let s = Unicode.Scalar(b)
+            return s.value >= 32 && s.value < 127 ? Character(s) : Character(".")
+        })
 
-        // Must be RTF
-        guard raw.contains("{\\rtf") else {
-            // Try treating it as a direct pascal-style or length-prefixed string
+        // Must contain RTF marker
+        guard asciiStr.contains("{\\rtf") || asciiStr.contains("\\fs") else {
             return extractDirectString(body)
         }
 
-        // Find content after \fs<N> tag (font size, precedes actual text)
-        // Strategy: strip everything inside { } control blocks, then trim
-        let text = raw
-
-        // Remove all RTF control words (\word or \word<N>) and special chars
-        // We use a simple state-machine approach:
-        var result = ""
-        var i = text.startIndex
-
-        while i < text.endIndex {
-            let ch = text[i]
-            if ch == "{" || ch == "}" {
-                i = text.index(after: i)
-                continue
+        // Find content after \fs<N> (font size tag) — the actual text follows
+        // Pattern: \fs24 <space or \cf2> TEXT}
+        if let fsRange = asciiStr.range(of: "\\fs", options: .literal) {
+            // Skip past the font size number
+            var idx = fsRange.upperBound
+            while idx < asciiStr.endIndex && (asciiStr[idx].isNumber) {
+                idx = asciiStr.index(after: idx)
             }
-            if ch == "\\" {
-                // Skip control word or symbol
-                let next = text.index(after: i)
-                if next < text.endIndex {
-                    let nc = text[next]
-                    if nc == "\\" || nc == "{" || nc == "}" || nc == ";" || nc == "\n" || nc == "\r" {
-                        // Escaped char
-                        if nc == "\\" || nc == "{" || nc == "}" {
-                            result.append(nc)
-                        }
-                        i = text.index(after: next)
-                        continue
-                    }
-                    if nc == "'" {
-                        // Hex escape \'XX
-                        let h1 = text.index(next, offsetBy: 1, limitedBy: text.endIndex) ?? text.endIndex
-                        let h2 = text.index(next, offsetBy: 2, limitedBy: text.endIndex) ?? text.endIndex
-                        let h3 = text.index(next, offsetBy: 3, limitedBy: text.endIndex) ?? text.endIndex
-                        if h1 < text.endIndex && h2 < text.endIndex {
-                            let hexStr = String(text[h1..<h2])
-                            if let code = UInt32(hexStr, radix: 16),
-                               let scalar = Unicode.Scalar(code) {
-                                result.append(Character(scalar))
-                            }
-                            i = h3 < text.endIndex ? h3 : text.endIndex
-                        } else {
-                            i = text.index(after: next)
-                        }
-                        continue
-                    }
-                    if nc.isLetter || nc == "-" {
-                        // Control word: skip until non-alphanumeric (and skip optional numeric param + optional space)
-                        var j = next
-                        while j < text.endIndex && (text[j].isLetter || text[j] == "-") {
-                            j = text.index(after: j)
-                        }
-                        // skip optional numeric parameter
-                        if j < text.endIndex && (text[j].isNumber || text[j] == "-") {
-                            while j < text.endIndex && (text[j].isNumber || text[j] == "-") {
-                                j = text.index(after: j)
-                            }
-                        }
-                        // skip single trailing space
-                        if j < text.endIndex && text[j] == " " {
-                            j = text.index(after: j)
-                        }
-                        i = j
-                        continue
-                    }
+            // Skip whitespace and \cf2 color tags
+            var textStart = idx
+            while textStart < asciiStr.endIndex {
+                if asciiStr[textStart] == " " {
+                    textStart = asciiStr.index(after: textStart)
+                    continue
                 }
-                i = text.index(after: i)
-                continue
+                if asciiStr[textStart] == "\\" {
+                    // Skip control word
+                    var j = asciiStr.index(after: textStart)
+                    while j < asciiStr.endIndex && (asciiStr[j].isLetter || asciiStr[j].isNumber) {
+                        j = asciiStr.index(after: j)
+                    }
+                    if j < asciiStr.endIndex && asciiStr[j] == " " {
+                        j = asciiStr.index(after: j)
+                    }
+                    textStart = j
+                    continue
+                }
+                break
             }
-            if ch == "\n" || ch == "\r" {
-                i = text.index(after: i)
-                continue
+
+            // Extract text until closing brace
+            var textEnd = textStart
+            while textEnd < asciiStr.endIndex && asciiStr[textEnd] != "}" {
+                textEnd = asciiStr.index(after: textEnd)
             }
-            result.append(ch)
-            i = text.index(after: i)
+
+            if textStart < textEnd {
+                var text = String(asciiStr[textStart..<textEnd])
+                // Clean up: remove stray dots, trim
+                text = text.replacingOccurrences(of: "..", with: " ")
+                text = text.replacingOccurrences(of: ".", with: "")
+                text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Remove leading/trailing non-alphanumeric
+                while text.first != nil && !text.first!.isLetter && !text.first!.isNumber {
+                    text.removeFirst()
+                }
+                while text.last != nil && !text.last!.isLetter && !text.last!.isNumber {
+                    text.removeLast()
+                }
+                return text.isEmpty ? nil : text
+            }
         }
 
-        let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
-        return cleaned.isEmpty ? nil : cleaned
+        return nil
     }
 
     /// Fallback: try to read a length-prefixed ASCII string from raw body bytes.
@@ -355,7 +335,7 @@ enum ProjectDataParser {
         var result: [MarkerEvent] = []
 
         for chunk in chunks where chunk.id == idEvSq {
-            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
             let events = parseType18Triplets(body: body)
             result.append(contentsOf: events)
         }
@@ -374,6 +354,8 @@ enum ProjectDataParser {
     /// Parse type-18 triplets from an EvSq body.
     private static func parseType18Triplets(body: Data) -> [MarkerEvent] {
         var events: [MarkerEvent] = []
+        // Rebase to 0-based
+        let body = Data(body)
         let count = body.count / 16
         guard count >= 3 else { return events }
 
@@ -404,7 +386,6 @@ enum ProjectDataParser {
                 && m1 == 0x88000000
                 && t0 == 0
                 && t1 == 0x88000000
-                && markerOIDs.contains(m0)
             {
                 events.append(MarkerEvent(oid: m0, startTick: h1, durationTicks: m3))
                 i += 3
@@ -427,7 +408,7 @@ enum ProjectDataParser {
 
         for chunk in chunks where chunk.id == idEvSq {
             guard chunk.bodyLength >= 20 else { continue }
-            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
             let tempos = parseTempoEvents(body: body)
             entries.append(contentsOf: tempos)
         }
@@ -440,7 +421,8 @@ enum ProjectDataParser {
 
     private static func parseTempoEvents(body: Data) -> [TempoEntry] {
         var entries: [TempoEntry] = []
-        let bytes = body
+        // Rebase slice to 0-based indices so direct subscript access works
+        let bytes = Data(body)
         let total = bytes.count
         var offset = 0
 
@@ -487,7 +469,7 @@ enum ProjectDataParser {
 
         for chunk in chunks where chunk.id == idMSeq {
             guard chunk.bodyLength > 0x12 else { continue }
-            let body = data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)]
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
 
             guard body.count > 0x12 else { continue }
             let nameLen = Int(readLE16(body, at: 0x10))
@@ -499,6 +481,11 @@ enum ProjectDataParser {
 
             let cleaned = name.trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
             guard !cleaned.isEmpty else { continue }
+            // Filter out generic/internal tracks
+            guard !cleaned.hasPrefix("*Automation"),
+                  cleaned != "Untitled",
+                  !cleaned.hasPrefix("Track Automation")
+            else { continue }
 
             if seen.insert(chunk.oid).inserted {
                 result.append(ParsedTrack(name: cleaned, oid: Int(chunk.oid)))

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -74,8 +74,16 @@ enum ProjectDataParser {
         // Extract per-type maps
         let txSqMap = extractTxSqNames(chunks: chunks, data: data)       // oid -> name
         let evSqMarkerEvents = extractMarkerEvents(chunks: chunks, data: data) // [(oid, startTick, durationTicks)]
-        let tempoMap = extractTempoMap(chunks: chunks, data: data)
+        var tempoMap = extractTempoMap(chunks: chunks, data: data)
         let parsedTracks = extractTracks(chunks: chunks, data: data)
+
+        // If no tempo found at tick=0, try to get initial BPM from plists
+        if let lx = logicxURL, !tempoMap.contains(where: { $0.tick == 0 }) {
+            if let plistBPM = readBPMFromPlist(logicx: lx) {
+                let initial = TempoEntry(bpm: plistBPM, tick: 0, bar: 1)
+                tempoMap.insert(initial, at: 0)
+            }
+        }
 
         // Join marker names with positions
         let markers = buildMarkers(txSqMap: txSqMap, events: evSqMarkerEvents)
@@ -398,19 +406,24 @@ enum ProjectDataParser {
 
     // MARK: - Tempo Map Extraction
 
-    /// Extract tempo events from EvSq chunks.
-    ///
-    /// Tempo events follow the pattern:
-    ///   7F 00 00 01  [MM MM MM MM] [00 00 00 00] [PP PP PP PP PP PP PP PP]
-    /// where MM = millitempo (LE u32), PP = tick position (LE u64, but we read u32 for simplicity).
+    /// Extract tempo events from EvSq chunks using multiple strategies:
+    ///   1. Standard 7F 00 00 01 signature (existing method)
+    ///   2. Type-96 tempo bridge: row A [96, seq_tick, 0, 0x0100007F|0x8100007F],
+    ///      row B [tempo_raw, 0x88400000, tempo_tick_abs, 0]
     private static func extractTempoMap(chunks: [ChunkInfo], data: Data) -> [TempoEntry] {
         var entries: [TempoEntry] = []
 
         for chunk in chunks where chunk.id == idEvSq {
             guard chunk.bodyLength >= 20 else { continue }
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
-            let tempos = parseTempoEvents(body: body)
-            entries.append(contentsOf: tempos)
+
+            // Strategy 1: standard 7F 00 00 01 signature
+            let standardTempos = parseTempoEvents(body: body)
+            entries.append(contentsOf: standardTempos)
+
+            // Strategy 2: type-96 bridge (16-byte aligned pairs)
+            let bridgeTempos = parseType96TempoEvents(body: body)
+            entries.append(contentsOf: bridgeTempos)
         }
 
         // Sort by tick and deduplicate
@@ -452,6 +465,60 @@ enum ProjectDataParser {
             let bar = tick / ticksPerBar + 1
             entries.append(TempoEntry(bpm: bpm, tick: tick, bar: bar))
             offset += 20
+        }
+        return entries
+    }
+
+    /// Parse type-96 tempo bridge format from EvSq body.
+    ///
+    /// Format (16-byte aligned rows):
+    ///   row A: [u32=96, u32=sequence_tick, u32=0, u32=0x0100007F or 0x8100007F]
+    ///   row B: [u32=tempo_raw, u32=0x88400000, u32=tempo_tick_abs, u32=0]
+    ///   tempo_raw = BPM * 10000
+    private static func parseType96TempoEvents(body: Data) -> [TempoEntry] {
+        var entries: [TempoEntry] = []
+        let bytes = Data(body)
+        let count = bytes.count / 16
+        guard count >= 2 else { return entries }
+
+        var i = 0
+        while i + 1 < count {
+            let aOff = i * 16
+            let bOff = (i + 1) * 16
+
+            guard aOff + 16 <= bytes.count, bOff + 16 <= bytes.count else { break }
+
+            let a0 = readLE32(bytes, at: aOff + 0)   // should be 96
+            let a3 = readLE32(bytes, at: aOff + 12)  // should be 0x0100007F or 0x8100007F
+
+            // Row A signature check
+            guard a0 == 96,
+                  (a3 == 0x0100007F || a3 == 0x8100007F)
+            else {
+                i += 1
+                continue
+            }
+
+            let b0 = readLE32(bytes, at: bOff + 0)   // tempo_raw = BPM * 10000
+            let b1 = readLE32(bytes, at: bOff + 4)   // should be 0x88400000
+            let b2 = readLE32(bytes, at: bOff + 8)   // tempo_tick_abs
+            // b3 should be 0
+
+            guard b1 == 0x88400000, b0 > 0 else {
+                i += 1
+                continue
+            }
+
+            let bpm = Double(b0) / 10000.0
+            guard bpm > 10.0 && bpm < 1000.0 else {
+                i += 1
+                continue
+            }
+
+            let tick = Int(b2)
+            let bar = tick / ticksPerBar + 1
+            entries.append(TempoEntry(bpm: bpm, tick: tick, bar: bar))
+            i += 2  // consumed both rows
         }
         return entries
     }
@@ -506,42 +573,121 @@ enum ProjectDataParser {
             uniquingKeysWith: { first, _ in first }
         )
 
-        var markers: [ParsedMarker] = []
+        // First pass: build markers with tick/bar, sort by tick
+        struct PartialMarker {
+            let name: String
+            let bar: Int
+            let tick: Int
+            let oid: Int
+        }
 
+        var partials: [PartialMarker] = []
         for (oid, name) in txSqMap {
             guard let event = eventMap[oid] else { continue }
             let tick = Int(event.startTick)
             let bar = tick / ticksPerBar + 1
-            let durationTicks = Int(event.durationTicks)
+            partials.append(PartialMarker(name: name, bar: bar, tick: tick, oid: Int(oid)))
+        }
+
+        // Sort by tick position (ascending)
+        partials.sort { $0.tick < $1.tick }
+
+        // Second pass: calculate duration from sequential markers (Fix 1)
+        // For each marker except the last: duration = next_marker.tick - this_marker.tick
+        // For the last marker: default 8 bars = 3840 * 8 = 30720 ticks
+        let defaultLastDuration = ticksPerBar * 8
+
+        var markers: [ParsedMarker] = []
+        for (i, partial) in partials.enumerated() {
+            let durationTicks: Int
+            if i + 1 < partials.count {
+                durationTicks = partials[i + 1].tick - partial.tick
+            } else {
+                durationTicks = defaultLastDuration
+            }
             let durationBars = durationTicks > 0 ? max(1, durationTicks / ticksPerBar) : 0
 
             markers.append(ParsedMarker(
-                name: name,
-                bar: bar,
-                tick: tick,
+                name: partial.name,
+                bar: partial.bar,
+                tick: partial.tick,
                 durationTicks: durationTicks,
                 durationBars: durationBars,
-                oid: Int(oid)
+                oid: partial.oid
             ))
         }
 
-        // Sort by bar position
-        markers.sort { $0.bar < $1.bar }
         return markers
     }
 
-    // MARK: - Plist Parsing (Time Signature, Sample Rate)
+    // MARK: - Plist Parsing (Time Signature, Sample Rate, BPM)
+
+    /// Build a list of candidate plist URLs to check within a .logicx bundle.
+    /// The MetaData.plist is typically inside Alternatives/000/ (not at the root).
+    private static func plistCandidateURLs(logicx: URL, name: String) -> [URL] {
+        var candidates: [URL] = []
+        // Root-level (some older versions place files here)
+        candidates.append(logicx.appendingPathComponent(name))
+        // Alternatives subdirectories (000, 001, etc.)
+        let altRoot = logicx.appendingPathComponent("Alternatives")
+        let fm = FileManager.default
+        for index in 0...9 {
+            let indexStr = String(format: "%03d", index)
+            let url = altRoot.appendingPathComponent(indexStr).appendingPathComponent(name)
+            if fm.fileExists(atPath: url.path) {
+                candidates.insert(url, at: 0) // prefer found file
+            } else {
+                candidates.append(url)
+            }
+        }
+        return candidates
+    }
 
     /// Read time signature from MetaData.plist or ProjectInformation.plist.
     private static func readTimeSignature(logicx: URL) -> String? {
-        let candidates = [
-            logicx.appendingPathComponent("MetaData.plist"),
-            logicx.appendingPathComponent("ProjectInformation.plist"),
-        ]
-        for url in candidates {
-            guard let data = try? Data(contentsOf: url) else { continue }
-            guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
-            if let sig = searchPlistForTimeSignature(plist) { return sig }
+        let names = ["MetaData.plist", "ProjectInformation.plist"]
+        for name in names {
+            for url in plistCandidateURLs(logicx: logicx, name: name) {
+                guard let data = try? Data(contentsOf: url) else { continue }
+                guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
+                if let sig = searchPlistForTimeSignature(plist) { return sig }
+            }
+        }
+        return nil
+    }
+
+    /// Read initial BPM from project plists.
+    /// Checks MetaData.plist and ProjectInformation.plist for common BPM/Tempo keys.
+    private static func readBPMFromPlist(logicx: URL) -> Double? {
+        let names = ["MetaData.plist", "ProjectInformation.plist"]
+        for name in names {
+            for url in plistCandidateURLs(logicx: logicx, name: name) {
+                guard let data = try? Data(contentsOf: url) else { continue }
+                guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
+                if let bpm = searchPlistForBPM(plist) { return bpm }
+            }
+        }
+        return nil
+    }
+
+    private static func searchPlistForBPM(_ plist: Any) -> Double? {
+        let bpmKeys = ["BPM", "bpm", "Tempo", "tempo", "BeatsPerMinute", "beatsPerMinute",
+                       "ProjectTempo", "projectTempo", "DefaultTempo", "defaultTempo"]
+        if let dict = plist as? [String: Any] {
+            for key in bpmKeys {
+                if let v = dict[key] {
+                    if let d = v as? Double, d > 10.0 && d < 1000.0 { return d }
+                    if let i = v as? Int, i > 10 && i < 1000 { return Double(i) }
+                    if let s = v as? String, let d = Double(s), d > 10.0 && d < 1000.0 { return d }
+                }
+            }
+            for (_, value) in dict {
+                if let found = searchPlistForBPM(value) { return found }
+            }
+        } else if let arr = plist as? [Any] {
+            for item in arr {
+                if let found = searchPlistForBPM(item) { return found }
+            }
         }
         return nil
     }
@@ -567,25 +713,33 @@ enum ProjectDataParser {
 
     /// Read sample rate from project plists.
     private static func readSampleRate(logicx: URL) -> Int? {
-        let candidates = [
-            logicx.appendingPathComponent("MetaData.plist"),
-            logicx.appendingPathComponent("ProjectInformation.plist"),
-        ]
-        for url in candidates {
-            guard let data = try? Data(contentsOf: url) else { continue }
-            guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
-            if let sr = searchPlistForSampleRate(plist) { return sr }
+        // Check standard project plists (MetaData.plist is inside Alternatives/000/)
+        let names = ["MetaData.plist", "ProjectInformation.plist", "Info.plist"]
+        for name in names {
+            for url in plistCandidateURLs(logicx: logicx, name: name) {
+                guard let data = try? Data(contentsOf: url) else { continue }
+                guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else { continue }
+                if let sr = searchPlistForSampleRate(plist) { return sr }
+            }
         }
         return nil
     }
 
     private static func searchPlistForSampleRate(_ plist: Any) -> Int? {
+        let srKeys = [
+            "SampleRate", "sampleRate", "sample_rate",
+            "Recording Sample Rate", "RecordingSampleRate",
+            "Audio Sample Rate", "AudioSampleRate",
+            "AudioFileSampleRate", "audioFileSampleRate",
+        ]
         if let dict = plist as? [String: Any] {
-            for key in ["SampleRate", "sampleRate", "sample_rate"] {
+            for key in srKeys {
                 if let v = dict[key] {
-                    if let i = v as? Int { return i }
-                    if let d = v as? Double { return Int(d) }
-                    if let s = v as? String, let i = Int(s) { return i }
+                    if let i = v as? Int, i > 0 { return i }
+                    if let d = v as? Double, d > 0 { return Int(d) }
+                    if let s = v as? String, let i = Int(s), i > 0 { return i }
+                    // Handle string-encoded floats (e.g. "44100.0")
+                    if let s = v as? String, let d = Double(s), d > 0 { return Int(d) }
                 }
             }
             for (_, value) in dict {

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -169,6 +169,10 @@ enum ProjectDataParser {
         info.trakEntries = trakEntries
         info.environmentLabels = environmentLabels
         info.subTrackHierarchy = subTrackHierarchy
+
+        // Compute per-song lengths from reference track (or marker boundary fallback)
+        info.songLengths = computeSongLengthsFromReference(info: info)
+
         return info
     }
 
@@ -2015,6 +2019,225 @@ enum ProjectDataParser {
             }
         }
         return nil
+    }
+
+    // MARK: - Track Index Map (Envi name → AX track index)
+
+    /// Build a mapping of Envi name → AX track index by fuzzy-matching Envi names
+    /// against the live track list read from the AX arrange window.
+    ///
+    /// Matching strategy (priority order):
+    ///   1. Exact name match (case-insensitive).
+    ///   2. Contains match — Envi name contains live name or vice versa.
+    ///   3. Token overlap — both names share ≥2 word tokens.
+    ///
+    /// Returns a dictionary: Envi name → AX 0-based track index.
+    static func buildTrackIndexMap(
+        enviNames: [String],
+        liveTracks: [LiveTrackInfo]
+    ) -> [String: Int] {
+        var result: [String: Int] = [:]
+
+        // Pre-compute lowercased live track names and their token sets for speed.
+        let liveNamesLower = liveTracks.map { $0.name.lowercased() }
+        let liveTokens: [[String]] = liveNamesLower.map { tokenise($0) }
+
+        for enviName in enviNames {
+            let enviLower = enviName.lowercased()
+            let enviToks = tokenise(enviLower)
+
+            // --- Pass 1: exact (case-insensitive) ---
+            if let idx = liveNamesLower.firstIndex(of: enviLower) {
+                result[enviName] = liveTracks[idx].index
+                continue
+            }
+
+            // --- Pass 2: contains ---
+            var containsIdx: Int? = nil
+            for (i, liveLow) in liveNamesLower.enumerated() {
+                if enviLower.contains(liveLow) || liveLow.contains(enviLower) {
+                    containsIdx = i
+                    break
+                }
+            }
+            if let idx = containsIdx {
+                result[enviName] = liveTracks[idx].index
+                continue
+            }
+
+            // --- Pass 3: token overlap (≥2 shared tokens) ---
+            if !enviToks.isEmpty {
+                var bestScore = 1          // need at least 2 to qualify
+                var bestIdx: Int? = nil
+                let enviSet = Set(enviToks)
+                for (i, toks) in liveTokens.enumerated() where !toks.isEmpty {
+                    let overlap = toks.filter { enviSet.contains($0) }.count
+                    if overlap > bestScore {
+                        bestScore = overlap
+                        bestIdx = i
+                    }
+                }
+                if let idx = bestIdx {
+                    result[enviName] = liveTracks[idx].index
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Split a name into lowercase word tokens (letters/digits only).
+    private static func tokenise(_ text: String) -> [String] {
+        return text
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 2 }
+    }
+
+    // MARK: - Song Lengths from Reference Track
+
+    /// Compute per-song lengths using reference track regions for accuracy.
+    ///
+    /// Strategy:
+    ///   1. Find the "Release Track" or "Reference" in the sub-track hierarchy
+    ///      (classified as functionGroup == "Reference").
+    ///   2. Collect all regions assigned to that track (via trackOid mapping).
+    ///   3. For each song marker, find a reference region that starts at (or near)
+    ///      the marker bar, and use that region's length.
+    ///   4. If no region overlaps a marker, try matching region name to marker name
+    ///      (e.g. region "New Beginnings" matches marker "New Beginnings").
+    ///   5. Fallback: marker-to-next-marker boundary.
+    ///
+    /// Returns one SongLength per arrangement marker, sorted by startBar.
+    static func computeSongLengthsFromReference(
+        info: ProjectDataInfo
+    ) -> [SongLength] {
+        let markers = info.markers.sorted { $0.bar < $1.bar }
+        guard !markers.isEmpty else { return [] }
+
+        // --- Find reference track OID ---
+        // Look in subTrackHierarchy for a stack named "Release Track" or "Reference".
+        let referenceStackNames: Set<String> = ["Release Track", "Reference", "Ref", "release track"]
+        var referenceTrackOids: Set<Int> = []
+
+        for stack in info.subTrackHierarchy {
+            if referenceStackNames.contains(stack.name)
+                || stack.name.lowercased().contains("release")
+                || stack.name.lowercased().contains("reference")
+            {
+                for strip in stack.strips {
+                    if let mseqOid = strip.mseqOid { referenceTrackOids.insert(mseqOid) }
+                    if strip.trakOid != nil || strip.mseqOid != nil {
+                        referenceTrackOids.insert(strip.oid)
+                    }
+                }
+            }
+        }
+        // Also check MSeq tracks by function group
+        for track in info.tracks where track.functionGroup == "Reference" {
+            referenceTrackOids.insert(track.oid)
+        }
+
+        // --- Collect reference regions ---
+        let referenceRegions: [ParsedRegion]
+        if !referenceTrackOids.isEmpty {
+            referenceRegions = info.regions.filter { region in
+                guard let tOid = region.trackOid else { return false }
+                return referenceTrackOids.contains(tOid)
+            }
+        } else {
+            referenceRegions = []
+        }
+
+        // --- Build a name-based region lookup (region.name lowercased → region) ---
+        var regionByName: [String: ParsedRegion] = [:]
+        for region in referenceRegions where !region.name.isEmpty {
+            let key = region.name.lowercased()
+            // Keep the longest region when names clash
+            if let existing = regionByName[key], existing.lengthBars >= region.lengthBars { continue }
+            regionByName[key] = region
+        }
+        // Also index by stripped names (without ".N" suffix like "Dead and Buried.2")
+        var regionByBaseName: [String: ParsedRegion] = [:]
+        for region in referenceRegions where !region.name.isEmpty {
+            let stripped = stripRegionSuffix(region.name).lowercased()
+            if let existing = regionByBaseName[stripped], existing.lengthBars >= region.lengthBars { continue }
+            regionByBaseName[stripped] = region
+        }
+
+        // --- Compute song lengths ---
+        var songLengths: [SongLength] = []
+
+        for (i, marker) in markers.enumerated() {
+            let markerStartBar = marker.bar
+            let markerEndBar: Int
+            if i + 1 < markers.count {
+                markerEndBar = markers[i + 1].bar
+            } else {
+                markerEndBar = marker.bar + marker.durationBars
+            }
+            let markerBoundaryLength = markerEndBar - markerStartBar
+
+            // --- Try to find a reference region ---
+            var matchedRegion: ParsedRegion? = nil
+
+            // 1. Overlapping by bar position: region starts within ±2 bars of marker
+            if !referenceRegions.isEmpty {
+                matchedRegion = referenceRegions.first { region in
+                    let regionStartInt = Int(region.startBar.rounded())
+                    return abs(regionStartInt - markerStartBar) <= 2
+                }
+            }
+
+            // 2. Name match: marker name matches region name (or base name)
+            if matchedRegion == nil {
+                let markerKey = marker.name.lowercased()
+                matchedRegion = regionByName[markerKey] ?? regionByBaseName[markerKey]
+            }
+
+            // 3. Partial name match (marker name contained in region base name or vice versa)
+            if matchedRegion == nil && !referenceRegions.isEmpty {
+                let markerKey = marker.name.lowercased()
+                matchedRegion = referenceRegions.first { region in
+                    let rKey = stripRegionSuffix(region.name).lowercased()
+                    return rKey.contains(markerKey) || markerKey.contains(rKey)
+                }
+            }
+
+            if let region = matchedRegion, region.lengthBars > 0 {
+                let lengthBars = max(1, Int(region.lengthBars.rounded()))
+                songLengths.append(SongLength(
+                    songName: marker.name,
+                    startBar: markerStartBar,
+                    endBar: markerStartBar + lengthBars,
+                    lengthBars: lengthBars,
+                    source: "reference_region"
+                ))
+            } else {
+                // Fallback: marker-to-marker boundary
+                songLengths.append(SongLength(
+                    songName: marker.name,
+                    startBar: markerStartBar,
+                    endBar: markerEndBar,
+                    lengthBars: markerBoundaryLength,
+                    source: "marker_boundary"
+                ))
+            }
+        }
+
+        return songLengths
+    }
+
+    /// Strip a trailing ".N" numeric suffix from a region name.
+    /// e.g. "Dead and Buried.2" → "Dead and Buried"
+    private static func stripRegionSuffix(_ name: String) -> String {
+        // Pattern: name ends with ".<digits>"
+        if let dotIdx = name.lastIndex(of: ".") {
+            let suffix = String(name[name.index(after: dotIdx)...])
+            if !suffix.isEmpty && suffix.allSatisfy({ $0.isNumber }) {
+                return String(name[name.startIndex..<dotIdx])
+            }
+        }
+        return name
     }
 
     // MARK: - Low-level Readers

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -139,6 +139,7 @@ enum ProjectDataParser {
 
         // Extract plugin list
         let plugins = extractPlugins(chunks: chunks, data: data)
+        let parsedPlugins = extractDetailedPlugins(chunks: chunks, data: data)
 
         // Extract Trak chunks (arrangement track → MSeq linkage)
         let trakEntries = extractTrakChunks(chunks: chunks, data: data)
@@ -173,6 +174,7 @@ enum ProjectDataParser {
         info.regions = regions
         info.audioFiles = audioFiles
         info.plugins = plugins
+        info.parsedPlugins = parsedPlugins
         info.timeSignature = timeSignature
         info.sampleRate = sampleRate
         info.projectName = projectName
@@ -1849,83 +1851,217 @@ enum ProjectDataParser {
 
     // MARK: - Plugin List
 
-    /// Extract plugin names by scanning ALL chunk bodies for known plugin name strings,
-    /// and scanning PluginData (null-ID) chunks for printable ASCII strings > 4 chars.
+    /// Extract plugins using multiple strategies:
+    ///   1. Known plugin name keyword matching across all chunks
+    ///   2. AU component code scanning (4-char type/subtype/manufacturer codes)
+    ///   3. PluginData (null-ID) chunk ASCII string extraction
+    ///   4. AuCO body scanning for embedded plugin references
     ///
-    /// Bug 4 Fix:
-    ///   - reverseID() now maps non-printable IDs to "PluginData" so they are no longer skipped.
-    ///   - PluginData chunks are scanned for all printable ASCII strings > 4 chars.
-    ///   - We also scan ALL chunks (not just "PluginData") for known plugin name strings.
-    ///   - Extended known plugin list per spec.
+    /// Returns (names: [String], detailed: [ParsedPlugin]).
     private static func extractPlugins(chunks: [ChunkInfo], data: Data) -> [String] {
-        var plugins = Set<String>()
+        let detailed = extractDetailedPlugins(chunks: chunks, data: data)
+        return detailed.map { $0.name }.sorted()
+    }
 
-        // Known plugin name keywords to search for (per spec + user requirement)
-        let knownPlugins: [String] = [
+    private static func extractDetailedPlugins(chunks: [ChunkInfo], data: Data) -> [ParsedPlugin] {
+        var pluginMap: [String: ParsedPlugin] = [:]  // name -> plugin (dedup)
+
+        // --- Comprehensive known plugin catalog ---
+        // Map: keyword → (type, manufacturer)
+        let knownPluginCatalog: [(keyword: String, type: String, manufacturer: String?)] = [
             // Logic built-ins
-            "Compressor", "Channel EQ", "Space Designer", "Alchemy", "Klopfgeist",
-            "Delay Designer", "Retro Synth", "Gain", "Limiter", "Multipressor",
+            ("Compressor", "au_builtin", "Apple"),
+            ("Channel EQ", "au_builtin", "Apple"),
+            ("Space Designer", "au_builtin", "Apple"),
+            ("Alchemy", "au_builtin", "Apple"),
+            ("Klopfgeist", "au_builtin", "Apple"),
+            ("Delay Designer", "au_builtin", "Apple"),
+            ("Retro Synth", "au_builtin", "Apple"),
+            ("Limiter", "au_builtin", "Apple"),
+            ("Multipressor", "au_builtin", "Apple"),
+            ("Tape Delay", "au_builtin", "Apple"),
+            ("Chromaverb", "au_builtin", "Apple"),
+            ("Phat FX", "au_builtin", "Apple"),
+            ("Step FX", "au_builtin", "Apple"),
+            ("Vintage EQ", "au_builtin", "Apple"),
+            ("Vintage Console", "au_builtin", "Apple"),
+            ("Linear Phase EQ", "au_builtin", "Apple"),
+            ("Match EQ", "au_builtin", "Apple"),
+            ("Amp Designer", "au_builtin", "Apple"),
+            ("Bass Amp Designer", "au_builtin", "Apple"),
+            ("Pedalboard", "au_builtin", "Apple"),
+            ("Sampler", "au_builtin", "Apple"),
+            ("Quick Sampler", "au_builtin", "Apple"),
+            ("Drum Machine Designer", "au_builtin", "Apple"),
+            ("Ultrabeat", "au_builtin", "Apple"),
+            ("ES2", "au_builtin", "Apple"),
+            ("EXS24", "au_builtin", "Apple"),
+            ("EVB3", "au_builtin", "Apple"),
+            ("Sculpture", "au_builtin", "Apple"),
+            ("AutoFilter", "au_builtin", "Apple"),
+            ("EVOC 20", "au_builtin", "Apple"),
+            ("Ringshifter", "au_builtin", "Apple"),
+            ("Vocal Transformer", "au_builtin", "Apple"),
+            ("Pitch Shifter", "au_builtin", "Apple"),
+            ("Tremolo", "au_builtin", "Apple"),
+            ("Scanner Vibrato", "au_builtin", "Apple"),
+            ("Phaser", "au_builtin", "Apple"),
+            ("Flanger", "au_builtin", "Apple"),
+            ("Chorus", "au_builtin", "Apple"),
+            ("Ensemble", "au_builtin", "Apple"),
+            ("Gain", "au_builtin", "Apple"),
             // Third-party
-            "Serum", "Kontakt", "Neural DSP", "FabFilter", "Valhalla", "Waves", "iZotope",
-            "Slate", "Massive", "Diva", "Sylenth", "Omnisphere", "Nexus", "Spire",
-            "Vital", "Pigments", "Saturn", "Vintage", "Native Instruments",
+            ("Serum", "au_thirdparty", "Xfer Records"),
+            ("Kontakt", "au_thirdparty", "Native Instruments"),
+            ("Neural DSP", "au_thirdparty", "Neural DSP"),
+            ("FabFilter", "au_thirdparty", "FabFilter"),
+            ("Pro-Q", "au_thirdparty", "FabFilter"),
+            ("Pro-L", "au_thirdparty", "FabFilter"),
+            ("Pro-C", "au_thirdparty", "FabFilter"),
+            ("Pro-R", "au_thirdparty", "FabFilter"),
+            ("Pro-MB", "au_thirdparty", "FabFilter"),
+            ("Valhalla", "au_thirdparty", "Valhalla DSP"),
+            ("ValhallaRoom", "au_thirdparty", "Valhalla DSP"),
+            ("VintageVerb", "au_thirdparty", "Valhalla DSP"),
+            ("Waves", "au_thirdparty", "Waves"),
+            ("iZotope", "au_thirdparty", "iZotope"),
+            ("Ozone", "au_thirdparty", "iZotope"),
+            ("Neutron", "au_thirdparty", "iZotope"),
+            ("Nectar", "au_thirdparty", "iZotope"),
+            ("Slate", "au_thirdparty", "Slate Digital"),
+            ("Massive", "au_thirdparty", "Native Instruments"),
+            ("Diva", "au_thirdparty", "u-he"),
+            ("Sylenth", "au_thirdparty", "LennarDigital"),
+            ("Omnisphere", "au_thirdparty", "Spectrasonics"),
+            ("Vital", "au_thirdparty", "Matt Tytel"),
+            ("Pigments", "au_thirdparty", "Arturia"),
+            ("Saturn", "au_thirdparty", "FabFilter"),
+            ("Soundtoys", "au_thirdparty", "Soundtoys"),
+            ("Eventide", "au_thirdparty", "Eventide"),
+            ("UAD", "au_thirdparty", "Universal Audio"),
+            ("Arturia", "au_thirdparty", "Arturia"),
+            ("Superior Drummer", "au_thirdparty", "Toontrack"),
+            ("EZdrummer", "au_thirdparty", "Toontrack"),
+            ("Spitfire", "au_thirdparty", "Spitfire Audio"),
+            ("RC-20", "au_thirdparty", "XLN Audio"),
+            ("Decapitator", "au_thirdparty", "Soundtoys"),
+            ("EchoBoy", "au_thirdparty", "Soundtoys"),
         ]
+
+        // AU component type codes (4-char identifiers found in binary)
+        let auTypeCodes: Set<String> = ["aufx", "aumu", "aumf", "auol", "aumi"]
 
         for chunk in chunks {
             guard chunk.bodyLength > 4, chunk.bodyLength < 10_000_000 else { continue }
 
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
 
-            // Scan for known plugin name keywords in ALL chunks
+            // Build ASCII representation for keyword search
             let ascii = body.map { b -> Character in
                 let s = Unicode.Scalar(b)
                 return s.value >= 32 && s.value < 127 ? Character(s) : Character("\0")
             }
             let bodyStr = String(ascii)
 
-            for plugin in knownPlugins where bodyStr.contains(plugin) {
-                plugins.insert(plugin)
+            // Strategy 1: Known plugin keyword matching
+            for entry in knownPluginCatalog where bodyStr.contains(entry.keyword) {
+                if pluginMap[entry.keyword] == nil {
+                    pluginMap[entry.keyword] = ParsedPlugin(
+                        name: entry.keyword,
+                        type: entry.type,
+                        manufacturer: entry.manufacturer,
+                        auComponentCode: nil
+                    )
+                }
             }
 
-            // For PluginData (null-ID) chunks: also extract all printable ASCII runs > 4 chars
-            // These may contain plugin names not in our known list.
-            if chunk.id == "PluginData" {
+            // Strategy 2: AU component code scanning
+            // Look for 4-char AU type codes followed by 4-char subtype and manufacturer
+            for i in stride(from: 0, to: body.count - 11, by: 1) {
+                // Read 4 bytes as potential AU type code
+                guard i + 12 <= body.count else { break }
+                let typeBytes = Data(body[i..<(i + 4)])
+                guard let typeStr = String(data: typeBytes, encoding: .ascii),
+                      auTypeCodes.contains(typeStr) else { continue }
+
+                // Read next 8 bytes as subtype (4) + manufacturer (4)
+                let subtypeBytes = Data(body[(i + 4)..<(i + 8)])
+                let mfrBytes = Data(body[(i + 8)..<(i + 12)])
+                guard let subtype = String(data: subtypeBytes, encoding: .ascii),
+                      let mfr = String(data: mfrBytes, encoding: .ascii) else { continue }
+
+                // Validate: all 3 codes should be printable 4-char strings
+                let allPrintable = (subtype + mfr).allSatisfy { $0.isASCII && $0 != "\0" }
+                guard allPrintable else { continue }
+
+                let componentCode = "\(typeStr):\(subtype):\(mfr)"
+                let name = "AU(\(subtype.trimmingCharacters(in: .whitespaces)))"
+                if pluginMap[componentCode] == nil {
+                    pluginMap[componentCode] = ParsedPlugin(
+                        name: name,
+                        type: "au_component",
+                        manufacturer: mfr.trimmingCharacters(in: .whitespaces),
+                        auComponentCode: componentCode
+                    )
+                }
+            }
+
+            // Strategy 3: PluginData and AuCO string extraction
+            if chunk.id == "PluginData" || chunk.id == idAuCO {
                 var run = ""
                 for byte in body {
                     let scalar = Unicode.Scalar(byte)
                     if scalar.value >= 32 && scalar.value < 127 {
                         run.append(Character(scalar))
                     } else {
-                        // End of printable run — keep if > 4 chars and looks like a plugin name
-                        // (starts with uppercase, not a path/URL/generic string)
-                        if run.count > 4
-                            && run.count < 64
-                            && run.first?.isUppercase == true
-                            && !run.hasPrefix("/")
-                            && !run.hasPrefix("http")
-                            && !run.contains("=")
-                            && !run.contains("\\")
-                        {
-                            plugins.insert(run)
+                        if let name = validatePluginStringRun(run) {
+                            if pluginMap[name] == nil {
+                                pluginMap[name] = ParsedPlugin(
+                                    name: name,
+                                    type: "unknown",
+                                    manufacturer: nil,
+                                    auComponentCode: nil
+                                )
+                            }
                         }
                         run = ""
                     }
                 }
                 // Flush final run
-                if run.count > 4
-                    && run.count < 64
-                    && run.first?.isUppercase == true
-                    && !run.hasPrefix("/")
-                    && !run.hasPrefix("http")
-                    && !run.contains("=")
-                    && !run.contains("\\")
-                {
-                    plugins.insert(run)
+                if let name = validatePluginStringRun(run) {
+                    if pluginMap[name] == nil {
+                        pluginMap[name] = ParsedPlugin(
+                            name: name,
+                            type: "unknown",
+                            manufacturer: nil,
+                            auComponentCode: nil
+                        )
+                    }
                 }
             }
         }
 
-        return Array(plugins).sorted()
+        return Array(pluginMap.values).sorted { $0.name < $1.name }
+    }
+
+    /// Validate a printable ASCII run as a potential plugin name.
+    /// Accepts both uppercase and lowercase starting chars (for "iZotope" etc).
+    private static func validatePluginStringRun(_ run: String) -> String? {
+        guard run.count > 4 && run.count < 64 else { return nil }
+        guard let first = run.first, first.isLetter else { return nil }
+        // Must contain at least one uppercase letter (excludes random lowercase noise)
+        guard run.contains(where: { $0.isUppercase }) else { return nil }
+        // Filter paths, URLs, generic strings
+        guard !run.hasPrefix("/"),
+              !run.hasPrefix("http"),
+              !run.contains("="),
+              !run.contains("\\"),
+              !run.hasPrefix("com."),
+              !run.contains("::"),
+              !run.hasPrefix("NS"),
+              !run.hasPrefix("CF")
+        else { return nil }
+        return run
     }
 
     /// Returns true if the chunk ID consists only of non-printable / null bytes.

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -141,8 +141,14 @@ enum ProjectDataParser {
         // Extract Envi environment labels (stack grouping labels)
         let environmentLabels = extractEnviNames(chunks: chunks, data: data)
 
+        // Extract Envi OID → name map for AuCO enrichment
+        let enviNameMap = extractEnviNameMap(chunks: chunks, data: data)
+
         // Extract all AuCO channel strips as sub-track enumeration
         var channelStrips = extractAllChannelStrips(chunks: chunks, data: data)
+
+        // Enrich generic AuCO names with Envi environment labels
+        enrichChannelStripNamesFromEnvi(strips: &channelStrips, enviNameMap: enviNameMap)
 
         // Wire AuCO → Trak → MSeq chain and infer function groups on strips
         linkChannelStripsToTrak(strips: &channelStrips, trakEntries: trakEntries)
@@ -1359,6 +1365,68 @@ enum ProjectDataParser {
         }
 
         return names
+    }
+
+    /// Extract Envi OID → name map for correlating environment objects with AuCO channel strips.
+    /// Unlike `extractEnviNames` which returns a flat list, this preserves the chunk OID.
+    private static func extractEnviNameMap(chunks: [ChunkInfo], data: Data) -> [UInt32: String] {
+        var map: [UInt32: String] = [:]
+
+        for chunk in chunks where chunk.id == idEnvi {
+            guard chunk.bodyLength >= 4 else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+
+            if let name = extractEnviName(body: body), !name.isEmpty {
+                // Keep first name per OID (Envi OIDs can repeat with different bodies)
+                if map[chunk.oid] == nil {
+                    map[chunk.oid] = name
+                }
+            }
+        }
+
+        return map
+    }
+
+    /// Enrich generic AuCO channel strip names ("Audio N") with Envi environment labels.
+    ///
+    /// Matching strategy: for each generic strip, find an Envi object whose OID is
+    /// within ±4 of the strip's OID and hasn't been consumed by another strip yet.
+    /// This exploits the fact that Logic assigns OIDs to Envi and AuCO objects in
+    /// nearby ranges for the same logical channel.
+    private static func enrichChannelStripNamesFromEnvi(
+        strips: inout [ChannelStrip],
+        enviNameMap: [UInt32: String]
+    ) {
+        guard !enviNameMap.isEmpty else { return }
+
+        // Sort Envi OIDs for efficient proximity search
+        let sortedEnviOids = enviNameMap.keys.sorted()
+        var consumedEnviOids = Set<UInt32>()
+
+        for i in strips.indices {
+            guard strips[i].isGeneric else { continue }
+
+            let stripOid = UInt32(strips[i].oid)
+
+            // Find nearest unconsumed Envi OID within ±4
+            var bestOid: UInt32? = nil
+            var bestDist: UInt32 = 5
+
+            for enviOid in sortedEnviOids {
+                guard !consumedEnviOids.contains(enviOid) else { continue }
+                let dist = stripOid > enviOid ? stripOid - enviOid : enviOid - stripOid
+                if dist < bestDist {
+                    bestDist = dist
+                    bestOid = enviOid
+                }
+            }
+
+            if let oid = bestOid, let enviName = enviNameMap[oid] {
+                strips[i].name = enviName
+                strips[i].isGeneric = false
+                consumedEnviOids.insert(oid)
+            }
+        }
     }
 
     /// Scan an Envi body for the first plausible printable ASCII name.

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -106,8 +106,13 @@ enum ProjectDataParser {
         // Extract audio file references
         let audioFiles = extractAudioFiles(chunks: chunks, data: data)
 
+        // Compute global timeline tick offset from marker events.
+        // If the first marker's tick is large (absolute timeline space),
+        // we subtract the offset so region bars align correctly.
+        let timelineTickOffset = computeTimelineTickOffset(markerEvents: evSqMarkerEvents)
+
         // Extract audio regions
-        var regions = extractRegions(chunks: chunks, data: data)
+        var regions = extractRegions(chunks: chunks, data: data, timelineTickOffset: timelineTickOffset)
 
         // Apply track-to-region mapping (uses public tracks for OID set)
         applyTrackRegionMapping(
@@ -799,7 +804,35 @@ enum ProjectDataParser {
     ///   0x4C  *B  name (ASCII)
     ///
     /// The AuRg OID matches the AuFl OID that owns this audio asset.
-    private static func extractRegions(chunks: [ChunkInfo], data: Data) -> [ParsedRegion] {
+    /// Compute the global timeline tick offset.
+    ///
+    /// Logic Pro's timeline may start well before bar 1, using a large pre-roll offset.
+    /// Marker events from type-18 sequences and tempo bridge events are in this absolute
+    /// space. We detect the offset by checking if the earliest marker tick implies a bar
+    /// much larger than expected. If the first marker is at a very high tick but should
+    /// be within the first ~50 bars, the difference is the pre-roll offset.
+    ///
+    /// Fallback: if markers aren't helpful, return 0 (no offset).
+    private static func computeTimelineTickOffset(markerEvents: [MarkerEvent]) -> Int {
+        guard !markerEvents.isEmpty else { return 0 }
+
+        // Find the minimum startTick across all markers
+        let minTick = markerEvents.map { Int($0.startTick) }.min() ?? 0
+        guard minTick > 0 else { return 0 }
+
+        // The first marker should typically be within the first ~200 bars.
+        // If minTick implies a bar > 200, there's likely a pre-roll offset.
+        let impliedBar = minTick / ticksPerBar + 1
+        if impliedBar > 200 {
+            // Round offset down to nearest bar boundary for clean alignment
+            let offsetBars = (minTick / ticksPerBar) - 1  // leave 1 bar before first marker
+            return max(0, offsetBars * ticksPerBar)
+        }
+
+        return 0
+    }
+
+    private static func extractRegions(chunks: [ChunkInfo], data: Data, timelineTickOffset: Int = 0) -> [ParsedRegion] {
         var result: [ParsedRegion] = []
 
         for chunk in chunks where chunk.id == idAuRg {
@@ -812,19 +845,18 @@ enum ProjectDataParser {
             var startTick: Int = 0
             var lengthTicks: Int = 0
 
-            // Bug 3 Fix: Try legacy tick mode FIRST.
-            // 8-byte LE tick at body offset 0x30; bar = tick / 3840 + 1.
-            // Accept if bar is in reasonable range (1-5000).
-            // Only fall back to bar-field mode if legacy gives 0 or unreasonable values.
+            // Bug 3 Fix: Try legacy tick mode FIRST, applying the global timeline
+            // tick offset to convert from absolute timeline space to relative (bar 1 = tick 0).
             var usedLegacy = false
             if body.count >= 0x38 {
-                // Read full 8-byte LE tick at 0x30
                 let rawStartTick = Int(readLE64(body, at: 0x30))
-                let legacyBar = rawStartTick / ticksPerBar + 1
-                if rawStartTick > 0 && legacyBar >= 1 && legacyBar <= 5000 {
-                    startTick = rawStartTick
-                    startBar = Double(rawStartTick) / Double(ticksPerBar) + 1.0
-                    // Length at 0x38 (8-byte LE tick)
+                // Apply timeline offset: subtract pre-roll to get relative ticks
+                let adjustedTick = rawStartTick - timelineTickOffset
+                let legacyBar = adjustedTick / ticksPerBar + 1
+                if adjustedTick > 0 && legacyBar >= 1 && legacyBar <= 5000 {
+                    startTick = adjustedTick
+                    startBar = Double(adjustedTick) / Double(ticksPerBar) + 1.0
+                    // Length at 0x38 (duration ticks — no offset needed)
                     if body.count >= 0x40 {
                         let rawLenTick = Int(readLE64(body, at: 0x38))
                         lengthTicks = rawLenTick
@@ -835,16 +867,9 @@ enum ProjectDataParser {
                         lengthBars = Double(lengthTicks) / Double(ticksPerBar)
                     }
                     usedLegacy = true
-                } else if rawStartTick > 0 {
-                    // Tick is non-zero but bar is out of range — check for large pre-roll offset.
-                    // Some projects encode absolute timeline ticks; subtract any offset > 5000 bars.
-                    // If after subtracting some pre-roll the bar lands in 1-5000, accept it.
-                    let barsFromZero = rawStartTick / ticksPerBar
-                    if barsFromZero > 5000 {
-                        // Try bar-field below — don't use this tick value
-                    } else if legacyBar > 5000 {
-                        // legacyBar > 5000: bar-field will be tried below
-                    }
+                } else if rawStartTick > 0 && adjustedTick <= 0 {
+                    // After offset subtraction the tick went negative — region is
+                    // before bar 1 (pre-roll area). Skip to bar-field fallback.
                 }
             }
 

--- a/Sources/LogicProMCP/Binary/ProjectDataParser.swift
+++ b/Sources/LogicProMCP/Binary/ProjectDataParser.swift
@@ -372,10 +372,10 @@ enum ProjectDataParser {
                 text = text.replacingOccurrences(of: ".", with: "")
                 text = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 // Remove leading/trailing non-alphanumeric
-                while text.first != nil && !text.first!.isLetter && !text.first!.isNumber {
+                while let c = text.first, !c.isLetter && !c.isNumber {
                     text.removeFirst()
                 }
-                while text.last != nil && !text.last!.isLetter && !text.last!.isNumber {
+                while let c = text.last, !c.isLetter && !c.isNumber {
                     text.removeLast()
                 }
                 return text.isEmpty ? nil : text
@@ -903,20 +903,17 @@ enum ProjectDataParser {
 
     // MARK: - Track-to-Region Mapping
 
-    /// Populate trackOid on regions and regions list on tracks using the AuRg body scanning
-    /// heuristic described in reference/LOGIC_BINARY_SPEC.md and python_extractor_snippets.txt.
+    /// Populate trackOid on regions and regions list on tracks.
     ///
-    /// Bug 1 Fix: Replace Song/USEl table scan with AuRg body offset heuristic.
+    /// Two-source approach (priority order):
+    ///   1. **Trak body scan** (primary): Trak chunk bodies may contain AuRg OIDs after the
+    ///      fixed header fields. Scan from offset 0x2C onwards for u32 values matching known
+    ///      region OIDs and build trakOid → [regionOid] mapping.
+    ///   2. **AuRg body offset heuristic** (fallback): Group AuRg bodies by length, find the
+    ///      offset where track OIDs appear most frequently, use that to read trackOid per region.
     ///
-    /// Algorithm:
-    ///   1. Collect known track OIDs from MSeq chunks.
-    ///   2. For each AuRg chunk body, group by body length.
-    ///   3. For each length group, scan u32 values at candidate offsets
-    ///      (0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68) counting how many bodies
-    ///      contain a known track OID at that offset.
-    ///   4. Use the highest-scoring offset as the track reference for that length group.
-    ///   5. Fallback: wide scan every 4 bytes from 0x00 to 0xC0 when no candidate offset wins.
-    ///   6. Set trackOid on each ParsedRegion; leave nil if no match.
+    /// Regions are matched to AuRg chunk bodies by composite key (oid, startTick) rather than
+    /// sequential index, avoiding drift when extractRegions skips chunks with no timing/name.
     private static func applyTrackRegionMapping(
         chunks: [ChunkInfo],
         data: Data,
@@ -926,29 +923,126 @@ enum ProjectDataParser {
         let trackOidSet = Set(tracks.map { UInt32($0.oid) })
         guard !trackOidSet.isEmpty, !regions.isEmpty else { return }
 
-        // Candidate offsets per spec: 0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68 (and more)
-        // Include 0x00 — in AuRg bodies the first u32 can be a track OID reference.
+        // Build region lookup by composite key (oid, startTick) for robust chunk↔region matching.
+        // When multiple regions share a key, store the first unmatched index.
+        struct RegionKey: Hashable { let oid: Int; let startTick: Int }
+        var regionLookup: [RegionKey: [Int]] = [:]
+        for (i, r) in regions.enumerated() {
+            regionLookup[RegionKey(oid: r.oid, startTick: r.startTick), default: []].append(i)
+        }
+        // Track which indices have been consumed (for duplicate keys)
+        var consumedIndices = Set<Int>()
+
+        func findRegionIndex(oid: Int, startTick: Int) -> Int? {
+            let key = RegionKey(oid: oid, startTick: startTick)
+            guard let indices = regionLookup[key] else { return nil }
+            for idx in indices where !consumedIndices.contains(idx) {
+                consumedIndices.insert(idx)
+                return idx
+            }
+            return nil
+        }
+
+        // Collect all region OIDs for Trak body scanning
+        let regionOidSet = Set(regions.map { UInt32($0.oid) })
+
+        // --- Source 1: Trak body scan ---
+        // Trak bodies have fixed fields at 0x00-0x2B. Any u32 values from 0x2C onwards
+        // that match known AuRg OIDs are region references owned by that track.
+        var trakRegionOids: [UInt32: Set<UInt32>] = [:]  // trakOid → {regionOid}
+        for chunk in chunks where chunk.id == idTrak {
+            guard chunk.bodyLength > 0x30 else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+            var foundRegionOids = Set<UInt32>()
+            // Scan u32 values from offset 0x2C to end of body
+            var off = 0x2C
+            while off + 4 <= body.count {
+                let val = readLE32(body, at: off)
+                if val != 0 && regionOidSet.contains(val) {
+                    foundRegionOids.insert(val)
+                }
+                off += 4
+            }
+            if !foundRegionOids.isEmpty {
+                trakRegionOids[chunk.oid] = foundRegionOids
+            }
+        }
+
+        // Apply Trak-based mapping: Trak.oid maps to MSeq via trakEntries,
+        // and we need the MSeq OID (which is what ParsedTrack.oid uses).
+        // Build Trak OID → MSeq OID map from Trak chunks.
+        var trakToMSeq: [UInt32: UInt32] = [:]
+        for chunk in chunks where chunk.id == idTrak {
+            guard chunk.bodyLength >= 0x0C else { continue }
+            let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
+            let mseqOid = readLE32(body, at: 0x08)
+            if mseqOid != 0 {
+                trakToMSeq[chunk.oid] = mseqOid
+            }
+        }
+
+        // Assign regions from Trak body scan
+        for (trakOid, regOids) in trakRegionOids {
+            let mseqOid = trakToMSeq[trakOid] ?? trakOid
+            guard trackOidSet.contains(mseqOid) else { continue }
+            for regOid in regOids {
+                // Mark all regions with this OID as belonging to this track
+                for i in regions.indices where regions[i].oid == Int(regOid) && regions[i].trackOid == nil {
+                    regions[i].trackOid = Int(mseqOid)
+                }
+            }
+        }
+
+        // --- Source 2: AuRg body offset heuristic (fallback for unmapped regions) ---
+
         let candidateOffsets: [Int] = [0x00, 0x04, 0x08, 0x0C, 0x60, 0x64, 0x68,
                                        0x10, 0x14, 0x18, 0x1C, 0x20, 0x24, 0x28,
                                        0x2C, 0x30, 0x34, 0x38, 0x3C, 0x40, 0x44,
                                        0x48, 0x4C, 0x50, 0x54, 0x58, 0x5C,
                                        0x6C, 0x70, 0x74, 0x78, 0x7C]
 
-        // Collect all AuRg (body, regionIdx) pairs in chunk order
+        // Collect AuRg (body, regionIdx) pairs using composite key matching
+        // instead of sequential index, avoiding drift from skipped chunks.
         var aurgBodies: [(body: Data, regionIdx: Int)] = []
-        var regionIdx = 0
         for chunk in chunks where chunk.id == idAuRg {
             guard chunk.bodyLength > 0x4C else { continue }
             let body = Data(data[chunk.bodyOffset..<(chunk.bodyOffset + chunk.bodyLength)])
-            if regionIdx < regions.count {
-                aurgBodies.append((body: body, regionIdx: regionIdx))
-                regionIdx += 1
+
+            // Extract timing to compute composite key (same logic as extractRegions)
+            var startTick = 0
+            if body.count >= 0x38 {
+                let rawStartTick = Int(readLE64(body, at: 0x30))
+                let legacyBar = rawStartTick / ticksPerBar + 1
+                if rawStartTick > 0 && legacyBar >= 1 && legacyBar <= 5000 {
+                    startTick = rawStartTick
+                }
+            }
+            if startTick == 0 {
+                let startBarInt = readLE32(body, at: 0x10)
+                let startBarFracRaw = readLE32(body, at: 0x14)
+                let startBarFrac = Double(startBarFracRaw >> 16) / 65536.0
+                let candidateBar = Double(startBarInt) + startBarFrac
+                if (startBarInt > 0 || startBarFrac > 0) && candidateBar <= 5000.0 {
+                    startTick = Int((candidateBar - 1.0) * Double(ticksPerBar))
+                }
+            }
+
+            if let regIdx = findRegionIndex(oid: Int(chunk.oid), startTick: startTick) {
+                aurgBodies.append((body: body, regionIdx: regIdx))
             }
         }
 
-        // Group by body length
+        // Only process regions not yet mapped by Trak scan
+        let unmappedBodies = aurgBodies.filter { regions[$0.regionIdx].trackOid == nil }
+        guard !unmappedBodies.isEmpty else {
+            // All mapped by Trak scan — just build cross-reference and return
+            buildTrackRegionCrossRef(tracks: &tracks, regions: regions)
+            return
+        }
+
+        // Group unmapped by body length
         var byLength: [Int: [(body: Data, regionIdx: Int)]] = [:]
-        for entry in aurgBodies {
+        for entry in unmappedBodies {
             byLength[entry.body.count, default: []].append(entry)
         }
 
@@ -963,23 +1057,20 @@ enum ProjectDataParser {
                 let maxScan = min(entry.body.count, 0xC0)
                 for off in candidateOffsets where off + 4 <= maxScan {
                     let val = readLE32(entry.body, at: off)
-                    // Exclude OID=0 to avoid false hits (many fields default to 0)
                     if trackOidSet.contains(val) && val != 0 {
                         hitCounts[off, default: 0] += 1
                     }
                 }
             }
 
-            // Accept offset if ratio >= 0.15 or count >= 2 (lower threshold to catch sparse groups)
             let filtered = hitCounts.filter { $0.value * 20 >= total * 3 || $0.value >= 2 }
             if let best = filtered.max(by: { $0.value < $1.value }) {
-                let len = group.first!.body.count
+                let len = group.first?.body.count ?? 0
                 bestOffsetByLength[len] = best.key
             }
         }
 
-        // Pass 2: if still no good offset for a length group, do wider scan (every 4 bytes from 0x00)
-        // Python: range(0, max_scan, 4) — includes offset 0
+        // Pass 2: wider scan for groups with no good offset
         for (len, group) in byLength {
             guard bestOffsetByLength[len] == nil else { continue }
             let total = group.count
@@ -996,14 +1087,13 @@ enum ProjectDataParser {
                 }
             }
 
-            // For wide scan, keep top offset with any hits (even 1 hit for single-region groups)
             if let best = hitCounts.max(by: { $0.value < $1.value }), best.value > 0 {
                 bestOffsetByLength[len] = best.key
             }
         }
 
-        // Assign track OIDs to regions
-        for entry in aurgBodies {
+        // Assign track OIDs to unmapped regions
+        for entry in unmappedBodies {
             let len = entry.body.count
             guard let bestOff = bestOffsetByLength[len], bestOff + 4 <= len else { continue }
             let val = readLE32(entry.body, at: bestOff)
@@ -1012,6 +1102,14 @@ enum ProjectDataParser {
         }
 
         // Build track -> regions cross-reference
+        buildTrackRegionCrossRef(tracks: &tracks, regions: regions)
+    }
+
+    /// Build track.regions arrays from region.trackOid assignments.
+    private static func buildTrackRegionCrossRef(
+        tracks: inout [ParsedTrack],
+        regions: [ParsedRegion]
+    ) {
         var trackRegionMap: [Int: [ParsedRegion]] = [:]
         for region in regions {
             if let tOid = region.trackOid {
@@ -1648,7 +1746,7 @@ enum ProjectDataParser {
                 stacks.append(SubTrackStack(
                     name: fg,
                     source: "function_group",
-                    strips: fgMap[fg]!.sorted { $0.name < $1.name }
+                    strips: (fgMap[fg] ?? []).sorted { $0.name < $1.name }
                 ))
             }
         }
@@ -2355,7 +2453,7 @@ func findMostRecentLogicxFile() -> String? {
         if url.pathExtension == "logicx" {
             if let attrs = try? fm.attributesOfItem(atPath: url.path),
                let modDate = attrs[.modificationDate] as? Date {
-                if best == nil || modDate > best!.date {
+                if best.map({ modDate > $0.date }) ?? true {
                     best = (url.path, modDate)
                 }
             }
@@ -2373,7 +2471,7 @@ func findMostRecentLogicxFile() -> String? {
             if child.pathExtension == "logicx" {
                 if let attrs = try? fm.attributesOfItem(atPath: child.path),
                    let modDate = attrs[.modificationDate] as? Date {
-                    if best == nil || modDate > best!.date {
+                    if best.map({ modDate > $0.date }) ?? true {
                         best = (child.path, modDate)
                     }
                 }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ApplicationServices
 import Foundation
 
@@ -398,43 +399,51 @@ actor AccessibilityChannel: Channel {
         }
 
         // Wait for the dialog to appear
-        Thread.sleep(forTimeInterval: 0.3)
+        Thread.sleep(forTimeInterval: 0.4)
 
-        // Type the track name using CGEvent
+        // Use clipboard paste — CGEvent unicode typing doesn't work in Logic's search dialog
         guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
 
-        // First clear any existing text with Cmd+A then type the name
+        // Put track name on clipboard
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(name, forType: .string)
+
+        // Cmd+A to select existing text
         if let selAll = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
            let selAllUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
             selAll.flags = .maskCommand
             selAllUp.flags = .maskCommand
-            selAll.postToPid(pid)
-            selAllUp.postToPid(pid)
+            selAll.post(tap: .cghidEventTap)
+            usleep(30_000)
+            selAllUp.post(tap: .cghidEventTap)
         }
         Thread.sleep(forTimeInterval: 0.05)
 
-        // Type each character of the track name
-        for scalar in name.unicodeScalars {
-            let char = scalar.value
-            // Use CGEventKeyboardSetUnicodeString for arbitrary characters
-            guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
-                  let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else { continue }
-            var utf16 = [UniChar(char & 0xFFFF)]
-            keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: &utf16)
-            keyUp.keyboardSetUnicodeString(stringLength: 1, unicodeString: &utf16)
-            keyDown.postToPid(pid)
-            keyUp.postToPid(pid)
+        // Cmd+V to paste
+        if let pasteDown = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: true),
+           let pasteUp = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: false) {
+            pasteDown.flags = .maskCommand
+            pasteUp.flags = .maskCommand
+            pasteDown.post(tap: .cghidEventTap)
+            usleep(30_000)
+            pasteUp.post(tap: .cghidEventTap)
         }
 
-        Thread.sleep(forTimeInterval: 0.2)
+        Thread.sleep(forTimeInterval: 0.3)
 
-        // Press Return to confirm
+        // Press Return to confirm selection
         guard let returnDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
               let returnUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else { return false }
-        returnDown.postToPid(pid)
-        returnUp.postToPid(pid)
+        returnDown.post(tap: .cghidEventTap)
+        returnUp.post(tap: .cghidEventTap)
 
-        Thread.sleep(forTimeInterval: 0.1)
+        // Wait for search dialog to close. The search dialog returns focus to the arrange
+        // area automatically — no need to click. AppleScript keystroke via System Events
+        // will target the frontmost app (Logic Pro) regardless.
+        Thread.sleep(forTimeInterval: 0.3)
+
+        Thread.sleep(forTimeInterval: 0.15)
         return true
     }
 
@@ -446,29 +455,42 @@ actor AccessibilityChannel: Channel {
         return .error("Failed to select track '\(name)' via menu search")
     }
 
-    /// Select a track by name then toggle mute/solo/arm via CGEvent key press.
+    /// Select a track by name then toggle mute/solo/arm via AppleScript keystroke.
+    /// AppleScript `keystroke` via System Events properly injects into the focused app,
+    /// unlike CGEvent.post which Logic ignores for focus-dependent shortcuts.
     private func toggleTrackByNameMenu(name: String, key: CGKeyCode, keyLabel: String) -> ChannelResult {
-        guard let pid = ProcessUtils.logicProPID() else {
-            return .error("Logic Pro is not running")
-        }
-
         let selected = AccessibilityChannel.selectTrackByNameViaMenu(name)
         guard selected else {
             return .error("Cannot select track '\(name)' — track search failed")
         }
 
-        // Brief pause so Logic registers the track selection before toggle
-        Thread.sleep(forTimeInterval: 0.1)
+        // Brief pause so Logic registers the track selection
+        Thread.sleep(forTimeInterval: 0.15)
 
-        guard let source = CGEventSource(stateID: .hidSystemState),
-              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false) else {
-            return .error("Failed to create CGEvent for \(keyLabel) key")
+        // Map key label to character
+        let keyChar: String
+        switch keyLabel {
+        case "Solo": keyChar = "s"
+        case "Mute": keyChar = "m"
+        case "Arm", "Record": keyChar = "r"
+        default: keyChar = "s"
         }
-        keyDown.postToPid(pid)
-        keyUp.postToPid(pid)
 
-        return .success("{\"track\":\"\(name)\",\"toggled\":\"\(keyLabel)\",\"via\":\"AX_menu_search\"}")
+        // Use osascript subprocess — NSAppleScript hangs in the MCP server process,
+        // but spawning osascript works reliably
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        proc.arguments = ["-e", "tell application \"System Events\" to keystroke \"\(keyChar)\""]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return .error("osascript keystroke failed: \(error)")
+        }
+
+        return .success("{\"track\":\"\(name)\",\"toggled\":\"\(keyLabel)\",\"via\":\"AX_menu+osascript\"}")
     }
 
     // MARK: - Tracks

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -46,6 +46,8 @@ actor AccessibilityChannel: Channel {
             return setTempo(params: params)
         case "transport.set_cycle_range":
             return setCycleRange(params: params)
+        case "transport.set_cycle_range_by_selection":
+            return setCycleRangeBySelection()
 
         // MARK: - Track reads
         case "track.get_tracks":
@@ -55,10 +57,22 @@ actor AccessibilityChannel: Channel {
 
         // MARK: - Track mutations
         case "track.select":
+            // Prefer name-based menu selection when 'name' param is provided
+            if let name = params["name"] {
+                return selectTrackByNameMenu(name: name)
+            }
             return selectTrack(params: params)
         case "track.set_mute":
+            // Prefer name-based when 'name' is provided
+            if let name = params["name"] {
+                return toggleTrackByNameMenu(name: name, key: 46, keyLabel: "Mute")
+            }
             return setTrackToggle(params: params, button: "Mute")
         case "track.set_solo":
+            // Prefer name-based when 'name' is provided
+            if let name = params["name"] {
+                return toggleTrackByNameMenu(name: name, key: 1, keyLabel: "Solo")
+            }
             return setTrackToggle(params: params, button: "Solo")
         case "track.set_arm":
             return setTrackToggle(params: params, button: "Record")
@@ -66,6 +80,18 @@ actor AccessibilityChannel: Channel {
             return renameTrack(params: params)
         case "track.set_color":
             return .error("Track color setting not supported via AX")
+
+        // MARK: - AX Menu operations
+        case "menu.click":
+            guard let pathStr = params["path"] else {
+                return .error("menu.click requires 'path' param (comma-separated menu titles)")
+            }
+            let components = pathStr.components(separatedBy: "|").map { $0.trimmingCharacters(in: .whitespaces) }
+            guard !components.isEmpty else {
+                return .error("menu.click: path must not be empty")
+            }
+            let ok = AXLogicProElements.clickMenuItem(path: components)
+            return ok ? .success("{\"clicked\":\"\(pathStr)\"}") : .error("Failed to click menu: \(pathStr)")
 
         // MARK: - Mixer reads
         case "mixer.get_state":
@@ -333,6 +359,116 @@ actor AccessibilityChannel: Channel {
             "To set the cycle range manually: enable Cycle (C), then drag the cycle region in the ruler, " +
             "or use Logic's Set Locators dialog (Option+click on cycle region)."
         )
+    }
+
+    /// Set the cycle range using Navigate > "Set Locators by Selection and Enable Cycle".
+    /// Requires that a region or marker is already selected in the arrange window.
+    private func setCycleRangeBySelection() -> ChannelResult {
+        let ok = AXLogicProElements.clickMenuItem(path: ["Navigate", "Set Locators by Selection and Enable Cycle"])
+        if ok {
+            return .success("{\"cycle_range_set\":\"by_selection\",\"via\":\"AX_menu\"}")
+        }
+        return .error("Failed to click Navigate > Set Locators by Selection and Enable Cycle")
+    }
+
+    // MARK: - AX Menu — Track Selection
+
+    /// Select a track by name using the Track > "Search and Select Track…" menu dialog.
+    ///
+    /// Steps:
+    ///   1. Open Track > "Search and Select Track…" via AX menu click.
+    ///   2. Wait 300 ms for the dialog to appear.
+    ///   3. Type the track name via CGEvent to the Logic Pro PID.
+    ///   4. Wait 200 ms for the search to filter.
+    ///   5. Press Return to confirm selection.
+    ///
+    /// Returns true on success.
+    static func selectTrackByNameViaMenu(_ name: String) -> Bool {
+        guard let pid = ProcessUtils.logicProPID() else {
+            Log.warn("selectTrackByNameViaMenu: Logic Pro not running", subsystem: "ax")
+            return false
+        }
+
+        // Open the search dialog — try Unicode ellipsis first, then ASCII "..."
+        let opened = AXLogicProElements.clickMenuItem(path: ["Track", "Search and Select Track\u{2026}"])
+            || AXLogicProElements.clickMenuItem(path: ["Track", "Search and Select Track..."])
+        guard opened else {
+            Log.warn("selectTrackByNameViaMenu: could not open Search and Select Track dialog", subsystem: "ax")
+            return false
+        }
+
+        // Wait for the dialog to appear
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // Type the track name using CGEvent
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
+
+        // First clear any existing text with Cmd+A then type the name
+        if let selAll = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+           let selAllUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
+            selAll.flags = .maskCommand
+            selAllUp.flags = .maskCommand
+            selAll.postToPid(pid)
+            selAllUp.postToPid(pid)
+        }
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // Type each character of the track name
+        for scalar in name.unicodeScalars {
+            let char = scalar.value
+            // Use CGEventKeyboardSetUnicodeString for arbitrary characters
+            guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+                  let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else { continue }
+            var utf16 = [UniChar(char & 0xFFFF)]
+            keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: &utf16)
+            keyUp.keyboardSetUnicodeString(stringLength: 1, unicodeString: &utf16)
+            keyDown.postToPid(pid)
+            keyUp.postToPid(pid)
+        }
+
+        Thread.sleep(forTimeInterval: 0.2)
+
+        // Press Return to confirm
+        guard let returnDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
+              let returnUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else { return false }
+        returnDown.postToPid(pid)
+        returnUp.postToPid(pid)
+
+        Thread.sleep(forTimeInterval: 0.1)
+        return true
+    }
+
+    private func selectTrackByNameMenu(name: String) -> ChannelResult {
+        let ok = AccessibilityChannel.selectTrackByNameViaMenu(name)
+        if ok {
+            return .success("{\"selected\":\"\(name)\",\"via\":\"AX_menu_search\"}")
+        }
+        return .error("Failed to select track '\(name)' via menu search")
+    }
+
+    /// Select a track by name then toggle mute/solo/arm via CGEvent key press.
+    private func toggleTrackByNameMenu(name: String, key: CGKeyCode, keyLabel: String) -> ChannelResult {
+        guard let pid = ProcessUtils.logicProPID() else {
+            return .error("Logic Pro is not running")
+        }
+
+        let selected = AccessibilityChannel.selectTrackByNameViaMenu(name)
+        guard selected else {
+            return .error("Cannot select track '\(name)' — track search failed")
+        }
+
+        // Brief pause so Logic registers the track selection before toggle
+        Thread.sleep(forTimeInterval: 0.1)
+
+        guard let source = CGEventSource(stateID: .hidSystemState),
+              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false) else {
+            return .error("Failed to create CGEvent for \(keyLabel) key")
+        }
+        keyDown.postToPid(pid)
+        keyUp.postToPid(pid)
+
+        return .success("{\"track\":\"\(name)\",\"toggled\":\"\(keyLabel)\",\"via\":\"AX_menu_search\"}")
     }
 
     // MARK: - Tracks

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -40,6 +40,8 @@ actor AccessibilityChannel: Channel {
             return toggleTransportButton(named: "Cycle")
         case "transport.toggle_metronome":
             return toggleTransportButton(named: "Metronome")
+        case "transport.toggle_count_in":
+            return toggleTransportButton(named: "Count In")
         case "transport.set_tempo":
             return setTempo(params: params)
         case "transport.set_cycle_range":
@@ -87,7 +89,7 @@ actor AccessibilityChannel: Channel {
 
         // MARK: - Navigation
         case "nav.get_markers":
-            return .error("Marker reading not yet implemented via AX")
+            return getMarkers()
         case "nav.rename_marker":
             return .error("Marker renaming not yet implemented via AX")
 
@@ -130,6 +132,71 @@ actor AccessibilityChannel: Channel {
         return .healthy(detail: "AX connected to Logic Pro")
     }
 
+    // MARK: - Direct synchronous AX reads (for ResourceHandlers one-shot queries)
+
+    /// Directly read transport state from AX (bypasses cache).
+    func readTransportStateDirect() -> TransportState? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        guard let transport = AXLogicProElements.getTransportBar() else { return nil }
+        return AXValueExtractors.extractTransportState(from: transport)
+    }
+
+    /// Directly read all tracks from AX (bypasses cache).
+    func readTracksDirect() -> [TrackState]? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        let headers = AXLogicProElements.allTrackHeaders()
+        guard !headers.isEmpty else { return nil }
+        return headers.enumerated().map { (index, header) in
+            AXValueExtractors.extractTrackState(from: header, index: index)
+        }
+    }
+
+    /// Directly read all channel strips from AX (bypasses cache).
+    func readMixerDirect() -> [ChannelStripState]? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        guard let mixer = AXLogicProElements.getMixerArea() else { return nil }
+        let strips = AXHelpers.getChildren(mixer)
+        guard !strips.isEmpty else { return nil }
+        return strips.enumerated().map { (index, strip) in
+            let sliders = AXHelpers.findAllDescendants(of: strip, role: kAXSliderRole, maxDepth: 4)
+            let volume = sliders.first.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0
+            let pan = sliders.count > 1
+                ? AXValueExtractors.extractSliderValue(sliders[1]) ?? 0.0
+                : 0.0
+            return ChannelStripState(trackIndex: index, volume: volume, pan: pan)
+        }
+    }
+
+    /// Directly read project info from AX (bypasses cache).
+    func readProjectInfoDirect() -> ProjectInfo? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        guard let window = AXLogicProElements.mainWindow() else { return nil }
+        let rawTitle = AXHelpers.getTitle(window) ?? ""
+        var info = ProjectInfo()
+        // Window title is typically "<project name> - Logic Pro"
+        if let dashRange = rawTitle.range(of: " - Logic Pro") {
+            info.name = String(rawTitle[rawTitle.startIndex..<dashRange.lowerBound])
+        } else if rawTitle.contains("Logic Pro") {
+            info.name = "Untitled"
+        } else {
+            info.name = rawTitle.isEmpty ? "Untitled" : rawTitle
+        }
+        // Attempt to read tempo + time signature from transport bar
+        if let transport = AXLogicProElements.getTransportBar() {
+            let state = AXValueExtractors.extractTransportState(from: transport)
+            info.tempo = state.tempo
+            info.sampleRate = state.sampleRate
+        }
+        info.lastUpdated = Date()
+        return info
+    }
+
+    /// Directly read all arrangement markers from AX (bypasses cache).
+    func readMarkersDirect() -> [MarkerState]? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        return AXValueExtractors.extractMarkers()
+    }
+
     // MARK: - Transport
 
     private func getTransportState() -> ChannelResult {
@@ -151,7 +218,7 @@ actor AccessibilityChannel: Channel {
     }
 
     private func setTempo(params: [String: String]) -> ChannelResult {
-        guard let tempoStr = params["tempo"], let _ = Double(tempoStr) else {
+        guard let tempoStr = params["tempo"] ?? params["bpm"], let _ = Double(tempoStr) else {
             return .error("Missing or invalid 'tempo' parameter")
         }
         guard let transport = AXLogicProElements.getTransportBar() else {
@@ -323,9 +390,22 @@ actor AccessibilityChannel: Channel {
         return .success("{\"\(label)\":\(value),\"track\":\(index)}")
     }
 
+    // MARK: - Markers
+
+    private func getMarkers() -> ChannelResult {
+        let markers = AXValueExtractors.extractMarkers()
+        if markers.isEmpty {
+            return .error("No markers found — is a project with markers open?")
+        }
+        return encodeResult(markers)
+    }
+
     // MARK: - Project
 
     private func getProjectInfo() -> ChannelResult {
+        if let info = readProjectInfoDirect() {
+            return encodeResult(info)
+        }
         guard let window = AXLogicProElements.mainWindow() else {
             return .error("Cannot locate Logic Pro main window")
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -264,11 +264,75 @@ actor AccessibilityChannel: Channel {
     }
 
     private func setCycleRange(params: [String: String]) -> ChannelResult {
-        // Cycle range setting via AX is fragile — requires locating the cycle locators
-        guard let _ = params["start"], let _ = params["end"] else {
+        guard let startStr = params["start"], let endStr = params["end"] else {
             return .error("Missing 'start' and/or 'end' parameters")
         }
-        return .error("Cycle range setting not yet fully implemented via AX")
+
+        // Strategy 1: Find the cycle locator text fields in the transport bar via AX.
+        // When Cycle mode is enabled, Logic Pro exposes the left/right locator as
+        // editable fields. We look for them by description keywords.
+        if let transport = AXLogicProElements.getTransportBar() {
+            let allFields = AXHelpers.findAllDescendants(of: transport, role: kAXTextFieldRole, maxDepth: 5)
+            var leftField: AXUIElement? = nil
+            var rightField: AXUIElement? = nil
+
+            for field in allFields {
+                let desc = (AXHelpers.getDescription(field) ?? AXHelpers.getTitle(field) ?? "").lowercased()
+                if desc.contains("left") || desc.contains("locator") && leftField == nil {
+                    leftField = field
+                } else if desc.contains("right") || (desc.contains("locator") && leftField != nil) {
+                    rightField = field
+                }
+            }
+
+            // If we found at least one of the locator fields, try setting them
+            if leftField != nil || rightField != nil {
+                if let lf = leftField {
+                    AXHelpers.setAttribute(lf, kAXValueAttribute, startStr as CFTypeRef)
+                    AXHelpers.performAction(lf, kAXConfirmAction)
+                }
+                if let rf = rightField {
+                    AXHelpers.setAttribute(rf, kAXValueAttribute, endStr as CFTypeRef)
+                    AXHelpers.performAction(rf, kAXConfirmAction)
+                }
+                let set = [leftField != nil ? "left locator → \(startStr)" : nil,
+                           rightField != nil ? "right locator → \(endStr)" : nil]
+                    .compactMap { $0 }.joined(separator: ", ")
+                return .success("{\"cycle_range_set\":\"\(set)\"}")
+            }
+        }
+
+        // Strategy 2: AppleScript via System Events — use key-value coding on Logic's
+        // cycle range properties. Logic Pro supports getting/setting locators via
+        // AppleScript but the property name varies by version.
+        let escapedStart = startStr.replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedEnd = endStr.replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+        tell application "Logic Pro"
+            set left locator to "\(escapedStart)"
+            set right locator to "\(escapedEnd)"
+        end tell
+        """
+        var errorDict: NSDictionary?
+        let appleScript = NSAppleScript(source: script)
+        _ = appleScript?.executeAndReturnError(&errorDict)
+
+        if errorDict == nil {
+            return .success("{\"cycle_range\":{\"start\":\"\(escapedStart)\",\"end\":\"\(escapedEnd)\"},\"via\":\"AppleScript\"}")
+        }
+
+        // Strategy 3: Use System Events key navigation to set cycle start/end.
+        // This is the keyboard approach: user must have cycle enabled.
+        // We cannot reliably type into locator fields without knowing their screen position.
+        // Return an informative error so users know the state of support.
+        let asError = (errorDict?[NSAppleScript.errorMessage] as? String) ?? "unknown"
+        return .error(
+            "Cannot set cycle range automatically. " +
+            "AX: locator fields not found in transport bar (cycle may be disabled). " +
+            "AppleScript: \(asError). " +
+            "To set the cycle range manually: enable Cycle (C), then drag the cycle region in the ruler, " +
+            "or use Logic's Set Locators dialog (Option+click on cycle region)."
+        )
     }
 
     // MARK: - Tracks

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -401,46 +401,35 @@ actor AccessibilityChannel: Channel {
         // Wait for the dialog to appear
         Thread.sleep(forTimeInterval: 0.4)
 
-        // Use clipboard paste — CGEvent unicode typing doesn't work in Logic's search dialog
-        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
-
-        // Put track name on clipboard
+        // Put track name on clipboard, then use osascript for all keystrokes
+        // (CGEvent HID tap is unreliable for Logic's custom search dialog)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(name, forType: .string)
 
-        // Cmd+A to select existing text
-        if let selAll = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
-           let selAllUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
-            selAll.flags = .maskCommand
-            selAllUp.flags = .maskCommand
-            selAll.post(tap: .cghidEventTap)
-            usleep(30_000)
-            selAllUp.post(tap: .cghidEventTap)
+        // Use osascript: Cmd+A (select all), Cmd+V (paste), wait for filter, Return
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        proc.arguments = ["-e", """
+            tell application "System Events"
+                keystroke "a" using {command down}
+                delay 0.1
+                keystroke "v" using {command down}
+                delay 0.4
+                keystroke return
+            end tell
+            """]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            Log.warn("selectTrackByNameViaMenu: osascript paste failed: \(error)", subsystem: "ax")
+            return false
         }
-        Thread.sleep(forTimeInterval: 0.05)
 
-        // Cmd+V to paste
-        if let pasteDown = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: true),
-           let pasteUp = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: false) {
-            pasteDown.flags = .maskCommand
-            pasteUp.flags = .maskCommand
-            pasteDown.post(tap: .cghidEventTap)
-            usleep(30_000)
-            pasteUp.post(tap: .cghidEventTap)
-        }
-
-        Thread.sleep(forTimeInterval: 0.3)
-
-        // Press Return to confirm selection
-        guard let returnDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
-              let returnUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else { return false }
-        returnDown.post(tap: .cghidEventTap)
-        returnUp.post(tap: .cghidEventTap)
-
-        // Wait for search dialog to close. The search dialog returns focus to the arrange
-        // area automatically — no need to click. AppleScript keystroke via System Events
-        // will target the frontmost app (Logic Pro) regardless.
+        // Wait for search dialog to close
         Thread.sleep(forTimeInterval: 0.3)
 
         Thread.sleep(forTimeInterval: 0.15)

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -419,17 +419,107 @@ actor AccessibilityChannel: Channel {
     // MARK: - JSON encoding
 
     private func encodeResult<T: Encodable>(_ value: T) -> ChannelResult {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
         do {
-            let data = try encoder.encode(value)
-            guard let json = String(data: data, encoding: .utf8) else {
-                return .error("Failed to encode result to UTF-8")
-            }
-            return .success(json)
+            let data = try JSONEncoder().encode(value)
+            let str = String(data: data, encoding: .utf8) ?? "{}"
+            return .success(str)
         } catch {
             return .error("JSON encoding failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Bounce Dialog Automation
+
+    /// Best-effort automation of the Logic Pro bounce dialog.
+    ///
+    /// NOTE: This is version-sensitive and may break between Logic updates.
+    ///
+    /// Steps attempted:
+    ///   1. Find a window whose title contains "Bounce" in the Logic Pro AX tree.
+    ///   2. If `destination` is provided, locate a text field and set its value.
+    ///   3. If `clickBounce` is true, find and press the "Bounce" button.
+    ///
+    /// Returns a ChannelResult describing what was done (or why it failed).
+    func completeBounceDialog(destination: String?, clickBounce: Bool) -> ChannelResult {
+        guard AXIsProcessTrusted() else {
+            return .error("Accessibility not trusted — cannot automate bounce dialog")
+        }
+        guard ProcessUtils.isLogicProRunning else {
+            return .error("Logic Pro is not running")
+        }
+
+        // Find the bounce dialog window
+        guard let appRoot = AXLogicProElements.appRoot() else {
+            return .error("Cannot access Logic Pro AX element")
+        }
+
+        // Walk windows looking for one whose title contains "Bounce"
+        let windows: [AXUIElement] = AXHelpers.getAttribute(appRoot, kAXWindowsAttribute) ?? []
+        var bounceWindow: AXUIElement? = nil
+        for window in windows {
+            let title = AXHelpers.getTitle(window) ?? ""
+            if title.lowercased().contains("bounce") {
+                bounceWindow = window
+                break
+            }
+        }
+
+        // Also try sheets / dialogs attached to the main window
+        if bounceWindow == nil {
+            if let mainWin = AXLogicProElements.mainWindow() {
+                let sheet = AXHelpers.findDescendant(of: mainWin, role: "AXSheet", maxDepth: 3)
+                    ?? AXHelpers.findDescendant(of: mainWin, role: kAXWindowRole, maxDepth: 3)
+                if let s = sheet {
+                    let title = AXHelpers.getTitle(s) ?? ""
+                    if title.lowercased().contains("bounce") || title.isEmpty {
+                        bounceWindow = s
+                    }
+                }
+            }
+        }
+
+        guard let dialog = bounceWindow else {
+            return .error(
+                "Bounce dialog not found. Use bounce_section first to open it, " +
+                "then call bounce_complete. If the dialog is open but this fails, " +
+                "complete the bounce manually — AX dialog detection may differ in this Logic version."
+            )
+        }
+
+        var steps: [String] = []
+
+        // Set destination path if provided
+        if let dest = destination, !dest.isEmpty {
+            // Look for a text field — typical label is "Destination" or similar
+            let textFields = AXHelpers.findAllDescendants(of: dialog, role: kAXTextFieldRole, maxDepth: 6)
+            if let field = textFields.first {
+                AXHelpers.setAttribute(field, kAXValueAttribute, dest as CFTypeRef)
+                AXHelpers.performAction(field, kAXConfirmAction)
+                steps.append("set destination to '\(dest)'")
+            } else {
+                steps.append("WARNING: could not find destination text field")
+            }
+        }
+
+        // Click the Bounce button
+        if clickBounce {
+            // Search for a button titled "Bounce" or "OK" inside the dialog
+            let buttons = AXHelpers.findAllDescendants(of: dialog, role: kAXButtonRole, maxDepth: 6)
+            let bounceBtn = buttons.first(where: {
+                let t = AXHelpers.getTitle($0)?.lowercased() ?? ""
+                return t == "bounce" || t == "ok" || t == "export"
+            })
+            if let btn = bounceBtn {
+                let btnTitle = AXHelpers.getTitle(btn) ?? "?"
+                AXHelpers.performAction(btn, kAXPressAction)
+                steps.append("clicked '\(btnTitle)' button")
+            } else {
+                steps.append("WARNING: could not find Bounce/OK button — complete manually")
+            }
+        }
+
+        let summary = steps.isEmpty ? "Bounce dialog found but no actions taken" : steps.joined(separator: "; ")
+        return .success("bounce_complete: \(summary)")
     }
 }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -197,6 +197,32 @@ actor AccessibilityChannel: Channel {
         return AXValueExtractors.extractMarkers()
     }
 
+    /// Read the FULL track list from the AX arrange window, including nesting depth.
+    ///
+    /// This supplements / overrides the binary-parser results by reading live state:
+    /// name, type (audio/instrument/aux), mute/solo/arm, and nesting depth.
+    ///
+    /// Nesting depth is inferred from the AX element's indentation level or structural
+    /// position in the tree. Logic Pro uses kAXDisclosureLevelAttribute on outline rows,
+    /// or the x-position of the name label as a proxy for depth.
+    func readLiveTracksDirect() -> [LiveTrackInfo]? {
+        guard AXIsProcessTrusted(), ProcessUtils.isLogicProRunning else { return nil }
+        let headers = AXLogicProElements.allTrackHeaders()
+        guard !headers.isEmpty else { return nil }
+
+        return headers.enumerated().map { (index, header) in
+            let track = AXValueExtractors.extractTrackState(from: header, index: index)
+            var live = LiveTrackInfo(index: index, name: track.name, type: track.type)
+            live.isMuted = track.isMuted
+            live.isSoloed = track.isSoloed
+            live.isArmed = track.isArmed
+            live.isSelected = track.isSelected
+            live.outputRouting = track.outputRouting
+            live.nestingDepth = AXValueExtractors.extractNestingDepth(from: header)
+            return live
+        }
+    }
+
     // MARK: - Transport
 
     private func getTransportState() -> ChannelResult {

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -45,6 +45,7 @@ actor CGEventChannel: Channel {
         "transport.fast_forward":     .key(124),        // Right arrow
         "transport.toggle_cycle":     .key(8),          // C
         "transport.toggle_metronome": .key(40),         // K
+        "transport.toggle_count_in":  .key(39),         // ' (apostrophe — Logic default for Count In)
         "transport.goto_position":    .key(47),         // / (opens Go To Position)
 
         // Editing
@@ -69,6 +70,8 @@ actor CGEventChannel: Channel {
         "project.save":               .cmd(1),          // Cmd+S
         "project.save_as":            .cmdShift(1),     // Cmd+Shift+S
         "project.close":              .cmd(13),         // Cmd+W
+        "project.bounce":             .cmd(11),         // Cmd+B
+        "project.bounce_section":     .cmd(11),         // Cmd+B (bounce dialog)
 
         // Track creation
         "track.create_audio":         .cmdOption(0),    // Option+Cmd+A (approximate)

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -108,6 +108,20 @@ actor CGEventChannel: Channel {
             return .error("Logic Pro is not running")
         }
 
+        // Special multi-step operations that can't be handled by the flat keyMap
+        switch operation {
+        case "track.select":
+            return selectTrackByIndex(params: params, pid: pid)
+        case "track.set_mute":
+            return setTrackToggle(params: params, pid: pid, key: 46)   // M
+        case "track.set_solo":
+            return setTrackToggle(params: params, pid: pid, key: 1)    // S
+        case "track.set_arm":
+            return setTrackToggle(params: params, pid: pid, key: 15)   // R
+        default:
+            break
+        }
+
         guard let shortcut = Self.keyMap[operation] else {
             return .error("No keyboard shortcut mapped for: \(operation)")
         }
@@ -130,7 +144,64 @@ actor CGEventChannel: Channel {
         return .healthy(detail: "CGEvent ready")
     }
 
-    // MARK: - Event Posting
+    // MARK: - Track Selection & Toggle via Keyboard
+
+    /// Select a track by index using keyboard navigation.
+    ///
+    /// Logic Pro lets you navigate tracks with Up/Down arrow keys. This selects
+    /// the track at `index` by first pressing Cmd+Up (go to first track) and
+    /// then pressing Down `index` times.
+    ///
+    /// Key codes: Up=126, Down=125, Cmd+Up=first track (Logic shortcut).
+    private func selectTrackByIndex(params: [String: String], pid: pid_t) -> ChannelResult {
+        guard let indexStr = params["index"], let index = Int(indexStr), index >= 0 else {
+            return .error("Missing or invalid 'index' parameter for track.select")
+        }
+
+        // Cmd+Up navigates to the first (top) track in Logic Pro
+        _ = postKeyEvent(keyCode: 126, flags: .maskCommand, pid: pid)
+        // Small delay to allow Logic to process the navigation
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // Press Down arrow `index` times to reach the desired track
+        for _ in 0..<index {
+            _ = postKeyEvent(keyCode: 125, flags: [], pid: pid)
+        }
+
+        return .success("{\"selected\":\(index),\"via\":\"cgEvent\"}")
+    }
+
+    /// Select a track by index and then toggle mute/solo/arm via the corresponding key.
+    ///
+    /// - Parameters:
+    ///   - key: Key code for M (mute=46), S (solo=1), or R (arm=15).
+    private func setTrackToggle(params: [String: String], pid: pid_t, key: CGKeyCode) -> ChannelResult {
+        guard let indexStr = params["index"], let index = Int(indexStr), index >= 0 else {
+            return .error("Missing or invalid 'index' parameter")
+        }
+
+        // First navigate to the track
+        let selectResult = selectTrackByIndex(params: params, pid: pid)
+        guard selectResult.isSuccess else { return selectResult }
+
+        // Brief pause so Logic registers the track selection before we toggle
+        Thread.sleep(forTimeInterval: 0.08)
+
+        // Press the toggle key
+        let toggled = postKeyEvent(keyCode: key, flags: [], pid: pid)
+        guard toggled else {
+            return .error("Failed to post toggle key \(key) to Logic Pro")
+        }
+
+        let keyName: String
+        switch key {
+        case 46: keyName = "Mute"
+        case 1:  keyName = "Solo"
+        case 15: keyName = "Arm"
+        default: keyName = "Key\(key)"
+        }
+        return .success("{\"track\":\(index),\"toggled\":\"\(keyName)\",\"via\":\"cgEvent\"}")
+    }
 
     /// Post a key-down/key-up pair to a specific PID.
     private func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, pid: pid_t) -> Bool {

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -219,10 +219,15 @@ actor CGEventChannel: Channel {
         keyDown.flags = flags
         keyUp.flags = flags
 
-        keyDown.postToPid(pid)
-        keyUp.postToPid(pid)
+        // Post to HID system tap (mimics physical keyboard) rather than postToPid.
+        // postToPid bypasses the window focus chain, so focus-dependent shortcuts
+        // like S (solo), M (mute), C (cycle) don't work. HID posting goes through
+        // the normal event dispatch and reaches the focused responder.
+        keyDown.post(tap: .cghidEventTap)
+        usleep(50_000) // 50ms between key down and up for reliability
+        keyUp.post(tap: .cghidEventTap)
 
-        Log.debug("Posted key \(keyCode) flags \(flags.rawValue) to PID \(pid)", subsystem: "cgEvent")
+        Log.debug("Posted key \(keyCode) flags \(flags.rawValue) via HID tap", subsystem: "cgEvent")
         return true
     }
 }

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -24,7 +24,7 @@ actor ChannelRouter {
         "transport.set_tempo":        [.osc, .accessibility],
         "transport.get_state":        [.accessibility],
         "transport.goto_position":    [.coreMIDI, .cgEvent],
-        "transport.set_cycle_range":  [.accessibility],
+        "transport.set_cycle_range":  [.accessibility, .appleScript],
 
         // Track state reading
         "track.get_tracks":           [.accessibility],

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -25,6 +25,7 @@ actor ChannelRouter {
         "transport.get_state":        [.accessibility],
         "transport.goto_position":    [.coreMIDI, .cgEvent],
         "transport.set_cycle_range":  [.accessibility, .appleScript],
+        "transport.set_cycle_range_by_selection": [.accessibility],
 
         // Track state reading
         "track.get_tracks":           [.accessibility],
@@ -141,6 +142,9 @@ actor ChannelRouter {
         "automation.set_mode":        [.accessibility, .cgEvent],
         "automation.toggle_view":     [.cgEvent, .accessibility],
         "automation.get_parameter":   [.accessibility],
+
+        // AX Menu operations — direct menu navigation
+        "menu.click":                 [.accessibility],
 
         // System — no channel needed
         "system.health":              [],

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -20,6 +20,7 @@ actor ChannelRouter {
         "transport.fast_forward":     [.cgEvent, .coreMIDI],
         "transport.toggle_cycle":     [.cgEvent, .accessibility],
         "transport.toggle_metronome": [.cgEvent, .accessibility],
+        "transport.toggle_count_in":  [.cgEvent, .accessibility],
         "transport.set_tempo":        [.osc, .accessibility],
         "transport.get_state":        [.accessibility],
         "transport.goto_position":    [.coreMIDI, .cgEvent],
@@ -84,6 +85,7 @@ actor ChannelRouter {
         "nav.delete_marker":          [.cgEvent, .accessibility],
         "nav.rename_marker":          [.accessibility],
         "nav.get_markers":            [.accessibility],
+        "nav.list_markers":           [.accessibility],
         "nav.zoom_to_fit":            [.cgEvent],
         "nav.set_zoom_level":         [.cgEvent],
 
@@ -109,6 +111,7 @@ actor ChannelRouter {
         "project.close":              [.cgEvent, .appleScript],
         "project.get_info":           [.accessibility],
         "project.bounce":             [.cgEvent, .accessibility],
+        "project.bounce_section":     [.cgEvent, .accessibility],
         "project.is_running":         [],  // No channel needed — pure process check
 
         // Views — keyboard toggle
@@ -171,6 +174,17 @@ actor ChannelRouter {
 
     // MARK: - Routing
 
+    /// Operations that route through CoreMIDI/MMC where silent failure is possible.
+    /// When these succeed via CoreMIDI, a warning note is appended to the result.
+    private static let mmcOperations: Set<String> = [
+        "transport.play", "transport.stop", "transport.record", "transport.pause",
+        "transport.rewind", "transport.fast_forward", "transport.goto_position",
+        "mmc.play", "mmc.stop", "mmc.record_strobe", "mmc.record_exit",
+        "mmc.locate", "mmc.pause",
+    ]
+
+    private static let mmcWarning = " (Note: sent via CoreMIDI/MMC — if Logic Pro is not configured to receive MMC, this may not have had effect. Enable in Logic Pro > Preferences > MIDI > Sync > MMC Input)"
+
     /// Route an operation through its fallback chain.
     /// Returns the result from the first channel that succeeds.
     func route(operation: String, params: [String: String] = [:]) async -> ChannelResult {
@@ -200,8 +214,12 @@ actor ChannelRouter {
 
             let result = await channel.execute(operation: operation, params: params)
             switch result {
-            case .success:
+            case .success(let msg):
                 Log.debug("\(operation) succeeded via \(channelID.rawValue)", subsystem: "router")
+                // Append MMC warning when the successful channel is CoreMIDI for transport ops
+                if channelID == .coreMIDI && Self.mmcOperations.contains(operation) {
+                    return .success(msg + Self.mmcWarning)
+                }
                 return result
             case .error(let msg):
                 Log.debug("\(operation) failed via \(channelID.rawValue): \(msg), trying next", subsystem: "router")

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -11,13 +11,13 @@ actor ChannelRouter {
     /// Static routing table: operation → ordered list of channels to try.
     /// Operations are prefixed by category (e.g., "transport.play", "track.mute").
     private static let routingTable: [String: [ChannelID]] = [
-        // Transport — MMC via CoreMIDI, fallback to keyboard, then AppleScript
-        "transport.play":             [.coreMIDI, .cgEvent, .appleScript],
-        "transport.stop":             [.coreMIDI, .cgEvent, .appleScript],
-        "transport.record":           [.coreMIDI, .cgEvent, .appleScript],
-        "transport.pause":            [.coreMIDI, .cgEvent, .appleScript],
-        "transport.rewind":           [.coreMIDI, .cgEvent],
-        "transport.fast_forward":     [.coreMIDI, .cgEvent],
+        // Transport — CGEvent (keyboard) primary, MMC fallback, then AppleScript
+        "transport.play":             [.cgEvent, .coreMIDI, .appleScript],
+        "transport.stop":             [.cgEvent, .coreMIDI, .appleScript],
+        "transport.record":           [.cgEvent, .coreMIDI, .appleScript],
+        "transport.pause":            [.cgEvent, .coreMIDI, .appleScript],
+        "transport.rewind":           [.cgEvent, .coreMIDI],
+        "transport.fast_forward":     [.cgEvent, .coreMIDI],
         "transport.toggle_cycle":     [.cgEvent, .accessibility],
         "transport.toggle_metronome": [.cgEvent, .accessibility],
         "transport.set_tempo":        [.osc, .accessibility],

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -83,7 +83,19 @@ struct NavigateDispatcher {
             return CallTool.Result(content: [.text("goto_marker requires 'index' or 'name' param")], isError: true)
 
         case "list_markers":
-            // Direct AX read for freshness, fall back to cache.
+            // Try binary parser first for richer data (bar, tick, duration).
+            if let projectPath = currentLogicProProjectPath(),
+               let parsed = ProjectDataParser.parse(path: projectPath),
+               !parsed.markers.isEmpty {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = .prettyPrinted
+                if let data = try? encoder.encode(parsed.markers),
+                   let json = String(data: data, encoding: .utf8) {
+                    return CallTool.Result(content: [.text(json)], isError: false)
+                }
+            }
+
+            // Fall back to direct AX read, then cache.
             let markers: [MarkerState]
             if let ax = axChannel, let live = await ax.readMarkersDirect() {
                 await cache.updateMarkers(live)

--- a/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/NavigateDispatcher.swift
@@ -7,13 +7,14 @@ struct NavigateDispatcher {
         description: """
             Navigation and markers in Logic Pro. \
             Commands: goto_bar, goto_marker, create_marker, delete_marker, \
-            rename_marker, zoom_to_fit, set_zoom, toggle_view. \
+            rename_marker, list_markers, zoom_to_fit, set_zoom, toggle_view. \
             Params by command: \
             goto_bar -> { bar: Int }; \
             goto_marker -> { index: Int } or { name: String }; \
             create_marker -> { name: String } (at current playhead); \
             rename_marker -> { index: Int, name: String }; \
             delete_marker -> { index: Int }; \
+            list_markers -> {} (returns all markers with name and bar position); \
             set_zoom -> { level: String } ("in", "out", "fit"); \
             toggle_view -> { view: String } ("mixer", "piano_roll", "score", \
             "step_editor", "library", "inspector", "automation")
@@ -38,7 +39,8 @@ struct NavigateDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        axChannel: AccessibilityChannel? = nil
     ) async -> CallTool.Result {
         switch command {
         case "goto_bar":
@@ -58,7 +60,14 @@ struct NavigateDispatcher {
                 return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
             }
             if let name = params["name"]?.stringValue {
-                let markers = await cache.getMarkers()
+                // Prefer a fresh AX read so name-based lookup works in one-shot mode.
+                let markers: [MarkerState]
+                if let ax = axChannel, let live = await ax.readMarkersDirect() {
+                    await cache.updateMarkers(live)
+                    markers = live
+                } else {
+                    markers = await cache.getMarkers()
+                }
                 if let marker = markers.first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
                     let result = await router.route(
                         operation: "nav.goto_marker",
@@ -66,9 +75,35 @@ struct NavigateDispatcher {
                     )
                     return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
                 }
-                return CallTool.Result(content: [.text("No marker found matching '\(name)'")], isError: true)
+                return CallTool.Result(
+                    content: [.text("No marker found matching '\(name)'. Use list_markers to see available markers.")],
+                    isError: true
+                )
             }
             return CallTool.Result(content: [.text("goto_marker requires 'index' or 'name' param")], isError: true)
+
+        case "list_markers":
+            // Direct AX read for freshness, fall back to cache.
+            let markers: [MarkerState]
+            if let ax = axChannel, let live = await ax.readMarkersDirect() {
+                await cache.updateMarkers(live)
+                markers = live
+            } else {
+                markers = await cache.getMarkers()
+            }
+            if markers.isEmpty {
+                return CallTool.Result(
+                    content: [.text("{\"markers\":[],\"note\":\"No markers found — is a project with markers open?\"}")],
+                    isError: false
+                )
+            }
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            if let data = try? encoder.encode(markers),
+               let json = String(data: data, encoding: .utf8) {
+                return CallTool.Result(content: [.text(json)], isError: false)
+            }
+            return CallTool.Result(content: [.text("Failed to encode markers")], isError: true)
 
         case "create_marker":
             let name = params["name"]?.stringValue ?? "Marker"
@@ -148,7 +183,7 @@ struct NavigateDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown navigate command: \(command). Available: goto_bar, goto_marker, create_marker, delete_marker, rename_marker, zoom_to_fit, set_zoom, toggle_view")],
+                content: [.text("Unknown navigate command: \(command). Available: goto_bar, goto_marker, create_marker, delete_marker, rename_marker, list_markers, zoom_to_fit, set_zoom, toggle_view")],
                 isError: true
             )
         }

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -7,7 +7,7 @@ struct ProjectDispatcher {
         description: """
             Project lifecycle in Logic Pro. \
             Commands: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, \
-            tracks_hierarchy, bounce_stems, launch, quit, analyze. \
+            tracks_hierarchy, bounce_stems, song_lengths, launch, quit, analyze. \
             Params by command: \
             open -> { path: String }; \
             save_as -> { path: String }; \
@@ -18,7 +18,9 @@ struct ProjectDispatcher {
             (best-effort AX automation of the open bounce dialog: set path, click Bounce); \
             tracks_hierarchy -> { path: String? } (full track tree with stacks and function groups); \
             bounce_stems -> { path: String?, marker_name: String?, start_bar: Int?, end_bar: Int?, \
-            groups: [String]?, execute: Bool? } (plan or execute per-group stem bounces); \
+            groups: [String]?, use_reference_lengths: Bool?, execute: Bool? } \
+            (plan or execute per-group stem bounces; use_reference_lengths defaults true); \
+            song_lengths -> { path: String? } (per-song lengths from reference track or marker boundaries); \
             analyze -> { path: String? } (parse ProjectData binary; defaults to current project); \
             launch/quit -> {} (app lifecycle); \
             Others -> {}
@@ -92,10 +94,13 @@ struct ProjectDispatcher {
             return analyzeProject(params: params)
 
         case "tracks_hierarchy":
-            return tracksHierarchy(params: params)
+            return await tracksHierarchy(params: params, axChannel: axChannel)
 
         case "bounce_stems":
             return await bounceStems(params: params, router: router, cache: cache, axChannel: axChannel)
+
+        case "song_lengths":
+            return songLengths(params: params)
 
         case "bounce_complete":
             return await bounceComplete(params: params, axChannel: axChannel)
@@ -134,7 +139,7 @@ struct ProjectDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, tracks_hierarchy, bounce_stems, analyze, launch, quit")],
+                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, tracks_hierarchy, bounce_stems, song_lengths, analyze, launch, quit")],
                 isError: true
             )
         }
@@ -143,7 +148,10 @@ struct ProjectDispatcher {
     // MARK: - tracks_hierarchy
 
     /// Return the full track tree with stacks, children, and function groups.
-    private static func tracksHierarchy(params: [String: Value]) -> CallTool.Result {
+    private static func tracksHierarchy(
+        params: [String: Value],
+        axChannel: AccessibilityChannel?
+    ) async -> CallTool.Result {
         let path: String?
         if let explicit = params["path"]?.stringValue, !explicit.isEmpty {
             path = explicit
@@ -163,6 +171,23 @@ struct ProjectDispatcher {
                 content: [.text("tracks_hierarchy: failed to parse ProjectData at '\(projectPath)'.")],
                 isError: true
             )
+        }
+
+        // Read live tracks from AX (if Logic is open) for the track index map
+        let liveTracks: [LiveTrackInfo]?
+        if let ax = axChannel {
+            liveTracks = await ax.readLiveTracksDirect()
+        } else {
+            liveTracks = nil
+        }
+
+        // Build Envi name → AX track index map (only when live tracks are available)
+        let trackIndexMap: [String: Int]?
+        if let live = liveTracks, !live.isEmpty {
+            let enviNames = info.environmentLabels
+            trackIndexMap = ProjectDataParser.buildTrackIndexMap(enviNames: enviNames, liveTracks: live)
+        } else {
+            trackIndexMap = nil
         }
 
         // --- Section 1: MSeq-level arrangement tracks (existing) ---
@@ -227,7 +252,7 @@ struct ProjectDispatcher {
         let namedStrips = info.channelStrips.filter { !$0.isGeneric }.count
         let envLabels = info.environmentLabels
 
-        let result: [String: Any] = [
+        var result: [String: Any] = [
             "project": info.projectName,
             "mseqTrackCount": tracks.count,
             "channelStripCount": totalStrips,
@@ -240,6 +265,11 @@ struct ProjectDispatcher {
             ],
             "subTrackHierarchy": subHierarchy,
         ]
+
+        // Include trackIndexMap when live tracks are available
+        if let indexMap = trackIndexMap, !indexMap.isEmpty {
+            result["trackIndexMap"] = indexMap
+        }
 
         guard let jsonData = try? JSONSerialization.data(
             withJSONObject: result,
@@ -259,6 +289,7 @@ struct ProjectDispatcher {
     ///   - path: .logicx path (optional, auto-detected if omitted)
     ///   - marker_name / start_bar + end_bar: section to bounce
     ///   - groups: array of function group / stack names to include (nil = all)
+    ///   - use_reference_lengths: Bool (default true) — use reference track region length for the song
     ///   - execute: Bool (default false) — when true, solo + bounce each group
     private static func bounceStems(
         params: [String: Value],
@@ -287,9 +318,32 @@ struct ProjectDispatcher {
             )
         }
 
+        // --- Read live tracks from AX (for track index mapping) ---
+        let liveTracks: [LiveTrackInfo]?
+        if let ax = axChannel {
+            liveTracks = await ax.readLiveTracksDirect()
+        } else {
+            liveTracks = nil
+        }
+
+        // Build Envi name → AX track index map
+        let trackIndexMap: [String: Int]
+        if let live = liveTracks, !live.isEmpty {
+            trackIndexMap = ProjectDataParser.buildTrackIndexMap(
+                enviNames: info.environmentLabels,
+                liveTracks: live
+            )
+        } else {
+            trackIndexMap = [:]
+        }
+
         // --- Resolve section bars ---
+        let useReferenceLengths = params["use_reference_lengths"]?.boolValue ?? true
+
         var startBar: Int
         var endBar: Int
+        var markerEndBar: Int   // marker-to-marker boundary (always computed)
+        var referenceLength: [String: Any]? = nil
 
         if let markerName = params["marker_name"]?.stringValue {
             let sorted = info.markers.sorted { $0.bar < $1.bar }
@@ -301,16 +355,34 @@ struct ProjectDispatcher {
             }
             startBar = target.bar
             if let next = sorted.first(where: { $0.bar > startBar }) {
-                endBar = next.bar
+                markerEndBar = next.bar
             } else {
-                endBar = startBar + target.durationBars
+                markerEndBar = startBar + target.durationBars
+            }
+
+            // Look for a reference-track-derived song length
+            if useReferenceLengths,
+               let songLen = info.songLengths.first(where: { $0.songName.localizedCaseInsensitiveContains(markerName) })
+            {
+                endBar = songLen.endBar
+                referenceLength = [
+                    "startBar": songLen.startBar,
+                    "endBar": songLen.endBar,
+                    "lengthBars": songLen.lengthBars,
+                    "source": songLen.source,
+                ]
+            } else {
+                endBar = markerEndBar
             }
         } else if let sb = params["start_bar"]?.intValue, let eb = params["end_bar"]?.intValue {
-            startBar = sb; endBar = eb
+            startBar = sb
+            endBar = eb
+            markerEndBar = eb
         } else {
             // Default: full project (bar 1 to last marker end)
             startBar = 1
-            endBar = (info.markers.map { $0.bar + $0.durationBars }.max() ?? 9) + 1
+            markerEndBar = (info.markers.map { $0.bar + $0.durationBars }.max() ?? 9) + 1
+            endBar = markerEndBar
         }
 
         // --- Build stem groups from sub-track hierarchy (channel strips) ---
@@ -327,7 +399,7 @@ struct ProjectDispatcher {
         var groups: [[String: Any]] = []
 
         if !info.subTrackHierarchy.isEmpty {
-            // Channel-strip-based groups (the full 449 sub-tracks)
+            // Channel-strip-based groups (the full sub-tracks)
             for stack in info.subTrackHierarchy {
                 if let requested = requestedGroups, !requested.contains(stack.name) { continue }
 
@@ -335,13 +407,29 @@ struct ProjectDispatcher {
                 let meaningfulStrips = stack.strips.filter { !$0.isGeneric }
                 if meaningfulStrips.isEmpty { continue }
 
-                groups.append([
+                // Build strip info including AX track indices
+                let stripNodes: [[String: Any]] = meaningfulStrips.map { strip -> [String: Any] in
+                    var node: [String: Any] = ["name": strip.name]
+                    if let axIdx = trackIndexMap[strip.name] {
+                        node["trackIndex"] = axIdx
+                    }
+                    return node
+                }
+
+                var groupEntry: [String: Any] = [
                     "name": stack.name,
                     "source": stack.source,
                     "stripOids": meaningfulStrips.map { $0.oid },
                     "stripNames": meaningfulStrips.map { $0.name },
                     "mseqOids": Array(Set(meaningfulStrips.compactMap { $0.mseqOid })).sorted(),
-                ])
+                    "strips": stripNodes,
+                ]
+                // Collect AX indices for all strips in this group
+                let groupAxIndices = meaningfulStrips.compactMap { trackIndexMap[$0.name] }
+                if !groupAxIndices.isEmpty {
+                    groupEntry["trackIndices"] = groupAxIndices.sorted()
+                }
+                groups.append(groupEntry)
             }
         } else {
             // Fallback: group MSeq tracks by function group (legacy behaviour)
@@ -353,23 +441,51 @@ struct ProjectDispatcher {
             }
             for groupName in groupMap.keys.sorted() {
                 let members = groupMap[groupName]!
+                let stripNodes: [[String: Any]] = members.map { track -> [String: Any] in
+                    var node: [String: Any] = ["name": track.name]
+                    if let axIdx = trackIndexMap[track.name] {
+                        node["trackIndex"] = axIdx
+                    }
+                    return node
+                }
                 groups.append([
                     "name": groupName,
                     "source": "function_group_mseq",
                     "stripOids": members.map { $0.oid },
                     "stripNames": members.map { $0.name },
                     "mseqOids": members.map { $0.oid },
+                    "strips": stripNodes,
                 ])
             }
         }
 
-        let plan: [String: Any] = [
+        // --- Build plan ---
+        var plan: [String: Any] = [
             "song": info.projectName,
             "bars": [startBar, endBar],
+            "markerBars": [startBar, markerEndBar],
             "channelStripCount": info.channelStrips.count,
             "namedStrips": info.channelStrips.filter { !$0.isGeneric }.count,
             "groups": groups,
         ]
+
+        if let refLen = referenceLength {
+            plan["referenceLength"] = refLen
+        }
+
+        // Include per-song lengths table
+        if !info.songLengths.isEmpty {
+            let songLengthsJson = info.songLengths.map { sl -> [String: Any] in
+                return [
+                    "songName": sl.songName,
+                    "startBar": sl.startBar,
+                    "endBar": sl.endBar,
+                    "lengthBars": sl.lengthBars,
+                    "source": sl.source,
+                ]
+            }
+            plan["songLengths"] = songLengthsJson
+        }
 
         let execute = params["execute"]?.boolValue ?? false
         guard execute else {
@@ -399,25 +515,41 @@ struct ProjectDispatcher {
         _ = await router.route(operation: "transport.toggle_cycle")
 
         for group in groups {
-            guard let groupName = group["name"] as? String,
-                  let oids = group["stripOids"] as? [Int],
-                  let names = group["stripNames"] as? [String] else { continue }
-
+            guard let groupName = group["name"] as? String else { continue }
+            let names = group["stripNames"] as? [String] ?? []
             log.append("  Group '\(groupName)': \(names.joined(separator: ", "))")
 
-            // Solo tracks by index — use MSeq track indices where available,
-            // falling back to position in the public tracks array for OID proximity
+            // Prefer AX track indices from the live track index map
             var soloedIndices: [Int] = []
-            let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
-            for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
-                let soloResult = await router.route(
-                    operation: "track.set_solo",
-                    params: ["index": "\(trackIdx)", "enabled": "true"]
-                )
-                if soloResult.isSuccess {
-                    soloedIndices.append(trackIdx)
-                } else {
-                    log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
+            let groupAxIndices = group["trackIndices"] as? [Int] ?? []
+
+            if !groupAxIndices.isEmpty {
+                // Solo by AX index
+                for axIdx in groupAxIndices {
+                    let soloResult = await router.route(
+                        operation: "track.set_solo",
+                        params: ["index": "\(axIdx)", "enabled": "true"]
+                    )
+                    if soloResult.isSuccess {
+                        soloedIndices.append(axIdx)
+                    } else {
+                        log.append("    WARNING: solo AX track \(axIdx) failed: \(soloResult.message)")
+                    }
+                }
+            } else {
+                // Fallback: solo by MSeq position in info.tracks
+                let oids = group["stripOids"] as? [Int] ?? []
+                let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
+                for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
+                    let soloResult = await router.route(
+                        operation: "track.set_solo",
+                        params: ["index": "\(trackIdx)", "enabled": "true"]
+                    )
+                    if soloResult.isSuccess {
+                        soloedIndices.append(trackIdx)
+                    } else {
+                        log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
+                    }
                 }
             }
 
@@ -435,6 +567,57 @@ struct ProjectDispatcher {
         }
 
         return CallTool.Result(content: [.text(log.joined(separator: "\n"))], isError: false)
+    }
+
+    // MARK: - song_lengths
+
+    /// Return per-song lengths derived from the reference track regions (or marker boundaries).
+    private static func songLengths(params: [String: Value]) -> CallTool.Result {
+        let path: String?
+        if let explicit = params["path"]?.stringValue, !explicit.isEmpty {
+            path = explicit
+        } else {
+            path = currentLogicProProjectPath()
+        }
+
+        guard let projectPath = path else {
+            return CallTool.Result(
+                content: [.text("song_lengths: could not determine project path. Pass 'path' param or ensure Logic Pro is open.")],
+                isError: true
+            )
+        }
+
+        guard let info = ProjectDataParser.parse(path: projectPath) else {
+            return CallTool.Result(
+                content: [.text("song_lengths: failed to parse ProjectData at '\(projectPath)'.")],
+                isError: true
+            )
+        }
+
+        let songLengthsJson: [[String: Any]] = info.songLengths.map { sl in
+            return [
+                "songName": sl.songName,
+                "startBar": sl.startBar,
+                "endBar": sl.endBar,
+                "lengthBars": sl.lengthBars,
+                "source": sl.source,
+            ]
+        }
+
+        let result: [String: Any] = [
+            "project": info.projectName,
+            "songCount": songLengthsJson.count,
+            "songLengths": songLengthsJson,
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(
+            withJSONObject: result,
+            options: [.prettyPrinted, .sortedKeys]
+        ), let json = String(data: jsonData, encoding: .utf8) else {
+            return CallTool.Result(content: [.text("song_lengths: JSON encoding failed")], isError: true)
+        }
+
+        return CallTool.Result(content: [.text(json)], isError: false)
     }
 
     // MARK: - analyze

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -6,7 +6,8 @@ struct ProjectDispatcher {
         name: "logic_project",
         description: """
             Project lifecycle in Logic Pro. \
-            Commands: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, launch, quit, analyze. \
+            Commands: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, \
+            tracks_hierarchy, bounce_stems, launch, quit, analyze. \
             Params by command: \
             open -> { path: String }; \
             save_as -> { path: String }; \
@@ -15,6 +16,9 @@ struct ProjectDispatcher {
             (sets cycle range to section boundaries, enables cycle, opens bounce dialog); \
             bounce_complete -> { destination: String?, click_bounce: Bool? } \
             (best-effort AX automation of the open bounce dialog: set path, click Bounce); \
+            tracks_hierarchy -> { path: String? } (full track tree with stacks and function groups); \
+            bounce_stems -> { path: String?, marker_name: String?, start_bar: Int?, end_bar: Int?, \
+            groups: [String]?, execute: Bool? } (plan or execute per-group stem bounces); \
             analyze -> { path: String? } (parse ProjectData binary; defaults to current project); \
             launch/quit -> {} (app lifecycle); \
             Others -> {}
@@ -87,6 +91,12 @@ struct ProjectDispatcher {
         case "analyze":
             return analyzeProject(params: params)
 
+        case "tracks_hierarchy":
+            return tracksHierarchy(params: params)
+
+        case "bounce_stems":
+            return await bounceStems(params: params, router: router, cache: cache, axChannel: axChannel)
+
         case "bounce_complete":
             return await bounceComplete(params: params, axChannel: axChannel)
 
@@ -124,10 +134,248 @@ struct ProjectDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, analyze, launch, quit")],
+                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, tracks_hierarchy, bounce_stems, analyze, launch, quit")],
                 isError: true
             )
         }
+    }
+
+    // MARK: - tracks_hierarchy
+
+    /// Return the full track tree with stacks, children, and function groups.
+    private static func tracksHierarchy(params: [String: Value]) -> CallTool.Result {
+        let path: String?
+        if let explicit = params["path"]?.stringValue, !explicit.isEmpty {
+            path = explicit
+        } else {
+            path = currentLogicProProjectPath()
+        }
+
+        guard let projectPath = path else {
+            return CallTool.Result(
+                content: [.text("tracks_hierarchy: could not determine project path. Pass 'path' param or ensure Logic Pro is open.")],
+                isError: true
+            )
+        }
+
+        guard let info = ProjectDataParser.parse(path: projectPath) else {
+            return CallTool.Result(
+                content: [.text("tracks_hierarchy: failed to parse ProjectData at '\(projectPath)'.")],
+                isError: true
+            )
+        }
+
+        // Build OID -> track map for the public tracks array
+        let tracks = info.tracks
+        let oidToTrack: [Int: ParsedTrack] = Dictionary(uniqueKeysWithValues: tracks.map { ($0.oid, $0) })
+
+        // Encode a track node (without full regions list to keep output concise)
+        func encodeNode(_ t: ParsedTrack) -> [String: Any] {
+            var node: [String: Any] = [
+                "name": t.name,
+                "oid": t.oid,
+                "stackDepth": t.stackDepth,
+                "isSummingStack": t.isSummingStack,
+            ]
+            if let fg = t.functionGroup { node["functionGroup"] = fg }
+            if let st = t.stackType { node["stackType"] = st }
+            if let parent = t.parentOid { node["parentOid"] = parent }
+            if !t.childOids.isEmpty {
+                let children = t.childOids.compactMap { oidToTrack[$0] }.map { encodeNode($0) }
+                node["children"] = children
+            }
+            return node
+        }
+
+        // Separate stack roots (has children, no parent in public set) from ungrouped
+        let publicOids = Set(tracks.map { $0.oid })
+        let stacks = tracks.filter { t in
+            !t.childOids.isEmpty && (t.parentOid == nil || !publicOids.contains(t.parentOid!))
+        }.map { encodeNode($0) }
+
+        let ungrouped = tracks.filter { t in
+            t.childOids.isEmpty && (t.parentOid == nil || !publicOids.contains(t.parentOid!))
+        }.map { t -> [String: Any] in
+            var node: [String: Any] = ["name": t.name, "oid": t.oid]
+            if let fg = t.functionGroup { node["functionGroup"] = fg }
+            return node
+        }
+
+        let result: [String: Any] = [
+            "project": info.projectName,
+            "trackCount": tracks.count,
+            "stacks": stacks,
+            "ungrouped": ungrouped,
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(
+            withJSONObject: result,
+            options: [.prettyPrinted, .sortedKeys]
+        ), let json = String(data: jsonData, encoding: .utf8) else {
+            return CallTool.Result(content: [.text("tracks_hierarchy: JSON encoding failed")], isError: true)
+        }
+
+        return CallTool.Result(content: [.text(json)], isError: false)
+    }
+
+    // MARK: - bounce_stems
+
+    /// Plan (or execute) per-function-group stem bounces for a song section.
+    ///
+    /// Params:
+    ///   - path: .logicx path (optional, auto-detected if omitted)
+    ///   - marker_name / start_bar + end_bar: section to bounce
+    ///   - groups: array of function group names to include (nil = all)
+    ///   - execute: Bool (default false) — when true, solo + bounce each group
+    private static func bounceStems(
+        params: [String: Value],
+        router: ChannelRouter,
+        cache: StateCache,
+        axChannel: AccessibilityChannel?
+    ) async -> CallTool.Result {
+        let path: String?
+        if let explicit = params["path"]?.stringValue, !explicit.isEmpty {
+            path = explicit
+        } else {
+            path = currentLogicProProjectPath()
+        }
+
+        guard let projectPath = path else {
+            return CallTool.Result(
+                content: [.text("bounce_stems: could not determine project path.")],
+                isError: true
+            )
+        }
+
+        guard let info = ProjectDataParser.parse(path: projectPath) else {
+            return CallTool.Result(
+                content: [.text("bounce_stems: failed to parse ProjectData at '\(projectPath)'.")],
+                isError: true
+            )
+        }
+
+        // --- Resolve section bars ---
+        var startBar: Int
+        var endBar: Int
+
+        if let markerName = params["marker_name"]?.stringValue {
+            let sorted = info.markers.sorted { $0.bar < $1.bar }
+            guard let target = sorted.first(where: { $0.name.localizedCaseInsensitiveContains(markerName) }) else {
+                return CallTool.Result(
+                    content: [.text("bounce_stems: no marker matching '\(markerName)'.")],
+                    isError: true
+                )
+            }
+            startBar = target.bar
+            if let next = sorted.first(where: { $0.bar > startBar }) {
+                endBar = next.bar
+            } else {
+                endBar = startBar + target.durationBars
+            }
+        } else if let sb = params["start_bar"]?.intValue, let eb = params["end_bar"]?.intValue {
+            startBar = sb; endBar = eb
+        } else {
+            // Default: full project (bar 1 to last marker end)
+            startBar = 1
+            endBar = (info.markers.map { $0.bar + $0.durationBars }.max() ?? 9) + 1
+        }
+
+        // --- Build function group → tracks mapping ---
+        let requestedGroups: Set<String>?
+        if let gArr = params["groups"],
+           case let Value.array(gVals) = gArr {
+            requestedGroups = Set(gVals.compactMap { $0.stringValue })
+        } else {
+            requestedGroups = nil
+        }
+
+        // Group tracks by function group (leaf tracks only — those with regions)
+        var groupMap: [String: [ParsedTrack]] = [:]
+        for track in info.tracks {
+            guard let group = track.functionGroup else { continue }
+            if let requested = requestedGroups, !requested.contains(group) { continue }
+            groupMap[group, default: []].append(track)
+        }
+
+        // Sort groups deterministically
+        let groups = groupMap.keys.sorted().map { groupName -> [String: Any] in
+            let members = groupMap[groupName]!
+            return [
+                "name": groupName,
+                "trackOids": members.map { $0.oid },
+                "trackNames": members.map { $0.name },
+            ]
+        }
+
+        let plan: [String: Any] = [
+            "song": info.projectName,
+            "bars": [startBar, endBar],
+            "groups": groups,
+        ]
+
+        let execute = params["execute"]?.boolValue ?? false
+        guard execute else {
+            // Return plan only
+            guard let jsonData = try? JSONSerialization.data(
+                withJSONObject: plan,
+                options: [.prettyPrinted, .sortedKeys]
+            ), let json = String(data: jsonData, encoding: .utf8) else {
+                return CallTool.Result(content: [.text("bounce_stems: JSON encoding failed")], isError: true)
+            }
+            return CallTool.Result(content: [.text(json)], isError: false)
+        }
+
+        // --- Execute: for each group, solo those tracks → set cycle → bounce → unsolo ---
+        var log: [String] = ["bounce_stems executing for bars \(startBar)–\(endBar):"]
+
+        // Set cycle range first
+        let cycleResult = await router.route(
+            operation: "transport.set_cycle_range",
+            params: ["start": "\(startBar).1.1.1", "end": "\(endBar).1.1.1"]
+        )
+        if !cycleResult.isSuccess {
+            log.append("  WARNING: set cycle range failed: \(cycleResult.message)")
+        } else {
+            log.append("  Cycle set to bars \(startBar)–\(endBar)")
+        }
+        _ = await router.route(operation: "transport.toggle_cycle")
+
+        for group in groups {
+            guard let groupName = group["name"] as? String,
+                  let oids = group["trackOids"] as? [Int],
+                  let names = group["trackNames"] as? [String] else { continue }
+
+            log.append("  Group '\(groupName)': \(names.joined(separator: ", "))")
+
+            // Solo tracks by index (best-effort — AX index may differ from binary OID)
+            // We use the track index in the public tracks array
+            var soloedIndices: [Int] = []
+            for (trackIdx, track) in info.tracks.enumerated() where oids.contains(track.oid) {
+                let soloResult = await router.route(
+                    operation: "track.set_solo",
+                    params: ["index": "\(trackIdx)", "enabled": "true"]
+                )
+                if soloResult.isSuccess {
+                    soloedIndices.append(trackIdx)
+                } else {
+                    log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
+                }
+            }
+
+            // Open bounce dialog
+            let bounceResult = await router.route(operation: "project.bounce_section")
+            log.append("    Bounce dialog: \(bounceResult.message)")
+
+            // Un-solo
+            for idx in soloedIndices {
+                _ = await router.route(
+                    operation: "track.set_solo",
+                    params: ["index": "\(idx)", "enabled": "false"]
+                )
+            }
+        }
+
+        return CallTool.Result(content: [.text(log.joined(separator: "\n"))], isError: false)
     }
 
     // MARK: - analyze

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -515,6 +515,16 @@ struct ProjectDispatcher {
             let stripNames = group["stripNames"] as? [String] ?? []
             log.append("  Group '\(groupName)': \(stripNames.joined(separator: ", "))")
 
+            // Clear ALL solos before starting this group (Ctrl+Option+Cmd+S)
+            let clearProc = Process()
+            clearProc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            clearProc.arguments = ["-e", "tell application \"System Events\" to keystroke \"s\" using {command down, option down, control down}"]
+            clearProc.standardOutput = FileHandle.nullDevice
+            clearProc.standardError = FileHandle.nullDevice
+            try? clearProc.run()
+            clearProc.waitUntilExit()
+            usleep(200_000) // 200ms for Logic to process
+
             var soloedNames: [String] = []
 
             if !stripNames.isEmpty {
@@ -548,27 +558,19 @@ struct ProjectDispatcher {
             let bounceResult = await router.route(operation: "project.bounce_section")
             log.append("    Bounce dialog: \(bounceResult.message)")
 
-            // Un-solo by name: select + osascript keystroke "s" to toggle off
-            for stripName in soloedNames {
-                let reselected = AccessibilityChannel.selectTrackByNameViaMenu(stripName)
-                if reselected {
-                    usleep(150_000) // 150 ms — let Logic register the selection
-                    let proc = Process()
-                    proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-                    proc.arguments = ["-e", "tell application \"System Events\" to keystroke \"s\""]
-                    proc.standardOutput = FileHandle.nullDevice
-                    proc.standardError = FileHandle.nullDevice
-                    do {
-                        try proc.run()
-                        proc.waitUntilExit()
-                    } catch {
-                        log.append("    WARNING: unsolo osascript keystroke failed for '\(stripName)': \(error)")
-                    }
-                } else {
-                    log.append("    WARNING: could not re-select '\(stripName)' to unsolo")
-                }
-            }
+            // Solos will be cleared at the start of the next group iteration
+            // (or after the loop ends — add a final clear below)
         }
+
+        // Final clear all solos after last group
+        let finalClear = Process()
+        finalClear.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        finalClear.arguments = ["-e", "tell application \"System Events\" to keystroke \"s\" using {command down, option down, control down}"]
+        finalClear.standardOutput = FileHandle.nullDevice
+        finalClear.standardError = FileHandle.nullDevice
+        try? finalClear.run()
+        finalClear.waitUntilExit()
+        log.append("  All solos cleared")
 
         return CallTool.Result(content: [.text(log.joined(separator: "\n"))], isError: false)
     }

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -1,4 +1,3 @@
-import CoreGraphics
 import Foundation
 import MCP
 
@@ -503,20 +502,13 @@ struct ProjectDispatcher {
         // --- Execute: for each group, solo those tracks → set cycle → bounce → unsolo ---
         var log: [String] = ["bounce_stems executing for bars \(startBar)–\(endBar):"]
 
-        // Set cycle range first using bar positions
-        let cycleResult = await router.route(
-            operation: "transport.set_cycle_range",
-            params: ["start": "\(startBar).1.1.1", "end": "\(endBar).1.1.1"]
-        )
-        if !cycleResult.isSuccess {
-            log.append("  WARNING: set cycle range failed: \(cycleResult.message)")
-        } else {
+        // Set cycle range using the confirmed-working AX + osascript approach
+        let cycleOk = setCycleRange(startBar: startBar, endBar: endBar)
+        if cycleOk {
             log.append("  Cycle set to bars \(startBar)–\(endBar)")
+        } else {
+            log.append("  WARNING: setCycleRange failed for bars \(startBar)–\(endBar)")
         }
-        _ = await router.route(operation: "transport.toggle_cycle")
-
-        // Determine if we have a pid for CGEvent-based solo toggling
-        let hasPid = ProcessUtils.logicProPID() != nil
 
         for group in groups {
             guard let groupName = group["name"] as? String else { continue }
@@ -524,102 +516,153 @@ struct ProjectDispatcher {
             log.append("  Group '\(groupName)': \(stripNames.joined(separator: ", "))")
 
             var soloedNames: [String] = []
-            var soloedIndices: [Int] = []
 
-            if hasPid && !stripNames.isEmpty {
-                // Prefer name-based selection via Track > Search and Select Track menu
+            if !stripNames.isEmpty {
+                // Solo each track: select by name via menu, then osascript keystroke "s"
                 for stripName in stripNames {
                     let selected = AccessibilityChannel.selectTrackByNameViaMenu(stripName)
                     if selected {
-                        // Post S key via CGEvent to toggle solo on the now-selected track
-                        if let pid = ProcessUtils.logicProPID(),
-                           let source = CGEventSource(stateID: .hidSystemState),
-                           let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
-                           let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
-                            keyDown.post(tap: .cghidEventTap)
-                            keyUp.post(tap: .cghidEventTap)
+                        usleep(150_000) // 150 ms — let Logic register the selection
+                        let proc = Process()
+                        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+                        proc.arguments = ["-e", "tell application \"System Events\" to keystroke \"s\""]
+                        proc.standardOutput = FileHandle.nullDevice
+                        proc.standardError = FileHandle.nullDevice
+                        do {
+                            try proc.run()
+                            proc.waitUntilExit()
                             soloedNames.append(stripName)
-                            log.append("    Soloed '\(stripName)' via menu search + S key")
-                        } else {
-                            log.append("    WARNING: selected '\(stripName)' but S-key post failed")
+                            log.append("    Soloed '\(stripName)' via menu search + osascript keystroke s")
+                        } catch {
+                            log.append("    WARNING: selected '\(stripName)' but osascript keystroke failed: \(error)")
                         }
                     } else {
-                        log.append("    WARNING: could not select '\(stripName)' via menu search; trying AX index fallback")
-                        // Fallback to AX index if available
-                        if let strips = group["strips"] as? [[String: Any]],
-                           let stripNode = strips.first(where: { $0["name"] as? String == stripName }),
-                           let axIdx = stripNode["trackIndex"] as? Int {
-                            let soloResult = await router.route(
-                                operation: "track.set_solo",
-                                params: ["index": "\(axIdx)", "enabled": "true"]
-                            )
-                            if soloResult.isSuccess {
-                                soloedIndices.append(axIdx)
-                            } else {
-                                log.append("    WARNING: AX index solo also failed for '\(stripName)': \(soloResult.message)")
-                            }
-                        }
+                        log.append("    WARNING: could not select '\(stripName)' via menu search — skipping solo")
                     }
                 }
             } else {
-                // No PID or no strip names — fall back to AX index approach
-                let groupAxIndices = group["trackIndices"] as? [Int] ?? []
-                if !groupAxIndices.isEmpty {
-                    for axIdx in groupAxIndices {
-                        let soloResult = await router.route(
-                            operation: "track.set_solo",
-                            params: ["index": "\(axIdx)", "enabled": "true"]
-                        )
-                        if soloResult.isSuccess {
-                            soloedIndices.append(axIdx)
-                        } else {
-                            log.append("    WARNING: solo AX track \(axIdx) failed: \(soloResult.message)")
-                        }
-                    }
-                } else {
-                    // Fallback: solo by MSeq position in info.tracks
-                    let oids = group["stripOids"] as? [Int] ?? []
-                    let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
-                    for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
-                        let soloResult = await router.route(
-                            operation: "track.set_solo",
-                            params: ["index": "\(trackIdx)", "enabled": "true"]
-                        )
-                        if soloResult.isSuccess {
-                            soloedIndices.append(trackIdx)
-                        } else {
-                            log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
-                        }
-                    }
-                }
+                log.append("    WARNING: no strip names for group '\(groupName)' — cannot solo")
             }
 
             // Open bounce dialog
             let bounceResult = await router.route(operation: "project.bounce_section")
             log.append("    Bounce dialog: \(bounceResult.message)")
 
-            // Un-solo by name (re-press S key on each selected track)
+            // Un-solo by name: select + osascript keystroke "s" to toggle off
             for stripName in soloedNames {
                 let reselected = AccessibilityChannel.selectTrackByNameViaMenu(stripName)
-                if reselected,
-                   let pid = ProcessUtils.logicProPID(),
-                   let source = CGEventSource(stateID: .hidSystemState),
-                   let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
-                   let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
-                    keyDown.post(tap: .cghidEventTap)
-                    keyUp.post(tap: .cghidEventTap)
+                if reselected {
+                    usleep(150_000) // 150 ms — let Logic register the selection
+                    let proc = Process()
+                    proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+                    proc.arguments = ["-e", "tell application \"System Events\" to keystroke \"s\""]
+                    proc.standardOutput = FileHandle.nullDevice
+                    proc.standardError = FileHandle.nullDevice
+                    do {
+                        try proc.run()
+                        proc.waitUntilExit()
+                    } catch {
+                        log.append("    WARNING: unsolo osascript keystroke failed for '\(stripName)': \(error)")
+                    }
+                } else {
+                    log.append("    WARNING: could not re-select '\(stripName)' to unsolo")
                 }
-            }
-            // Un-solo by index (legacy fallback)
-            for idx in soloedIndices {
-                _ = await router.route(
-                    operation: "track.set_solo",
-                    params: ["index": "\(idx)", "enabled": "false"]
-                )
             }
         }
 
         return CallTool.Result(content: [.text(log.joined(separator: "\n"))], isError: false)
+    }
+
+    // MARK: - setCycleRange
+
+    /// Set the Logic Pro cycle range to exact bar positions using the confirmed-working
+    /// Navigate > Go To > Position... dialog + locator keyboard shortcuts.
+    ///
+    /// Steps:
+    ///  1. AX menu: Navigate > Go To > Position... (opens Go To Position dialog)
+    ///  2. osascript: Cmd+A, type "\(startBar) 1 1 1", Return  (moves playhead)
+    ///  3. osascript: Cmd+Ctrl+[  (set left locator to playhead)
+    ///  4. Repeat 1–2 for endBar
+    ///  5. osascript: Cmd+Ctrl+]  (set right locator to playhead)
+    ///  6. osascript: "c"          (enable cycle)
+    @discardableResult
+    private static func setCycleRange(startBar: Int, endBar: Int) -> Bool {
+        func runOsascript(_ script: String) -> Bool {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            proc.arguments = ["-e", script]
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            do {
+                try proc.run()
+                proc.waitUntilExit()
+                return proc.terminationStatus == 0
+            } catch {
+                return false
+            }
+        }
+
+        // Step 1: Open Navigate > Go To > Position...
+        let opened1 = AXLogicProElements.clickMenuItem(path: ["Navigate", "Go To", "Position\u{2026}"])
+                   || AXLogicProElements.clickMenuItem(path: ["Navigate", "Go To", "Position..."])
+        guard opened1 else { return false }
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Step 2: Select all + type start bar position + Return
+        let typeStart = """
+            tell application "System Events"
+                keystroke "a" using {command down}
+                keystroke "\(startBar) 1 1 1"
+                key code 36
+            end tell
+            """
+        _ = runOsascript(typeStart)
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Step 3: Set left locator (Cmd+Ctrl+[)
+        let setLeft = """
+            tell application "System Events"
+                key code 33 using {command down, control down}
+            end tell
+            """
+        _ = runOsascript(setLeft)
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // Step 4: Open Navigate > Go To > Position... again
+        let opened2 = AXLogicProElements.clickMenuItem(path: ["Navigate", "Go To", "Position\u{2026}"])
+                   || AXLogicProElements.clickMenuItem(path: ["Navigate", "Go To", "Position..."])
+        guard opened2 else { return false }
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Step 5: Select all + type end bar position + Return
+        let typeEnd = """
+            tell application "System Events"
+                keystroke "a" using {command down}
+                keystroke "\(endBar) 1 1 1"
+                key code 36
+            end tell
+            """
+        _ = runOsascript(typeEnd)
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Step 6: Set right locator (Cmd+Ctrl+])
+        let setRight = """
+            tell application "System Events"
+                key code 30 using {command down, control down}
+            end tell
+            """
+        _ = runOsascript(setRight)
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // Step 7: Enable cycle (C key)
+        let enableCycle = """
+            tell application "System Events"
+                keystroke "c"
+            end tell
+            """
+        _ = runOsascript(enableCycle)
+
+        return true
     }
 
     // MARK: - song_lengths

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -6,11 +6,13 @@ struct ProjectDispatcher {
         name: "logic_project",
         description: """
             Project lifecycle in Logic Pro. \
-            Commands: new, open, save, save_as, close, bounce, launch, quit. \
+            Commands: new, open, save, save_as, close, bounce, bounce_section, launch, quit. \
             Params by command: \
             open -> { path: String }; \
             save_as -> { path: String }; \
             bounce -> {} (opens bounce dialog); \
+            bounce_section -> { marker_name: String } or { start_bar: Int, end_bar: Int } \
+            (sets cycle range to section boundaries, enables cycle, opens bounce dialog); \
             launch/quit -> {} (app lifecycle); \
             Others -> {}
             """,
@@ -34,7 +36,8 @@ struct ProjectDispatcher {
         command: String,
         params: [String: Value],
         router: ChannelRouter,
-        cache: StateCache
+        cache: StateCache,
+        axChannel: AccessibilityChannel? = nil
     ) async -> CallTool.Result {
         switch command {
         case "new":
@@ -75,6 +78,9 @@ struct ProjectDispatcher {
             let result = await router.route(operation: "project.bounce")
             return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
 
+        case "bounce_section":
+            return await bounceSection(params: params, router: router, cache: cache, axChannel: axChannel)
+
         case "launch":
             if ProcessUtils.isLogicProRunning {
                 return CallTool.Result(content: [.text("Logic Pro is already running")], isError: false)
@@ -109,9 +115,114 @@ struct ProjectDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, launch, quit")],
+                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, launch, quit")],
                 isError: true
             )
         }
+    }
+
+    // MARK: - bounce_section
+
+    /// Set cycle range to the section boundaries, enable cycle mode, then open the bounce dialog.
+    ///
+    /// Accepts either:
+    ///   - `marker_name`: looks up a marker by name and uses its bar position
+    ///   - `start_bar` + `end_bar`: explicit bar range
+    private static func bounceSection(
+        params: [String: Value],
+        router: ChannelRouter,
+        cache: StateCache,
+        axChannel: AccessibilityChannel?
+    ) async -> CallTool.Result {
+        var startBar: Int
+        var endBar: Int
+
+        if let markerName = params["marker_name"]?.stringValue {
+            // Resolve marker boundaries: find this marker and the next one.
+            let markers: [MarkerState]
+            if let ax = axChannel, let live = await ax.readMarkersDirect() {
+                await cache.updateMarkers(live)
+                markers = live
+            } else {
+                markers = await cache.getMarkers()
+            }
+
+            guard let target = markers.first(where: { $0.name.localizedCaseInsensitiveContains(markerName) }) else {
+                return CallTool.Result(
+                    content: [.text("No marker found matching '\(markerName)'. Use list_markers to see available markers.")],
+                    isError: true
+                )
+            }
+
+            // Extract start bar from marker position
+            guard let targetBar = target.bar ?? barFromPositionString(target.position) else {
+                return CallTool.Result(
+                    content: [.text("Cannot determine bar position for marker '\(target.name)' (position: \(target.position))")],
+                    isError: true
+                )
+            }
+            startBar = targetBar
+
+            // End bar: look for the next marker with a higher bar number, or default to start + 8
+            let sortedMarkers = markers.compactMap { m -> (bar: Int, marker: MarkerState)? in
+                guard let b = m.bar ?? barFromPositionString(m.position) else { return nil }
+                return (bar: b, marker: m)
+            }.sorted { $0.bar < $1.bar }
+
+            if let nextEntry = sortedMarkers.first(where: { $0.bar > startBar }) {
+                endBar = nextEntry.bar
+            } else {
+                endBar = startBar + 8
+            }
+        } else if let sb = params["start_bar"]?.intValue, let eb = params["end_bar"]?.intValue {
+            startBar = sb
+            endBar = eb
+        } else {
+            return CallTool.Result(
+                content: [.text("bounce_section requires 'marker_name' or both 'start_bar' and 'end_bar'")],
+                isError: true
+            )
+        }
+
+        guard endBar > startBar else {
+            return CallTool.Result(
+                content: [.text("end_bar (\(endBar)) must be greater than start_bar (\(startBar))")],
+                isError: true
+            )
+        }
+
+        // Step 1: Set cycle range
+        let cycleResult = await router.route(
+            operation: "transport.set_cycle_range",
+            params: ["start": "\(startBar).1.1.1", "end": "\(endBar).1.1.1"]
+        )
+        if !cycleResult.isSuccess {
+            return CallTool.Result(
+                content: [.text("Failed to set cycle range [\(startBar)-\(endBar)]: \(cycleResult.message)")],
+                isError: true
+            )
+        }
+
+        // Step 2: Enable cycle mode
+        let toggleResult = await router.route(operation: "transport.toggle_cycle")
+        // Not fatal if this fails — cycle may already be enabled
+
+        // Step 3: Open bounce dialog (Cmd+B)
+        let bounceResult = await router.route(operation: "project.bounce_section")
+        let cycleNote = toggleResult.isSuccess ? "" : " (cycle toggle may have failed: \(toggleResult.message))"
+        let summary = "Cycle set to bars \(startBar)–\(endBar)\(cycleNote). Bounce dialog: \(bounceResult.message)"
+        return CallTool.Result(
+            content: [.text(summary)],
+            isError: !bounceResult.isSuccess
+        )
+    }
+
+    /// Parse a bar number from a "Bar.Beat.Division.Tick" or plain integer string.
+    private static func barFromPositionString(_ position: String) -> Int? {
+        let trimmed = position.trimmingCharacters(in: .whitespaces)
+        if let bar = Int(trimmed) { return bar }
+        let components = trimmed.components(separatedBy: ".")
+        if let first = components.first, let bar = Int(first) { return bar }
+        return nil
     }
 }

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -165,11 +165,10 @@ struct ProjectDispatcher {
             )
         }
 
-        // Build OID -> track map for the public tracks array
+        // --- Section 1: MSeq-level arrangement tracks (existing) ---
         let tracks = info.tracks
         let oidToTrack: [Int: ParsedTrack] = Dictionary(uniqueKeysWithValues: tracks.map { ($0.oid, $0) })
 
-        // Encode a track node (without full regions list to keep output concise)
         func encodeNode(_ t: ParsedTrack) -> [String: Any] {
             var node: [String: Any] = [
                 "name": t.name,
@@ -187,7 +186,6 @@ struct ProjectDispatcher {
             return node
         }
 
-        // Separate stack roots (has children, no parent in public set) from ungrouped
         let publicOids = Set(tracks.map { $0.oid })
         let stacks = tracks.filter { t in
             !t.childOids.isEmpty && (t.parentOid == nil || !publicOids.contains(t.parentOid!))
@@ -201,11 +199,46 @@ struct ProjectDispatcher {
             return node
         }
 
+        // --- Section 2: Full sub-track hierarchy from AuCO channel strips ---
+        let subHierarchy = info.subTrackHierarchy.map { stack -> [String: Any] in
+            let stripNodes = stack.strips.map { strip -> [String: Any] in
+                var node: [String: Any] = [
+                    "name": strip.name,
+                    "oid": strip.oid,
+                    "isGeneric": strip.isGeneric,
+                ]
+                if let fg = strip.functionGroup { node["functionGroup"] = fg }
+                if let routing = strip.outputRouting { node["outputRouting"] = routing }
+                if let vol = strip.volume { node["volumeDB"] = String(format: "%.1f", vol) }
+                if let tOid = strip.trakOid { node["trakOid"] = tOid }
+                if let mOid = strip.mseqOid { node["mseqOid"] = mOid }
+                return node
+            }
+            return [
+                "name": stack.name,
+                "source": stack.source,
+                "stripCount": stack.strips.count,
+                "strips": stripNodes,
+            ]
+        }
+
+        // --- Counts ---
+        let totalStrips = info.channelStrips.count
+        let namedStrips = info.channelStrips.filter { !$0.isGeneric }.count
+        let envLabels = info.environmentLabels
+
         let result: [String: Any] = [
             "project": info.projectName,
-            "trackCount": tracks.count,
-            "stacks": stacks,
-            "ungrouped": ungrouped,
+            "mseqTrackCount": tracks.count,
+            "channelStripCount": totalStrips,
+            "namedChannelStrips": namedStrips,
+            "trakEntryCount": info.trakEntries.count,
+            "environmentLabels": envLabels,
+            "arrangementTracks": [
+                "stacks": stacks,
+                "ungrouped": ungrouped,
+            ],
+            "subTrackHierarchy": subHierarchy,
         ]
 
         guard let jsonData = try? JSONSerialization.data(
@@ -225,7 +258,7 @@ struct ProjectDispatcher {
     /// Params:
     ///   - path: .logicx path (optional, auto-detected if omitted)
     ///   - marker_name / start_bar + end_bar: section to bounce
-    ///   - groups: array of function group names to include (nil = all)
+    ///   - groups: array of function group / stack names to include (nil = all)
     ///   - execute: Bool (default false) — when true, solo + bounce each group
     private static func bounceStems(
         params: [String: Value],
@@ -280,7 +313,7 @@ struct ProjectDispatcher {
             endBar = (info.markers.map { $0.bar + $0.durationBars }.max() ?? 9) + 1
         }
 
-        // --- Build function group → tracks mapping ---
+        // --- Build stem groups from sub-track hierarchy (channel strips) ---
         let requestedGroups: Set<String>?
         if let gArr = params["groups"],
            case let Value.array(gVals) = gArr {
@@ -289,27 +322,52 @@ struct ProjectDispatcher {
             requestedGroups = nil
         }
 
-        // Group tracks by function group (leaf tracks only — those with regions)
-        var groupMap: [String: [ParsedTrack]] = [:]
-        for track in info.tracks {
-            guard let group = track.functionGroup else { continue }
-            if let requested = requestedGroups, !requested.contains(group) { continue }
-            groupMap[group, default: []].append(track)
-        }
+        // Use subTrackHierarchy as primary source (channel strips grouped by stack/function group)
+        // Fall back to MSeq-based grouping if no channel strips found
+        var groups: [[String: Any]] = []
 
-        // Sort groups deterministically
-        let groups = groupMap.keys.sorted().map { groupName -> [String: Any] in
-            let members = groupMap[groupName]!
-            return [
-                "name": groupName,
-                "trackOids": members.map { $0.oid },
-                "trackNames": members.map { $0.name },
-            ]
+        if !info.subTrackHierarchy.isEmpty {
+            // Channel-strip-based groups (the full 449 sub-tracks)
+            for stack in info.subTrackHierarchy {
+                if let requested = requestedGroups, !requested.contains(stack.name) { continue }
+
+                // Filter to non-generic strips (they have real content)
+                let meaningfulStrips = stack.strips.filter { !$0.isGeneric }
+                if meaningfulStrips.isEmpty { continue }
+
+                groups.append([
+                    "name": stack.name,
+                    "source": stack.source,
+                    "stripOids": meaningfulStrips.map { $0.oid },
+                    "stripNames": meaningfulStrips.map { $0.name },
+                    "mseqOids": Array(Set(meaningfulStrips.compactMap { $0.mseqOid })).sorted(),
+                ])
+            }
+        } else {
+            // Fallback: group MSeq tracks by function group (legacy behaviour)
+            var groupMap: [String: [ParsedTrack]] = [:]
+            for track in info.tracks {
+                guard let group = track.functionGroup else { continue }
+                if let requested = requestedGroups, !requested.contains(group) { continue }
+                groupMap[group, default: []].append(track)
+            }
+            for groupName in groupMap.keys.sorted() {
+                let members = groupMap[groupName]!
+                groups.append([
+                    "name": groupName,
+                    "source": "function_group_mseq",
+                    "stripOids": members.map { $0.oid },
+                    "stripNames": members.map { $0.name },
+                    "mseqOids": members.map { $0.oid },
+                ])
+            }
         }
 
         let plan: [String: Any] = [
             "song": info.projectName,
             "bars": [startBar, endBar],
+            "channelStripCount": info.channelStrips.count,
+            "namedStrips": info.channelStrips.filter { !$0.isGeneric }.count,
             "groups": groups,
         ]
 
@@ -342,15 +400,16 @@ struct ProjectDispatcher {
 
         for group in groups {
             guard let groupName = group["name"] as? String,
-                  let oids = group["trackOids"] as? [Int],
-                  let names = group["trackNames"] as? [String] else { continue }
+                  let oids = group["stripOids"] as? [Int],
+                  let names = group["stripNames"] as? [String] else { continue }
 
             log.append("  Group '\(groupName)': \(names.joined(separator: ", "))")
 
-            // Solo tracks by index (best-effort — AX index may differ from binary OID)
-            // We use the track index in the public tracks array
+            // Solo tracks by index — use MSeq track indices where available,
+            // falling back to position in the public tracks array for OID proximity
             var soloedIndices: [Int] = []
-            for (trackIdx, track) in info.tracks.enumerated() where oids.contains(track.oid) {
+            let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
+            for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
                 let soloResult = await router.route(
                     operation: "track.set_solo",
                     params: ["index": "\(trackIdx)", "enabled": "true"]

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -6,13 +6,14 @@ struct ProjectDispatcher {
         name: "logic_project",
         description: """
             Project lifecycle in Logic Pro. \
-            Commands: new, open, save, save_as, close, bounce, bounce_section, launch, quit. \
+            Commands: new, open, save, save_as, close, bounce, bounce_section, launch, quit, analyze. \
             Params by command: \
             open -> { path: String }; \
             save_as -> { path: String }; \
             bounce -> {} (opens bounce dialog); \
             bounce_section -> { marker_name: String } or { start_bar: Int, end_bar: Int } \
             (sets cycle range to section boundaries, enables cycle, opens bounce dialog); \
+            analyze -> { path: String? } (parse ProjectData binary; defaults to current project); \
             launch/quit -> {} (app lifecycle); \
             Others -> {}
             """,
@@ -81,6 +82,9 @@ struct ProjectDispatcher {
         case "bounce_section":
             return await bounceSection(params: params, router: router, cache: cache, axChannel: axChannel)
 
+        case "analyze":
+            return analyzeProject(params: params)
+
         case "launch":
             if ProcessUtils.isLogicProRunning {
                 return CallTool.Result(content: [.text("Logic Pro is already running")], isError: false)
@@ -115,10 +119,50 @@ struct ProjectDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, launch, quit")],
+                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, analyze, launch, quit")],
                 isError: true
             )
         }
+    }
+
+    // MARK: - analyze
+
+    /// Parse the ProjectData binary for the given (or current) Logic Pro project and return
+    /// a JSON summary of markers, tempo map, tracks, and project metadata.
+    private static func analyzeProject(params: [String: Value]) -> CallTool.Result {
+        // Prefer explicitly supplied path; fall back to AppleScript discovery.
+        let path: String?
+        if let explicit = params["path"]?.stringValue, !explicit.isEmpty {
+            path = explicit
+        } else {
+            path = currentLogicProProjectPath()
+        }
+
+        guard let projectPath = path else {
+            return CallTool.Result(
+                content: [.text("analyze: could not determine project path. Pass 'path' param or ensure Logic Pro is open.")],
+                isError: true
+            )
+        }
+
+        guard let info = ProjectDataParser.parse(path: projectPath) else {
+            return CallTool.Result(
+                content: [.text("analyze: failed to parse ProjectData at '\(projectPath)'. Check the path and that the file is a valid .logicx project.")],
+                isError: true
+            )
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(info),
+              let json = String(data: data, encoding: .utf8) else {
+            return CallTool.Result(
+                content: [.text("analyze: failed to encode result as JSON")],
+                isError: true
+            )
+        }
+
+        return CallTool.Result(content: [.text(json)], isError: false)
     }
 
     // MARK: - bounce_section

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -6,13 +6,15 @@ struct ProjectDispatcher {
         name: "logic_project",
         description: """
             Project lifecycle in Logic Pro. \
-            Commands: new, open, save, save_as, close, bounce, bounce_section, launch, quit, analyze. \
+            Commands: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, launch, quit, analyze. \
             Params by command: \
             open -> { path: String }; \
             save_as -> { path: String }; \
             bounce -> {} (opens bounce dialog); \
             bounce_section -> { marker_name: String } or { start_bar: Int, end_bar: Int } \
             (sets cycle range to section boundaries, enables cycle, opens bounce dialog); \
+            bounce_complete -> { destination: String?, click_bounce: Bool? } \
+            (best-effort AX automation of the open bounce dialog: set path, click Bounce); \
             analyze -> { path: String? } (parse ProjectData binary; defaults to current project); \
             launch/quit -> {} (app lifecycle); \
             Others -> {}
@@ -85,6 +87,9 @@ struct ProjectDispatcher {
         case "analyze":
             return analyzeProject(params: params)
 
+        case "bounce_complete":
+            return await bounceComplete(params: params, axChannel: axChannel)
+
         case "launch":
             if ProcessUtils.isLogicProRunning {
                 return CallTool.Result(content: [.text("Logic Pro is already running")], isError: false)
@@ -119,7 +124,7 @@ struct ProjectDispatcher {
 
         default:
             return CallTool.Result(
-                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, analyze, launch, quit")],
+                content: [.text("Unknown project command: \(command). Available: new, open, save, save_as, close, bounce, bounce_section, bounce_complete, analyze, launch, quit")],
                 isError: true
             )
         }
@@ -259,6 +264,41 @@ struct ProjectDispatcher {
             content: [.text(summary)],
             isError: !bounceResult.isSuccess
         )
+    }
+
+    // MARK: - bounce_complete
+
+    /// Best-effort automation of the bounce dialog opened by bounce_section.
+    ///
+    /// Uses the Accessibility API to:
+    ///   1. Locate the bounce dialog window in Logic Pro.
+    ///   2. Optionally set output format controls (WAV 48 kHz 24-bit) via AX.
+    ///   3. Optionally set the destination path via an AX text field.
+    ///   4. Click the "Bounce" button.
+    ///
+    /// This is best-effort — the exact AX element structure may change between Logic versions.
+    /// If the dialog cannot be found, an error is returned suggesting manual completion.
+    ///
+    /// Params:
+    ///   - destination: Optional output file path to set in the dialog.
+    ///   - click_bounce: Bool (default true) — whether to click the Bounce button.
+    private static func bounceComplete(
+        params: [String: Value],
+        axChannel: AccessibilityChannel?
+    ) async -> CallTool.Result {
+        guard let ax = axChannel else {
+            return CallTool.Result(
+                content: [.text("bounce_complete requires AX channel (axChannel unavailable)")],
+                isError: true
+            )
+        }
+
+        let destination = params["destination"]?.stringValue
+        let shouldClick = params["click_bounce"]?.boolValue ?? true
+
+        // Delegate to the AccessibilityChannel actor
+        let result = await ax.completeBounceDialog(destination: destination, clickBounce: shouldClick)
+        return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
     }
 
     /// Parse a bar number from a "Bar.Beat.Division.Tick" or plain integer string.

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -536,8 +536,8 @@ struct ProjectDispatcher {
                            let source = CGEventSource(stateID: .hidSystemState),
                            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
                            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
-                            keyDown.postToPid(pid)
-                            keyUp.postToPid(pid)
+                            keyDown.post(tap: .cghidEventTap)
+                            keyUp.post(tap: .cghidEventTap)
                             soloedNames.append(stripName)
                             log.append("    Soloed '\(stripName)' via menu search + S key")
                         } else {
@@ -606,8 +606,8 @@ struct ProjectDispatcher {
                    let source = CGEventSource(stateID: .hidSystemState),
                    let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
                    let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
-                    keyDown.postToPid(pid)
-                    keyUp.postToPid(pid)
+                    keyDown.post(tap: .cghidEventTap)
+                    keyUp.post(tap: .cghidEventTap)
                 }
             }
             // Un-solo by index (legacy fallback)

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import MCP
 
@@ -502,7 +503,7 @@ struct ProjectDispatcher {
         // --- Execute: for each group, solo those tracks → set cycle → bounce → unsolo ---
         var log: [String] = ["bounce_stems executing for bars \(startBar)–\(endBar):"]
 
-        // Set cycle range first
+        // Set cycle range first using bar positions
         let cycleResult = await router.route(
             operation: "transport.set_cycle_range",
             params: ["start": "\(startBar).1.1.1", "end": "\(endBar).1.1.1"]
@@ -514,41 +515,81 @@ struct ProjectDispatcher {
         }
         _ = await router.route(operation: "transport.toggle_cycle")
 
+        // Determine if we have a pid for CGEvent-based solo toggling
+        let hasPid = ProcessUtils.logicProPID() != nil
+
         for group in groups {
             guard let groupName = group["name"] as? String else { continue }
-            let names = group["stripNames"] as? [String] ?? []
-            log.append("  Group '\(groupName)': \(names.joined(separator: ", "))")
+            let stripNames = group["stripNames"] as? [String] ?? []
+            log.append("  Group '\(groupName)': \(stripNames.joined(separator: ", "))")
 
-            // Prefer AX track indices from the live track index map
+            var soloedNames: [String] = []
             var soloedIndices: [Int] = []
-            let groupAxIndices = group["trackIndices"] as? [Int] ?? []
 
-            if !groupAxIndices.isEmpty {
-                // Solo by AX index
-                for axIdx in groupAxIndices {
-                    let soloResult = await router.route(
-                        operation: "track.set_solo",
-                        params: ["index": "\(axIdx)", "enabled": "true"]
-                    )
-                    if soloResult.isSuccess {
-                        soloedIndices.append(axIdx)
+            if hasPid && !stripNames.isEmpty {
+                // Prefer name-based selection via Track > Search and Select Track menu
+                for stripName in stripNames {
+                    let selected = AccessibilityChannel.selectTrackByNameViaMenu(stripName)
+                    if selected {
+                        // Post S key via CGEvent to toggle solo on the now-selected track
+                        if let pid = ProcessUtils.logicProPID(),
+                           let source = CGEventSource(stateID: .hidSystemState),
+                           let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
+                           let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
+                            keyDown.postToPid(pid)
+                            keyUp.postToPid(pid)
+                            soloedNames.append(stripName)
+                            log.append("    Soloed '\(stripName)' via menu search + S key")
+                        } else {
+                            log.append("    WARNING: selected '\(stripName)' but S-key post failed")
+                        }
                     } else {
-                        log.append("    WARNING: solo AX track \(axIdx) failed: \(soloResult.message)")
+                        log.append("    WARNING: could not select '\(stripName)' via menu search; trying AX index fallback")
+                        // Fallback to AX index if available
+                        if let strips = group["strips"] as? [[String: Any]],
+                           let stripNode = strips.first(where: { $0["name"] as? String == stripName }),
+                           let axIdx = stripNode["trackIndex"] as? Int {
+                            let soloResult = await router.route(
+                                operation: "track.set_solo",
+                                params: ["index": "\(axIdx)", "enabled": "true"]
+                            )
+                            if soloResult.isSuccess {
+                                soloedIndices.append(axIdx)
+                            } else {
+                                log.append("    WARNING: AX index solo also failed for '\(stripName)': \(soloResult.message)")
+                            }
+                        }
                     }
                 }
             } else {
-                // Fallback: solo by MSeq position in info.tracks
-                let oids = group["stripOids"] as? [Int] ?? []
-                let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
-                for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
-                    let soloResult = await router.route(
-                        operation: "track.set_solo",
-                        params: ["index": "\(trackIdx)", "enabled": "true"]
-                    )
-                    if soloResult.isSuccess {
-                        soloedIndices.append(trackIdx)
-                    } else {
-                        log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
+                // No PID or no strip names — fall back to AX index approach
+                let groupAxIndices = group["trackIndices"] as? [Int] ?? []
+                if !groupAxIndices.isEmpty {
+                    for axIdx in groupAxIndices {
+                        let soloResult = await router.route(
+                            operation: "track.set_solo",
+                            params: ["index": "\(axIdx)", "enabled": "true"]
+                        )
+                        if soloResult.isSuccess {
+                            soloedIndices.append(axIdx)
+                        } else {
+                            log.append("    WARNING: solo AX track \(axIdx) failed: \(soloResult.message)")
+                        }
+                    }
+                } else {
+                    // Fallback: solo by MSeq position in info.tracks
+                    let oids = group["stripOids"] as? [Int] ?? []
+                    let mseqOids = (group["mseqOids"] as? [Int]) ?? oids
+                    for (trackIdx, track) in info.tracks.enumerated() where mseqOids.contains(track.oid) {
+                        let soloResult = await router.route(
+                            operation: "track.set_solo",
+                            params: ["index": "\(trackIdx)", "enabled": "true"]
+                        )
+                        if soloResult.isSuccess {
+                            soloedIndices.append(trackIdx)
+                        } else {
+                            log.append("    WARNING: solo track \(trackIdx) (\(track.name)) failed: \(soloResult.message)")
+                        }
                     }
                 }
             }
@@ -557,7 +598,19 @@ struct ProjectDispatcher {
             let bounceResult = await router.route(operation: "project.bounce_section")
             log.append("    Bounce dialog: \(bounceResult.message)")
 
-            // Un-solo
+            // Un-solo by name (re-press S key on each selected track)
+            for stripName in soloedNames {
+                let reselected = AccessibilityChannel.selectTrackByNameViaMenu(stripName)
+                if reselected,
+                   let pid = ProcessUtils.logicProPID(),
+                   let source = CGEventSource(stateID: .hidSystemState),
+                   let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: true),
+                   let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 1, keyDown: false) {
+                    keyDown.postToPid(pid)
+                    keyUp.postToPid(pid)
+                }
+            }
+            // Un-solo by index (legacy fallback)
             for idx in soloedIndices {
                 _ = await router.route(
                     operation: "track.set_solo",

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -48,14 +48,23 @@ struct TrackDispatcher {
                 return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
             }
             if let name = params["name"]?.stringValue {
-                // Find track by name in cache
+                // Prefer AX menu-based name search (Track > Search and Select Track)
+                // Pass name directly to the channel which will use menu search
+                let result = await router.route(
+                    operation: "track.select",
+                    params: ["name": name]
+                )
+                if result.isSuccess {
+                    return CallTool.Result(content: [.text(result.message)], isError: false)
+                }
+                // Fallback: find track by name in cache and select by index
                 let tracks = await cache.getTracks()
                 if let track = tracks.first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
-                    let result = await router.route(
+                    let indexResult = await router.route(
                         operation: "track.select",
                         params: ["index": String(track.id)]
                     )
-                    return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
+                    return CallTool.Result(content: [.text(indexResult.message)], isError: !indexResult.isSuccess)
                 }
                 return CallTool.Result(content: [.text("No track found matching '\(name)'")], isError: true)
             }
@@ -113,8 +122,15 @@ struct TrackDispatcher {
             return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
 
         case "mute":
-            let index = params["index"]?.intValue ?? 0
             let enabled = params["enabled"]?.boolValue ?? true
+            if let name = params["name"]?.stringValue {
+                let result = await router.route(
+                    operation: "track.set_mute",
+                    params: ["name": name, "muted": String(enabled)]
+                )
+                return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
+            }
+            let index = params["index"]?.intValue ?? 0
             let result = await router.route(
                 operation: "track.set_mute",
                 params: ["index": String(index), "muted": String(enabled)]
@@ -122,8 +138,15 @@ struct TrackDispatcher {
             return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
 
         case "solo":
-            let index = params["index"]?.intValue ?? 0
             let enabled = params["enabled"]?.boolValue ?? true
+            if let name = params["name"]?.stringValue {
+                let result = await router.route(
+                    operation: "track.set_solo",
+                    params: ["name": name, "soloed": String(enabled)]
+                )
+                return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
+            }
+            let index = params["index"]?.intValue ?? 0
             let result = await router.route(
                 operation: "track.set_solo",
                 params: ["index": String(index), "soloed": String(enabled)]

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -34,6 +34,9 @@ struct ResourceHandlers {
         case "logic://tracks":
             return try await readTracks(cache: cache, axChannel: axChannel, uri: uri)
 
+        case "logic://tracks/live":
+            return try await readLiveTracks(cache: cache, axChannel: axChannel, uri: uri)
+
         case "logic://mixer":
             return try await readMixer(cache: cache, axChannel: axChannel, uri: uri)
 
@@ -88,6 +91,39 @@ struct ResourceHandlers {
             tracks = await cache.getTracks()
         }
         let json = encodeJSON(tracks)
+        return ReadResource.Result(
+            contents: [.text(json, uri: uri, mimeType: "application/json")]
+        )
+    }
+
+    private static func readLiveTracks(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        // Read full live track list including nesting depth from AX tree.
+        if let ax = axChannel, let live = await ax.readLiveTracksDirect() {
+            let json = encodeJSON(live)
+            return ReadResource.Result(
+                contents: [.text(json, uri: uri, mimeType: "application/json")]
+            )
+        }
+        // Fallback: standard tracks from cache (no nesting depth)
+        let tracks = await cache.getTracks()
+        let liveInfos = tracks.map { t in
+            LiveTrackInfo(
+                index: t.id,
+                name: t.name,
+                type: t.type,
+                isMuted: t.isMuted,
+                isSoloed: t.isSoloed,
+                isArmed: t.isArmed,
+                isSelected: t.isSelected,
+                nestingDepth: t.nestingDepth,
+                outputRouting: t.outputRouting
+            )
+        }
+        let json = encodeJSON(liveInfos)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -152,6 +152,25 @@ struct ResourceHandlers {
         } else {
             info = await cache.getProject()
         }
+
+        // Enrich with binary-parsed data (tempo, time signature, project name) when available.
+        if let projectPath = currentLogicProProjectPath(),
+           let parsed = ProjectDataParser.parse(path: projectPath) {
+            // Fill in fields that AX may leave empty
+            if !parsed.projectName.isEmpty && info.name.isEmpty {
+                info.name = parsed.projectName
+            }
+            if parsed.sampleRate > 0 && info.sampleRate == 0 {
+                info.sampleRate = parsed.sampleRate
+            }
+            if parsed.timeSignature != "4/4" || info.timeSignature == "4/4" {
+                info.timeSignature = parsed.timeSignature
+            }
+            if let first = parsed.tempoMap.first, info.tempo == 120.0 {
+                info.tempo = first.bpm
+            }
+        }
+
         let json = encodeJSON(info)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
@@ -163,6 +182,21 @@ struct ResourceHandlers {
         axChannel: AccessibilityChannel?,
         uri: String
     ) async throws -> ReadResource.Result {
+        // Try binary parser first — it gives richer data (bar, tick, duration) without AX.
+        if let projectPath = currentLogicProProjectPath(),
+           let parsed = ProjectDataParser.parse(path: projectPath),
+           !parsed.markers.isEmpty {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            if let data = try? encoder.encode(parsed.markers),
+               let json = String(data: data, encoding: .utf8) {
+                return ReadResource.Result(
+                    contents: [.text(json, uri: uri, mimeType: "application/json")]
+                )
+            }
+        }
+
+        // Fall back to AX / cache
         let markers: [MarkerState]
         if let ax = axChannel, let live = await ax.readMarkersDirect() {
             await cache.updateMarkers(live)

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -5,10 +5,17 @@ import MCP
 struct ResourceHandlers {
 
     /// Handle a ReadResource request by URI.
+    ///
+    /// - Parameters:
+    ///   - axChannel: When provided, resources perform direct synchronous AX reads instead
+    ///     of relying solely on the background-polled StateCache. This ensures correct
+    ///     results in one-shot / short-lived invocations where the poller hasn't had
+    ///     time to warm the cache.
     static func read(
         uri: String,
         cache: StateCache,
-        router: ChannelRouter
+        router: ChannelRouter,
+        axChannel: AccessibilityChannel? = nil
     ) async throws -> ReadResource.Result {
         await cache.recordToolAccess()
 
@@ -16,22 +23,25 @@ struct ResourceHandlers {
         if uri.hasPrefix("logic://tracks/") {
             let indexStr = String(uri.dropFirst("logic://tracks/".count))
             if let index = Int(indexStr) {
-                return try await readTrack(at: index, cache: cache, uri: uri)
+                return try await readTrack(at: index, cache: cache, axChannel: axChannel, uri: uri)
             }
         }
 
         switch uri {
         case "logic://transport/state":
-            return try await readTransportState(cache: cache, uri: uri)
+            return try await readTransportState(cache: cache, axChannel: axChannel, uri: uri)
 
         case "logic://tracks":
-            return try await readTracks(cache: cache, uri: uri)
+            return try await readTracks(cache: cache, axChannel: axChannel, uri: uri)
 
         case "logic://mixer":
-            return try await readMixer(cache: cache, uri: uri)
+            return try await readMixer(cache: cache, axChannel: axChannel, uri: uri)
 
         case "logic://project/info":
-            return try await readProjectInfo(cache: cache, uri: uri)
+            return try await readProjectInfo(cache: cache, axChannel: axChannel, uri: uri)
+
+        case "logic://markers":
+            return try await readMarkers(cache: cache, axChannel: axChannel, uri: uri)
 
         case "logic://midi/ports":
             return try await readMIDIPorts(router: router, uri: uri)
@@ -46,25 +56,59 @@ struct ResourceHandlers {
 
     // MARK: - Individual resource handlers
 
-    private static func readTransportState(cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        let state = await cache.getTransport()
+    private static func readTransportState(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        // Prefer a direct AX read for freshness; fall back to cache if AX is unavailable.
+        let state: TransportState
+        if let ax = axChannel, let live = await ax.readTransportStateDirect() {
+            await cache.updateTransport(live)
+            state = live
+        } else {
+            state = await cache.getTransport()
+        }
         let json = encodeJSON(state)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readTracks(cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        let tracks = await cache.getTracks()
+    private static func readTracks(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        let tracks: [TrackState]
+        if let ax = axChannel, let live = await ax.readTracksDirect() {
+            await cache.updateTracks(live)
+            tracks = live
+        } else {
+            tracks = await cache.getTracks()
+        }
         let json = encodeJSON(tracks)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readTrack(at index: Int, cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        if let track = await cache.getTrack(at: index) {
-            let json = encodeJSON(track)
+    private static func readTrack(
+        at index: Int,
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        // Refresh full track list, then slice the requested index.
+        let tracks: [TrackState]
+        if let ax = axChannel, let live = await ax.readTracksDirect() {
+            await cache.updateTracks(live)
+            tracks = live
+        } else {
+            tracks = await cache.getTracks()
+        }
+        if tracks.indices.contains(index) {
+            let json = encodeJSON(tracks[index])
             return ReadResource.Result(
                 contents: [.text(json, uri: uri, mimeType: "application/json")]
             )
@@ -72,17 +116,61 @@ struct ResourceHandlers {
         throw MCPError.invalidParams("No track at index \(index)")
     }
 
-    private static func readMixer(cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        let strips = await cache.getChannelStrips()
+    private static func readMixer(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        let strips: [ChannelStripState]
+        if let ax = axChannel, let live = await ax.readMixerDirect() {
+            await cache.updateChannelStrips(live)
+            strips = live
+        } else {
+            strips = await cache.getChannelStrips()
+        }
         let json = encodeJSON(strips)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 
-    private static func readProjectInfo(cache: StateCache, uri: String) async throws -> ReadResource.Result {
-        let info = await cache.getProject()
+    private static func readProjectInfo(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        var info: ProjectInfo
+        if let ax = axChannel, let live = await ax.readProjectInfoDirect() {
+            // Merge track count from cache when AX doesn't populate it
+            let cachedTrackCount = await cache.getTracks().count
+            var merged = live
+            if merged.trackCount == 0 && cachedTrackCount > 0 {
+                merged.trackCount = cachedTrackCount
+            }
+            await cache.updateProject(merged)
+            info = merged
+        } else {
+            info = await cache.getProject()
+        }
         let json = encodeJSON(info)
+        return ReadResource.Result(
+            contents: [.text(json, uri: uri, mimeType: "application/json")]
+        )
+    }
+
+    private static func readMarkers(
+        cache: StateCache,
+        axChannel: AccessibilityChannel?,
+        uri: String
+    ) async throws -> ReadResource.Result {
+        let markers: [MarkerState]
+        if let ax = axChannel, let live = await ax.readMarkersDirect() {
+            await cache.updateMarkers(live)
+            markers = live
+        } else {
+            markers = await cache.getMarkers()
+        }
+        let json = encodeJSON(markers)
         return ReadResource.Result(
             contents: [.text(json, uri: uri, mimeType: "application/json")]
         )

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -14,7 +14,7 @@ struct ResourceProvider {
         Resource(
             name: "Tracks",
             uri: "logic://tracks",
-            description: "All tracks: name, type, index, mute/solo/arm states",
+            description: "All tracks: name, type (audio/software_instrument/drummer/aux/bus/folder), index, mute/solo/arm states, output routing",
             mimeType: "application/json"
         ),
         Resource(
@@ -26,7 +26,13 @@ struct ResourceProvider {
         Resource(
             name: "Project Info",
             uri: "logic://project/info",
-            description: "Project name, sample rate, time signature, track count",
+            description: "Project name, tempo, time signature, sample rate, bit depth, track count. Read directly from Logic Pro via AX for freshness.",
+            mimeType: "application/json"
+        ),
+        Resource(
+            name: "Markers",
+            uri: "logic://markers",
+            description: "All arrangement markers: name, bar position (1-based), position string. Read via Accessibility API.",
             mimeType: "application/json"
         ),
         Resource(
@@ -47,7 +53,7 @@ struct ResourceProvider {
         Resource.Template(
             uriTemplate: "logic://tracks/{index}",
             name: "Track Detail",
-            description: "Single track detail by index (including automation mode)",
+            description: "Single track detail by index (including type, mute/solo/arm, output routing)",
             mimeType: "application/json"
         ),
     ]

--- a/Sources/LogicProMCP/Resources/ResourceProvider.swift
+++ b/Sources/LogicProMCP/Resources/ResourceProvider.swift
@@ -18,6 +18,12 @@ struct ResourceProvider {
             mimeType: "application/json"
         ),
         Resource(
+            name: "Live Tracks",
+            uri: "logic://tracks/live",
+            description: "Full live track list read directly from the AX arrange window: name, type, mute/solo/arm, nesting depth for hierarchy inference. Supplements binary-parser results.",
+            mimeType: "application/json"
+        ),
+        Resource(
             name: "Mixer",
             uri: "logic://mixer",
             description: "All channel strips: volume, pan, plugins, sends",

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -66,6 +66,7 @@ actor LogicProServer {
         // Capture for closures
         let router = self.router
         let cache = self.cache
+        let axChannel = self.axChannel
 
         await server.withMethodHandler(CallTool.self) { params in
             let name = params.name
@@ -102,12 +103,14 @@ actor LogicProServer {
 
             case "logic_navigate":
                 return await NavigateDispatcher.handle(
-                    command: command, params: cmdParams, router: router, cache: cache
+                    command: command, params: cmdParams, router: router, cache: cache,
+                    axChannel: axChannel
                 )
 
             case "logic_project":
                 return await ProjectDispatcher.handle(
-                    command: command, params: cmdParams, router: router, cache: cache
+                    command: command, params: cmdParams, router: router, cache: cache,
+                    axChannel: axChannel
                 )
 
             case "logic_system":
@@ -124,11 +127,12 @@ actor LogicProServer {
         }
     }
 
-    // MARK: - Resource Registration (7 resources)
+    // MARK: - Resource Registration (8 resources)
 
     private func registerResources() async {
         let router = self.router
         let cache = self.cache
+        let axChannel = self.axChannel
 
         await server.withMethodHandler(ListResources.self) { _ in
             ListResources.Result(resources: ResourceProvider.resources, nextCursor: nil)
@@ -138,7 +142,8 @@ actor LogicProServer {
             try await ResourceHandlers.read(
                 uri: params.uri,
                 cache: cache,
-                router: router
+                router: router,
+                axChannel: axChannel
             )
         }
 
@@ -169,7 +174,7 @@ actor LogicProServer {
         await registerResources()
 
         Log.info(
-            "Starting \(ServerConfig.serverName) v\(ServerConfig.serverVersion) — 8 tools, 7 resources",
+            "Starting \(ServerConfig.serverName) v\(ServerConfig.serverVersion) — 8 tools, 8 resources",
             subsystem: "server"
         )
 

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -40,6 +40,31 @@ struct TrackState: Sendable, Codable, Identifiable {
     var color: String?
     /// Output routing label (e.g. "Stereo Out", "Bus 1"). Populated via AX inspection.
     var outputRouting: String?
+    /// Nesting depth in the arrange window (0 = top-level). Populated by AX live discovery.
+    var nestingDepth: Int = 0
+}
+
+/// A live track record read directly from the AX tree of the arrange window.
+/// Richer than TrackState — includes nesting depth for hierarchy inference.
+struct LiveTrackInfo: Sendable, Codable {
+    /// 0-based display index in the arrange window.
+    var index: Int
+    /// Track name as shown in the arrange window header.
+    var name: String
+    /// Track type inferred from AX roles/descriptions.
+    var type: TrackType = .unknown
+    /// True when the mute button is active.
+    var isMuted: Bool = false
+    /// True when the solo button is active.
+    var isSoloed: Bool = false
+    /// True when the record-arm button is active.
+    var isArmed: Bool = false
+    /// True when this track is selected in the arrange window.
+    var isSelected: Bool = false
+    /// Nesting depth in the track stack hierarchy (0 = root level, 1 = child, etc.).
+    var nestingDepth: Int = 0
+    /// Output routing label if readable from AX.
+    var outputRouting: String?
 }
 
 /// Mixer channel strip state (extends track with routing info).

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -38,6 +38,8 @@ struct TrackState: Sendable, Codable, Identifiable {
     var volume: Double = 0.0   // dB, 0 = unity
     var pan: Double = 0.0      // -1.0 (L) to 1.0 (R)
     var color: String?
+    /// Output routing label (e.g. "Stereo Out", "Bus 1"). Populated via AX inspection.
+    var outputRouting: String?
 }
 
 /// Mixer channel strip state (extends track with routing info).
@@ -83,7 +85,10 @@ struct RegionState: Sendable, Codable, Identifiable {
 struct MarkerState: Sendable, Codable, Identifiable {
     let id: Int
     var name: String
+    /// Bar position as a string (e.g. "1.1.1.1" or "Verse").
     var position: String
+    /// Bar number extracted from position, if available (1-based).
+    var bar: Int?
 }
 
 /// Automation mode.

--- a/Tests/LogicProMCPTests/Decoders/TxSqMarkerDecoderTests.swift
+++ b/Tests/LogicProMCPTests/Decoders/TxSqMarkerDecoderTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import LogicProMCP
+
+/// Integration tests for `TxSqMarkerDecoder` against the three bundled sample
+/// Logic projects. Project 1 has no TxSq chunks; projects 2 and 3 carry
+/// short-ASCII arrangement-marker TxSq chunks whose names we can recover.
+final class TxSqMarkerDecoderTests: XCTestCase {
+
+    // MARK: - Sample Discovery
+
+    private static let sampleNames = [
+        "logic-project-1.logicx",
+        "logic-project-2.logicx",
+        "logic-project-3.logicx",
+    ]
+
+    private static func repoRoot() -> URL? {
+        if let override = ProcessInfo.processInfo.environment["LOGIC_SAMPLES_ROOT"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        var url = URL(fileURLWithPath: #file)
+        for _ in 0..<10 {
+            url.deleteLastPathComponent()
+            let pkg = url.appendingPathComponent("Package.swift")
+            let sample = url.appendingPathComponent("logic-project-1.logicx")
+            if FileManager.default.fileExists(atPath: pkg.path),
+               FileManager.default.fileExists(atPath: sample.path) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func projectData(for sample: String) -> URL? {
+        guard let root = repoRoot() else { return nil }
+        let altRoot = root.appendingPathComponent(sample).appendingPathComponent("Alternatives")
+        for i in 0...9 {
+            let candidate = altRoot
+                .appendingPathComponent(String(format: "%03d", i))
+                .appendingPathComponent("ProjectData")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func loadData(_ sample: String) throws -> Data {
+        guard let url = projectData(for: sample) else {
+            throw XCTSkip("Sample project '\(sample)' not available")
+        }
+        return try Data(contentsOf: url)
+    }
+
+    // MARK: - Tests
+
+    func testProject1HasNoTxSqMarkers() throws {
+        let data = try Self.loadData("logic-project-1.logicx")
+        let markers = TxSqMarkerDecoder.decode(data: data)
+        XCTAssertTrue(markers.isEmpty, "Expected no TxSq marker chunks in project 1, got \(markers.count)")
+    }
+
+    func testProject2ContainsExpectedMarkers() throws {
+        let data = try Self.loadData("logic-project-2.logicx")
+        let markers = TxSqMarkerDecoder.decode(data: data)
+        let names = Set(markers.map { $0.markerName })
+        XCTAssertTrue(names.contains("Intro"),  "Expected 'Intro' marker, got \(names)")
+        XCTAssertTrue(names.contains("Chorus"), "Expected 'Chorus' marker, got \(names)")
+        XCTAssertTrue(names.contains("Bridge"), "Expected 'Bridge' marker, got \(names)")
+    }
+
+    func testProject3ContainsAtLeastOneExpectedMarker() throws {
+        let data = try Self.loadData("logic-project-3.logicx")
+        let markers = TxSqMarkerDecoder.decode(data: data)
+        XCTAssertFalse(markers.isEmpty, "Expected at least one TxSq marker in project 3")
+        let expected: Set<String> = ["Intro", "Verse", "Chorus", "Bridge"]
+        let names = Set(markers.map { $0.markerName })
+        XCTAssertFalse(names.intersection(expected).isEmpty,
+                       "Expected project 3 to contain at least one of \(expected), got \(names)")
+    }
+
+    func testAllMarkerNamesAreNonEmpty() throws {
+        for sample in Self.sampleNames {
+            guard let data = try? Self.loadData(sample) else { continue }
+            let markers = TxSqMarkerDecoder.decode(data: data)
+            for m in markers {
+                XCTAssertFalse(m.markerName.isEmpty, "Empty markerName in \(sample) oid=\(m.oid)")
+                XCTAssertTrue(m.markerName.count <= 32, "Marker name too long in \(sample): \(m.markerName)")
+            }
+        }
+    }
+
+    func testEmptyDataReturnsNoRecords() {
+        XCTAssertTrue(TxSqMarkerDecoder.decode(data: Data()).isEmpty)
+    }
+
+    func testInvalidMagicReturnsNoRecords() {
+        var bogus = Data(repeating: 0, count: 64)
+        bogus[0] = 0xFF
+        XCTAssertTrue(TxSqMarkerDecoder.decode(data: bogus).isEmpty)
+    }
+}

--- a/docs/reference/LOGIC_BINARY_SPEC.md
+++ b/docs/reference/LOGIC_BINARY_SPEC.md
@@ -1,0 +1,390 @@
+# Logic Pro ProjectData: Binary Specification
+
+This document provides a technical specification for the internal structure and data mapping of the proprietary ProjectData file found within Logic Pro project packages (.logicx).
+
+## 1. File Structure Overview
+
+The ProjectData file is a binary container consisting of a global header followed by a sequence of structured data chunks.
+
+- Location: .logicx/Alternatives/[Index]/ProjectData
+- Some tooling (including `logic_extractor.py`) can also operate on a raw ProjectData file path.
+- Magic Bytes (Offsets 0x00-0x03): 23 47 C0 AB
+- Versioning (Offsets 0x04-0x07): Varies by Logic Pro version (e.g., D0 09 03 00).
+- Global Table Offset: The chunk sequence typically begins at offset 0x18.
+- **Global Settings (Plist-derived)**:
+  - Time Signatures: Extracted from `MetaData.plist` or `ProjectInformation.plist` (looking for `TimeSignature` keys). Defaults to 4/4 if missing.
+  - Sample Rate, BPM, Key, Frame Rate.
+
+---
+
+## 2. Chunk Architecture (36-Byte Header)
+
+Every data block is preceded by a standardized 36-byte header that defines the chunk type, identity, and size.
+
+| Offset | Size | Field    | Description                                                                   |
+| :----- | :--- | :------- | :---------------------------------------------------------------------------- |
+| 0x00   | 4B   | ID       | 4-character identifier, stored in reverse byte order (e.g., "ivnE" for Envi). |
+| 0x04   | 6B   | Metadata | Internal versioning and type flags.                                           |
+| 0x0A   | 4B   | OID      | Object Identifier. Used for cross-referencing between chunks.                 |
+| 0x0E   | 8B   | Padding  | Reserved or static binary structure.                                          |
+| 0x16   | 6B   | Anchor   | Static signature. Typically 02 00 00 00 [01/02] 00.                           |
+| 0x1C   | 8B   | Length   | 64-bit Little Endian integer representing the body size in bytes.             |
+
+### Discovery Pattern
+
+Chunks can be located within a file by scanning for the anchor signature (02 00 00 00 . 00). The 4-byte chunk ID is located exactly 22 bytes before the start of this signature. In practice, this signature can also occur inside payloads, so validate that:
+
+1. The header is a full 36 bytes.
+2. The length field fits inside the file bounds.
+3. The anchor bytes at 0x16 match the detected signature.
+
+---
+
+## 3. Event Sequences (EvSq) and Tempo Encoding
+
+EvSq chunks store the project timeline, including MIDI data, automation, and tempo events.
+
+### Tempo Event Signature
+
+Tempo changes follow a specific 20-byte pattern:
+7F 00 00 01 [MM MM MM MM] [00 00 00 00] [PP PP PP PP PP PP PP PP]
+
+- Millitempo (4B): The tempo value stored as an integer (BPM x 10,000). To calculate BPM, divide the Little Endian integer by 10,000.
+- Tick Position (8B): The absolute timeline position in ticks.
+- Resolution: Logic Pro standard resolution is 3840 ticks per bar in 4/4 time.
+- Bar Calculation: (Ticks / 3840) + 1.
+
+**Extractor Note:** `logic_extractor.py` now preserves the raw tick position in the JSON output (`tempo_map[].tick`) so downstream tooling can avoid rounding error when converting to seconds.
+
+### MIDI Event Encoding
+
+Events are stored in 12-byte structures interleaved with tempo events.
+
+- **Structure**: `[Status Byte] [Data 1] [Data 2] [Reserved] [Position (8B)]`
+- **Status Byte**:
+  - High Nibble (Type): `0x9` (Note On), `0x8` (Note Off), `0xB` (Control Change), `0xC` (Program Change).
+  - Low Nibble (Channel): `0x0`-`0xF` (Channels 1-16).
+- **Position**: 8-byte Little Endian integer representing absolute tick position.
+
+---
+
+## 4. Sequence & Track Objects (MSeq / Trak)
+
+### MSeq (Sequence Object)
+
+MSeq entries appear to represent high-level sequence/track objects. In this file, the following layout was consistent:
+
+- **Name Length**: 2-byte Little Endian at offset 0x10.
+- **Name**: ASCII string starting at 0x12, `name_len` bytes.
+
+Example names observed: `Click Track`, `Drums`, `NSP Quad Cortex`, `Track Alternatives`, `Global Harmonies`.
+
+### Trak (Track Object)
+
+Trak chunks are fixed-length (58 bytes) in this ProjectData. The body does **not** appear to contain a region list.
+
+Observed fields:
+
+- **MSeq Reference**: 4-byte Little Endian at offset 0x08 (references an MSeq OID).
+- **UUID**: 16 bytes at offset 0x18 (format as standard UUID).
+- **Flags**: 4 bytes at offset 0x28 (unknown / UI state).
+
+Track names are commonly stored in TxSq/TxSt chunks (RTF text), cleaned and mapped by OID when MSeq references are absent.
+
+---
+
+## 5. Mixer and Track Parameters (AuCO / ivnE)
+
+Mixer and channel strip data are primarily stored in Audio Channel Objects (AuCO).
+
+### Volume Calculation
+
+Volume levels are stored as 32-bit integers using a proprietary logarithmic scale.
+
+- Unity Gain (0 dB) Reference: 1509949440 (00 80 00 5A)
+- Decibel Formula: dB = 40 \* log10(Value / 1509949440)
+- Note: A value of 0 indicates negative infinity dB.
+
+### Panning
+
+- Offset: 0x59 within the AuCO body.
+- Range: 0 (Hard Left) to 127 (Hard Right).
+- Center: 64.
+
+### Channel Strip Name
+
+- Offset: 0x3C within the AuCO body.
+- Encoding: null-terminated ASCII.
+- Example values: `Audio 1`, `Audio 2`, `Audio 3`.
+
+### Output Routing Labels
+
+- **Pattern Scan**: The extractor scans `AuCO` chunks for strings containing "Output", "Bus", or "Stereo Out".
+- **Usage**: Identifies the physical output or bus assignment (e.g., `Output 1-2`) useful for grouping stems.
+
+### Track Hierarchy and Routing
+
+Additional chunks define track properties and routing:
+
+- **AuCn**: Presence indicates active routing or auxiliary channel status.
+- **AuCU**: Presence and count indicates automation lanes.
+- **Trak**: Defines the arrangement track.
+  - **Region Mapping**: The body contains 4-byte Little Endian OIDs. These match the OIDs of Audio Regions (AuRg), linking them to this specific track.
+
+Extractor additions:
+
+- `channel_strip.config_records`: Summary of AuCO record lengths and byte-offset value counts. For length 241 records, the extractor reports byte values at offsets `0x50` and `0x51` (decimal 80/81) as `length_details["241"].offset_80_counts` and `offset_81_counts`, plus pair counts. In a send on/off toggle test, these bytes shifted (e.g., `0x08 -> 0x00` at 0x50 and `0x0A -> 0x08` at 0x51) indicating a likely send enable/bus slot flag.
+- `channel_strip.routing_records`: Summary of AuCn record lengths and u32 head samples.
+- `channel_strip.automation_records`: Summary of AuCU record lengths and decoded plist root keys (when present). For 76-byte AuCU records:
+  - `len76_field_counts` reports u16 values at offsets `0x10` and `0x12` (decimal 16/18) plus u32 values at offsets `0x10` and `0x18` (decimal 16/24).
+  - `len76_records` is a per‑record list with decoded fields including `send_level_db` (derived from `u32_offset_24` using the standard `raw_to_db` scale), a stable `index`, and `send_enabled_guess` (true when `u16_offset_18 == 0`, false when `u16_offset_18 == 0x0100`, otherwise null).
+  
+In send on/off tests:
+  - `u16_offset_18` flipped from `0x0000` (send on) to `0x0100` (send off).
+  - `u32_offset_24` matched the standard volume scale (e.g., `0x5A000000` = unity/0 dB). Sending level to `-inf` set this field to `0x00000000`, which converts to about `-144 dB` via the existing `raw_to_db` formula.
+  - Additional validation: `-6 dB` produced `u32_offset_24 = 0x3FE00000` (≈ -5.95 dB) and `+6 dB` produced `u32_offset_24 = 0x7F000000` (≈ +5.98 dB), confirming the same scale with quantization.
+
+---
+
+## 6. Assets and Regions (AuFl / AuRg)
+
+Logic Pro separates the definition of audio files from their placement on the timeline.
+
+### Audio File References (AuFl)
+
+- Content: Original file paths or aliases.
+- Encoding: UTF-16LE.
+- Payload Offset: Typically begins at offset 0x0A relative to the chunk body start.
+
+### Audio Regions (AuRg)
+
+- **Linkage**: The OID in the AuRg chunk header corresponds to an AuFl OID. In this file, AuRg OIDs are **not unique** (they map to audio assets), so regions must be uniquely identified by a composite key (e.g., OID + start ticks + name).
+- **Timeline Placement**:
+  - Legacy mode: Start Position is an 8-byte Little Endian tick value at body offset `0x30`; duration can appear at `0x38`/`0x40`.
+  - Bar-field mode (newly observed): Start/length are encoded as bar values across `0x10..0x1F`:
+    - start bar = `u32@0x10 + (u32@0x14 >> 16)/65536`
+    - length bars = `u32@0x18 + (u32@0x1C >> 16)/65536`
+    - ticks are derived with `3840 ticks/bar`.
+  - **Important**: `u32@0x48` may alias `name_len << 16` (because `name_len` lives at `0x4A`), so it is now treated as a low-confidence legacy fallback.
+
+### Region Name
+
+- Name Length: 2-byte Little Endian at offset 0x4A.
+- Name: ASCII string at 0x4C, length `name_len`.
+- Example values: `Rec#03.31`, `Click Track.10`, `The Last Light.4`.
+
+### Region → Track Association (Heuristic)
+
+Track association does **not** appear directly in Trak. Instead, AuRg bodies contain track references at **variable offsets depending on AuRg length**. The extractor uses a heuristic:
+
+1. Group AuRg bodies by length.
+2. For each length, scan offsets to find positions that frequently contain Trak OIDs.
+3. Use the most frequent offsets for that length as candidate track refs.
+
+Additional signal (best-effort):
+
+- **Song / USEl (Explicit Tables)**: These chunks contain explicit `[TrackOID, Count, RegionOID...]` mapping tables. The extractor now prioritizes these tables over heuristics when present.
+- **Co-occurrence**: Proximity-based heuristic (nearest Trak OID within a short window) used as a fallback.
+- **Confidence Scoring**: The extractor assigns a confidence score (0.0 - 1.0) and source label (e.g., `song_usel_table`, `aurg_offset`, `name_prefix`) to every link.
+- **Song / USEl Tables**: Some sections appear to encode explicit `[track_oid, count, region_oid * count]` tables. The extractor now detects these tables and prefers them as a high-confidence source when the best match is dominant.
+
+This heuristic is documented in code (`logic_extractor.py`) and should be treated as “best-effort” until a definitive mapping is known.
+
+**Extractor Output:** When a region is mapped to a track, `logic_extractor.py` records:
+
+- `regions[].track_oid`, `regions[].track_confidence`, `regions[].track_source`
+- `regions[].timing_source`: Which timing decoder was used (`legacy:*` or `bar_fields_0x10_0x1C`).
+- `regions[].track_sources` (optional): List of contributing sources when multiple signals agree (e.g., `["aurg_offset", "name_tokens"]`).
+- `tracks[].regions[]` entries as objects: `{ oid, confidence, source }`
+- `tracks[].region_mapping_stats`: `{ total, by_source: { <source>: count } }`
+- `tracks[].track_id`: Stable identifier for cross‑project matching. Prefers `uuid`, otherwise falls back to `mseq_oid`, then normalized name, then OID.
+- `tracks[].name_norm`: Normalized track name tokens (lowercased, stopwords removed) when a name is present.
+- `tracks[].display_name`: Best-effort human-friendly name used by render planning; falls back to `Track <oid>` when only placeholder names are available.
+- `tracks[].name_raw` / `tracks[].name_is_generic`: Preserve the original extracted name and flag generic placeholders (e.g. `*Automation`).
+- `tracks[].track_stack` / `tracks[].is_summing_track_stack`: Best-effort stack classification metadata (`type`, `source`, `confidence`) and boolean summing flag.
+- `tracks[].parent_track_oid`, `tracks[].stack_root_track_oid`, `tracks[].stack_depth`, `tracks[].stack_child_oids`: Best-effort hierarchy fields inferred from MSeq linkage.
+- `tracks[].top_level_stack_name`: Best-effort canonical stack grouping label (`Midi Triggers`, `Click Track`, `Backing Track`, `Release Track`) from environment labels + track/region keywords.
+- `tracks[].synthetic` / `tracks[].synthetic_source` (optional): Synthetic catalog tracks created from unmapped environment labels when a concrete Trak mapping is unavailable. These carry names/stack hints but no regions.
+- `summary.track_hierarchy[]`: Flattened inferred parent/child edges with source and confidence.
+- `summary.top_level_stacks[]`: Group summary with stack name, member track OIDs/names, and aggregate region counts.
+- `summary.region_timing_mode` / `summary.timeline_tick_offset`: Decoder mode and optional global tick offset normalization applied when tempo/region data are stored in absolute timeline space.
+- `summary.environment_name_catalog[]`: Unmapped environment labels promoted into the synthetic track catalog (`oid`, `name`, `stack_hint`).
+- `summary.region_oid_reuse`: AuRg OID reuse diagnostics (`total_regions`, `unique_region_oids`, `max_region_oid_reuse`) and whether Song/USEl table mapping was enabled.
+- `summary.region_alias_refinement`: Post-processing diagnostics for alias-based region remapping (`retargeted_count`, `assigned_count`) and optional pass-level details when multi-pass refinement is used.
+- `summary.region_orphan_rec_assignment`: Diagnostics for generic orphan `Rec#..` region assignment pass (`assigned_count`) when unresolved regions are mapped via prefix-to-track fallback.
+
+---
+
+## 7. Plugin Data
+
+Plugin usage is recorded in specific chunks identified by a null ID.
+
+- **ID**: `00 00 00 00` (Null Bytes)
+- **Identification**: These chunks are detected by the standard header structure but with a zeroed ID.
+- **Content**: The body typically contains ASCII signatures of the plugin names (e.g., "Serum", "Valhalla", "Compressor", "Kontakt").
+
+---
+
+## 8. Text and Metadata (TxSt / TxSq)
+
+Text-based data, including track names and markers, is frequently stored in Rich Text Format (RTF).
+
+- Identifiers: TxSt (Text String) or TxSq (Text Sequence) chunks.
+- Format: RTF data starts with the standard {\rtf1 header.
+- Parsing: Extract payload text after the \fs24 (font size) or similar formatting tags.
+- **Arrangement Markers**: `TxSq` chunks often contain global arrangement markers (Verse, Chorus) distinguished from track names by context or specific text patterns.
+
+---
+
+## 9. Auxiliary Metadata Chunks (Observed)
+
+These chunk types appear in this ProjectData and contain useful metadata, but are not fully decoded:
+
+- **SngO**: NSKeyedArchiver plist. Contains keys like `arrangementMarkerTitleList`.
+- **GenM**: JSON and/or NSKeyedArchiver plist. Includes Drummer model state and arrangement metadata.
+- **CorM**: MIDI port names (e.g., `IAC Driver`, `Logic Pro Virtual In`).
+- **Hypr**: Automation parameter list (e.g., `Volume`, `Modulation`, `Pitch Bend`).
+- **Layr**: Environment layer names (e.g., `All Objects`, `Mixer`).
+- **ScSt**: Score/notation instrument set names (e.g., `Guitar`, `Bass 4`).
+- **InSt**: Score set root (e.g., `Score Set`).
+- **Trns**: Transition metadata (no obvious strings).
+- **Envi**: Environment objects. The extractor parses a best‑effort object record (name + column `x` coordinate + class id) and emits `summary.environment_objects`.
+- **USEl**: Large string-heavy chunk; likely selection/state data.
+
+These are currently extracted only as raw strings (see `logic_extractor.py`).
+
+---
+
+## 10. Non-ASCII Chunk Families (Decoded)
+
+Several chunk IDs are non-ASCII and encode embedded plists or fixed tables. The extractor now decodes these **best-effort** and records a summary in `summary.non_ascii_chunks`.
+
+Observed families:
+
+- **0x00000002** (len ~675,000; 3 copies): Mixed payload. Contains many **NSKeyedArchiver** segments plus length‑prefixed ASCII take names (e.g., `Drums_bip.18`). Dominant plist roots include `{"Shared": {"LoopFamily": {"LoopName": <name>, "LoopId": <int>}}}` (loop entries), `{"Cb": {"LoopFamilyName": <name>, "IsFamilyLoop": <bool>}}}` (loop families), and a small `contentTagLayoutName` plist (e.g., `Automatic`).
+- **0x000000E0** (len ~167,936): Similar **NSKeyedArchiver** segments (arrangement marker type map, loop families, edit metadata) plus many port/bus/track strings.
+- **0x0000004C / 0x000000A8** (len ~133,888): **NSKeyedArchiver** plists with `Cb` keys like `lastEditedDate` (NS.time seconds since 2001‑01‑01), `persistentAGCPreparedFlag`, and `nameUserModified`.
+- **0x00000004 / 0xFFFFFFFF**: **NSKeyedArchiver** plist containing `Shared.arrangementMarkerTitleList`, a map of slot → `{type: n}` (no titles).
+- **0x00000040** (len ~338,944): Dense **string table** with environment labels and GM instrument names.
+- **0x00000400** (len 136; ~224 copies): Fixed record layout (34 x `u32`). Indices `12/13` and `32/33` behave like UI coordinates when scaled by `/256`. Extractor emits `layout_tables` with `x1/y1/x2/y2`.
+- **0xFFFF0001**: Short ASCII payload (e.g., `Delete Tracks`).
+
+Extractor output shape:
+
+- `summary.non_ascii_chunks.string_tables[]`: `{ id, count, length, string_count, strings_sample[] }`
+- `summary.non_ascii_chunks.numeric_tables[]`: `{ id, count, length, track_oid_hits, region_oid_hits, top_pairs[] }` (heuristic; track/region OIDs are small, so expect false positives)
+- `summary.non_ascii_chunks.plists[]`: `{ id, count, length, keys[], root_keys[], strings_sample[] }`
+- `summary.non_ascii_chunks.layout_tables[]`: `{ id, count, scale, fields, records[] }` where each record includes `x1/y1/x2/y2` plus `source_env`/`target_env` when an `Envi` object matches the x‑column.
+- `summary.non_ascii_chunks.decoded.loop_entries[]`: `{ loop_name, loop_id, source }`
+- `summary.non_ascii_chunks.decoded.loop_families[]`: `{ family_name, is_family_loop, source }`
+- `summary.non_ascii_chunks.decoded.edit_metadata[]`: `{ last_edited_ns_time, last_edited_iso, name_user_modified, persistent_agc_prepared_flag, source }`
+- `summary.non_ascii_chunks.decoded.content_tag_layouts[]`: `{ layout_name, source }`
+- `summary.non_ascii_chunks.decoded.arrangement_marker_types[]`: `{ slot, type, source }`
+- `summary.non_ascii_chunks.misc[]`: `{ id, count, length }`
+
+Environment object extraction:
+
+- `summary.environment_objects[]`: `{ oid, name, x, class_id, length, name_offset, name_len, name_prefix_u16[], header_u32{}, y_positions[], y_decode_candidates[] }`.
+  - `x` is the environment column coordinate from the `Envi` chunk.
+  - `name_offset/name_len` are derived by scanning for the first length‑prefixed ASCII name.
+  - `name_prefix_u16` are the three u16 values immediately before the name length (useful for reverse‑engineering).
+  - `header_u32` captures u32 fields at offsets `0x00..0x1C` (raw header values).
+  - `y_positions` are derived from layout tables (no stable y‑coordinate observed inside `Envi`).
+  - `y_decode_candidates` is present only if a direct encoding match is detected (none observed for this file).
+- `summary.environment_layout_map`: `{ x -> { name?, y_positions[], track_oid? } }` compact index for column‑level lookup (JSON keys are strings).
+- `summary.environment_y_decode_report`: `{ top_encodings[], object_samples[], objects_scanned }` best‑effort report of near‑miss y‑decode patterns.
+
+---
+
+## 11. Global String Discovery and Heuristics
+
+Beyond structured chunks, significant metadata is recovered by scanning the entire binary for string patterns.
+
+### String Scanner
+
+The extractor scans for contiguous printable ASCII sequences (len > 6) and categorizes them:
+
+- **Performance Metadata**: Keywords like `vocal`, `stem`, `bpm`, `verse`, `chorus`.
+- **Project Notes**: Longer text blocks (>10 chars) often containing user notes or RTF fragments.
+- **System Noise**: Paths (`/usr/lib`, `/System/`), copyright strings, and library references are filtered out.
+
+---
+
+## 12. Implementation Notes for Parsing
+
+1. Endianness: All multi-byte integers (Length, OID, Ticks, Millitempo) are Little Endian.
+2. Chunk IDs: IDs are 4-byte characters. They must be byte-reversed for human-readable labels (e.g., binary 45 6E 76 69 is read as ivnE but represents the Envi chunk).
+3. Non-Contiguity: While chunks are often sequential, some files may contain padding between blocks. The anchor-based discovery method is more reliable than purely sequential parsing.
+
+---
+
+## 13. Arrangement Markers, Time Signature, Routing (Extractor State)
+
+### Arrangement Markers
+
+- The extractor uses TxSq RTF strings as arrangement marker names and records them in `summary.arrangement_markers`.
+- Primary decode path uses an explicit marker sequence table found in a small `EvSq` chunk (`EvSq(oid=0)` in this file):
+  - 16-byte triplet groups:
+    - head: `[18, start_tick, 0, ...]`
+    - marker row: `[marker_oid, 0x88000000, marker_type, duration_ticks]`
+    - tail: `[0, 0x88000000, 0, 0]`
+  - marker row `marker_oid` is joined to TxSq marker `oid`
+  - decoded rows are exposed in `summary.arrangement_marker_sequence_decode.events[]`
+  - marker placement source: `evsq_type18_sequence_unique` (single start per marker) or `evsq_type18_sequence_first`
+  - when available, `position_duration_ticks` and `position_end_tick` are emitted per marker
+- Secondary decode path (fallback) uses marker-linked `EvSq(oid=4)` 80-byte records:
+  - row type `u32[0] == 36`
+  - marker/object reference `u32[11]` (joined to TxSq marker `oid`)
+  - timeline tick `u32[1]`
+  - sequence index `u32[10]`
+  - lane id `u32[4]`
+  - decoded rows are exposed in `summary.arrangement_marker_decode.events[]`
+  - marker placement source: `evsq_type36_index0` or `evsq_type36_single_tick`
+- Each marker includes `oid` and `position_candidates[]` (decoded candidates with tick and source-specific fields).
+- `summary.arrangement_marker_position_stats` now reports decode details:
+  - `decoded_sequence_events`
+  - `decoded_sequence_ambiguous`
+  - `decoded_events`
+  - `decoded_ambiguous`
+  - `heuristics_used`
+- Legacy lexical/track heuristics remain available only when `summary.arrangement_marker_allow_heuristics` is set truthy.
+
+### Time Signature
+
+- `summary.time_signature_map` is populated from MetaData.plist / ProjectInformation.plist if available.
+- If no explicit time signature is found, the extractor defaults to **4/4 at bar 1** with source `assumed_default`.
+
+### Bar-Number Mapping (Current Decode)
+
+- The extractor emits `summary.bar_number_mapping_decode` and `summary.bar_number_mapping_stats`.
+- Primary decoded source is an `EvSq` type-96 tempo bridge (small `len=432` chunks in this file):
+  - row A: `[96, sequence_tick, 0, 0x0100007F|0x8100007F]`
+  - row B: `[tempo_raw, 0x88400000, tempo_tick_abs, 0]`
+  - `tempo_raw` is decoded as `BPM * 10000`
+  - normalized `tempo_tick` subtracts `summary.timeline_tick_offset` when present
+  - decoded rows are emitted as `bar_number_mapping_decode.anchors[]`
+  - adjacent anchor deltas are emitted as `bar_number_mapping_decode.segments[]`
+- Candidate bridge chunks and alignment scores are emitted in `bar_number_mapping_decode.bridge_candidates[]` (top-ranked entries only).
+- A secondary explicit bar-anchor decode is emitted from type-48 triplets:
+  - head: `[48, tick, 0x02000000, ...]`
+  - row: `[48, 0x88000000, bar_raw, tick]`
+  - tail: `[0, 0x88000000, 0, 0]`
+  - decoded rows are emitted in `bar_number_mapping_decode.explicit_bar_anchor_decode.events[]`
+  - both `bar_raw` and signed interpretation `bar_signed` are preserved
+  - cross-checks against the tempo bridge interpolation are emitted in `bar_number_mapping_decode.explicit_bar_anchor_decode.cross_check_vs_tempo_bridge[]`
+- A Song-table companion decode is emitted when `Song` bodies contain 24-byte node tables:
+  - candidate records are parsed as `u32x6` at best alignment
+  - type-20 nodes expose dense bar-domain values (`bar_nodes_head` / `bar_nodes_tail`)
+  - type-14 nodes expose marker-domain values (observed marker OID set: `0,4,8,...,36`)
+  - arrangement-marker-specific node hits are exposed as `arrangement_marker_nodes[]`
+  - linked-node hints are emitted in `bar_number_mapping_decode.song_bar_node_decode.bar_edge_sample[]` and `marker_edge_sample[]`
+  - same payload is mirrored at `summary.bar_number_mapping_song_decode` for convenience
+  - summary count is emitted as `summary.bar_number_mapping_stats.song_bar_node_count`
+- Marker projections through the tempo bridge are emitted in `bar_number_mapping_decode.marker_projection[]` and summarized in `summary.bar_number_mapping_stats.marker_projection_count`.
+
+### Routing
+
+- `AuCn` presence flags routing/aux status.
+- `AuCO` may contain output labels (e.g., `Output 1`, `Bus 1`, `Stereo Out`); these are extracted into `channel_strip.output` when present.
+- `channel_strip.config_records` provides per‑strip summaries of AuCO record lengths and byte-offset stats (currently offsets 0x50/0x51 for length‑241 records).
+- `channel_strip.routing_records` and `channel_strip.automation_records` provide per‑strip summaries of AuCn/AuCU record lengths and decoded plist root keys.

--- a/docs/reference/RE_FINDINGS.md
+++ b/docs/reference/RE_FINDINGS.md
@@ -1,0 +1,87 @@
+# Reverse Engineering Findings Log
+
+This log captures concrete findings from `ProjectData` analysis, including discoveries that may help decode data beyond arrangement markers.
+
+## 2026-02-09 (Current Pass)
+
+- `USEl` payloads contain embedded 80-byte event rows that decode like `EvSq` rows.
+- The best 80-byte alignment offset in `USEl` varies by chunk (examples observed: `11`, `12`, `57`, `63`), but decoded event content is stable.
+- Decoding `USEl` 80-byte rows reproduces the same marker-linked type-36 event set seen in `EvSq(oid=4)`, including the same tick/OID pairs.
+- Marker-linked type-36 events are stable across many project snapshots:
+  - marker OIDs: `4, 8, 12, 16, 20, 24, 28, 32, 36`
+  - consistent 27-event set with ticks in range `521280..3536339`.
+- A separate explicit marker sequence table exists in `EvSq(oid=0, len=448)` using 16-byte triplets:
+  - head `[18, start_tick, 0, ...]`
+  - marker row `[marker_oid, 0x88000000, marker_type, duration_ticks]`
+  - tail `[0, 0x88000000, 0, 0]`
+- This type-18 table encodes marker order exactly as the arrangement lane sequence observed in the screenshot:
+  - `28 -> 20 -> 16 -> 4 -> 8 -> 32 -> 24 -> 12 -> 36`
+- In that table, `duration_ticks` on each marker row equals `next_start_tick - start_tick` for all non-terminal rows, indicating explicit section span encoding.
+- A dedicated tempo-bridge table exists in small `EvSq` chunks (`len=432`, seen at `oid=0` and `oid=64`) with repeated 16-byte pairs:
+  - row A `[96, sequence_tick, 0, 0x0100007F|0x8100007F]`
+  - row B `[tempo_raw, 0x88400000, tempo_tick_abs, 0]`
+  - `tempo_raw` decodes as `BPM * 10000` and `tempo_tick_abs` matches the absolute pre-offset tempo timeline.
+- A separate small `EvSq(oid=0, len=192)` triplet structure contains explicit bar-like anchors:
+  - head `[48, tick, 0x02000000, ...]`
+  - row `[48, 0x88000000, bar_raw, tick]`
+  - tail `[0, 0x88000000, 0, 0]`
+  - observed decoded rows include `(tick=1651200, bar_raw=420)` and `(tick=1654080, bar_raw=421)` plus a pre-roll style value `bar_raw=65526` (signed-16 interpretation `-10`).
+- `SngO`/`GenM` `NSKeyedArchiver` data includes `Shared.arrangementMarkerTitleList`, but observed content is type metadata (`slot -> { type }`) only; no marker titles or position ticks were found there.
+- `TxSq` contains arrangement marker titles (`oid` `4..36` and notes at `oid=40`), while nearby `TxSt` entries with overlapping OIDs are unrelated score/text style labels (e.g., `Page Numbers`, `Bar Numbers`, etc.).
+- Multiple chunk families embed the same small arrangement-marker plist (`arrangementMarkerTitleList`), including large `PluginData` and non-ASCII chunk families; this appears to be replicated metadata, not timeline position data.
+- OIDs are not globally unique across chunk families. The same OID can refer to unrelated records in different chunk types (`TxSt`, `AuFl`, `AuRg`, `GenM`, `Envi`, `MSeq`, `EvSq`, etc.), so joins must remain chunk-type scoped.
+- Several non-marker object IDs from type-36 rows (e.g., `40`, `44`, `48`, `52`, `56`, `60`, `64`, `68`, `120`, `124`, `128`, `144`, `152`, `168`, `172`, `232`, `236`, `240`, `244`, `248`, `264`, `268`) appear to map to loop/section-related entities and may be useful for broader timeline decoding.
+- Embedded 80-byte rows inside the large `PluginData` body include `type=32` records with timeline ticks and a field that flips between `1024`/`1025` near `tick=3,811,619`; this likely represents timeline/ruler state metadata and is a candidate source for future bar-number decoding.
+- In the largest `PluginData` chunk (`len=4,856,566`), 80-byte row decoding is strongly alignment-sensitive; the strongest stable decode is at alignment `1` (99 rows with sentinel signature `u32[7]=0x3FFFFFFF` and `u32[9]=0x88000000`).
+- That aligned `PluginData` type-32 table is heavily repeated with near-identical row templates across the file, indicating replicated state snapshots rather than a single canonical timeline table.
+- In those type-32 rows:
+  - `u32[1]` behaves like a timeline tick and repeatedly lands near known section boundaries (`~1,144,320`, `~1,582,080`, `~2,096,640`, `~2,875,859`, `~3,807,779`, `~4,462,499`, `~4,557,059`).
+  - `u32[4]` and `u32[8]` behave like object/lane references (small ID domains), not direct bar counters.
+  - `u32[3]` toggles between small state values (`1`, `1024`, `1025`) and appears to be a mode/state flag.
+- Type-36 rows in the same binary neighborhood share the same sentinel pattern and carry per-lane/event references; these rows remain event-layer metadata and still do not expose a direct absolute bar-number field.
+- `Trns(oid=0,len=468)` contains compact global timeline constants including a literal `3840`, `4096`, and pre-roll-like signed values (`0xFFFF`-style), suggesting transport/grid configuration storage separate from arrangement section events.
+- Re-evaluated `PluginData` pattern `[144, tick, ..., 64, 0x89000000, 0, 240]` is MIDI-style event data (`type 144` + companion `type 64`) with beat-like `960` tick spacing, not a standalone bar-axis table.
+- Across `EvSq`, the only observed `0x7F0000xx` bridge signatures are `0x0100007F` (and a single `0x8100007F` variant), both tied to tempo bridge rows; no additional sibling signatures were observed that would directly encode time-signature/bar transforms.
+- `Song` bodies contain structured 24-byte (`u32x6`) node tables with stable type domains:
+  - type-14 nodes carry marker-domain values (`0,4,8,...,36`) and linked-list style edges (`14 -> 14` in fields `u32[4:6]`).
+  - type-20 nodes carry dense bar-domain values (mostly `+4` steps) and linked-list style edges (`20 -> 20` in fields `u32[4:6]`).
+- In the strongest `Song` decode candidate (`len=55796`, alignment `20`), the arrangement marker OID set `{4,8,12,16,20,24,28,32,36}` is present explicitly inside type-14 nodes, confirming the marker domain exists in this table family even though marker->bar joins are not yet decoded.
+- The type-20 bar node chains are deterministic and monotonic within snapshots (examples observed up through `bar ~848` in `len=12876` snapshots), but a direct, decoded join from these bar nodes to arrangement marker sequence ticks remains unresolved.
+- In larger `Song` snapshots, node records frequently carry non-typed/hash-like link payloads in `u32[2:6]`, while smaller snapshots retain clearer typed edge chains (`14 -> 14`, `20 -> 20`), suggesting these tables are snapshot/state variants of the same graph structure.
+
+## Working Hypotheses
+
+- `USEl` may preserve active edit-state snapshots with embedded event tables; extracting stable timeline layers may require selecting the right logical snapshot, not just latest chunk by file order.
+- Type-18 sequence tables likely represent arrangement-lane sections, while marker-linked type-36 rows likely represent a different timeline lane/use-case.
+
+## Song Node Graph / Marker-Bar Join (Decoded)
+
+- **Song Node Graph Identified**: The `Song` chunk body (specifically the largest one, alignment often near 20 or 9500) contains a graph of 24-byte nodes (`u32x6`).
+- **Node Types**:
+  - **Type 14**: "Marker Domain" nodes. Records often (but not always) correspond to Marker OIDs.
+  - **Type 20**: "Bar Domain" nodes. Records appear densely (step 4 instructions in ID space).
+- **Common ID Space (Join Key)**: The second field `rec[1]` acts as a unified ID space shared between Type 14 and Type 20.
+  - When a Type 14 node and a Type 20 node share the same `rec[1]`, they represent the same logical point (the Join).
+  - The ID space seems to step regularly (e.g., 68, 72, 76, 80...).
+- **Graph Structure**:
+  - `rec[4]` and `rec[5]` act as **Typed Links**: `(TargetType, TargetID)`.
+  - Type 14 nodes often form linked lists (e.g. `(14, 72) -> (14, 76)`).
+  - Type 20 nodes often form linked lists (e.g. `(20, 68) -> (20, 72)`).
+  - Cross-type links are implicit via `rec[1]` identity (structural intersection).
+  - **Node Roles**: A single ID (e.g., OID 20) can map to multiple Type-20 nodes:
+    - **Data Node**: Carries payload in `rec[2], rec[3]` (High word often `0xF016...`). Link fields often zero or garbage.
+    - **Link Node**: Carries structural links in `rec[4], rec[5]`. Payload fields often zero.
+- **Payloads**:
+  - `rec[2]` and `rec[3]` contain payload data (Bar/Tick info).
+  - Payload existence is distributed: Sometimes a Type 14 node carries data while the corresponding Type 20 node is just a placeholder link, or (more commonly for bars) vice versa.
+  - Common payload constant `rec[3] = 0xF016884F` (`4027672655`) is observed in both types when data is present.
+- **Extractor Implementation**: `logic_extractor.py` now extracts this graph into `summary.song_node_graph`, providing:
+  - `marker_map`: Map of `rec[1] -> { type14: [nodes], type20: [nodes] }`.
+  - `sequence`: Sorted list of keys useful for timeline reconstruction.
+  - **Correlation**: The extractor now injects `graph_payload_u32` (from Data Nodes) and `graph_links_20` (from Link Nodes) directly into `arrangement_markers`, allowing correlation of Markers with Song Graph data.
+    - **Payload Analysis (2026-02-09 - Conclusion)**:
+      - Extensive analysis of `rec[2]` (Payload) and `rec[4]/rec[5]` (Data Node "Links") yields no standard numeric decoding.
+      - Values are non-monotonic with respect to time.
+      - Values do not map to file offsets or `PluginData` indices.
+      - **Conclusion**: The fields likely contain a hash or opaque Object ID that references an internal runtime object not serialized in a simple table.
+      - **Recommendation**: Rely on `EvSq` for absolute timing. Use Song Graph only for topological sequencing (A -> B).

--- a/docs/reference/RE_FINDINGS.md
+++ b/docs/reference/RE_FINDINGS.md
@@ -85,3 +85,164 @@ This log captures concrete findings from `ProjectData` analysis, including disco
       - Values do not map to file offsets or `PluginData` indices.
       - **Conclusion**: The fields likely contain a hash or opaque Object ID that references an internal runtime object not serialized in a simple table.
       - **Recommendation**: Rely on `EvSq` for absolute timing. Use Song Graph only for topological sequencing (A -> B).
+
+## Project Alternatives (2026-04-05)
+
+### Overview
+
+Logic Pro's "Project Alternatives" feature allows users to save multiple variations of a project (different arrangements, mixes, etc.) within a single `.logicx` bundle. All alternatives share the same audio assets but maintain independent project state (track configuration, mix settings, arrangement, UI layout).
+
+### Bundle Structure
+
+A `.logicx` bundle is a macOS package directory with this structure:
+
+```
+MyProject.logicx/
+  Resources/
+    ProjectInformation.plist        # Bundle metadata, alternative names registry
+  Alternatives/
+    000/                            # First alternative (zero-indexed, zero-padded to 3 digits)
+      ProjectData                   # Binary project state (tracks, regions, mix, arrangement)
+      MetaData.plist                # Per-alternative metadata (tempo, key, track count, audio refs)
+      DisplayState.plist            # UI state as XML plist (screensets, inspector, editor layout)
+      DisplayStateArchive           # Same UI state as NSKeyedArchiver binary plist
+      WindowImage.jpg               # Thumbnail screenshot (1920xN JPEG, progressive)
+      Undo Data.nosync/             # Per-alternative undo history (.nosync prevents iCloud sync)
+        Trash/                      # Cleared undo data
+      Project File Backups/         # Rolling backup snapshots (up to 10 observed)
+        00/
+          ProjectData               # Backup copy of ProjectData
+          MetaData.plist            # Backup copy of MetaData
+        01/
+          ...
+        09/
+          ...
+    001/                            # Second alternative (if created)
+      ProjectData
+      MetaData.plist
+      ...
+  Media/
+    Audio Files/                    # SHARED across all alternatives
+      Record#01.aif
+      Record#02.aif
+      ...
+```
+
+### Key Findings
+
+#### 1. Alternative Directory Naming
+
+- Alternatives are stored as zero-padded 3-digit directories: `000`, `001`, `002`, etc.
+- The directory name is a simple sequential index, not an ID or hash.
+- All 14 projects examined on this system have only a single alternative (`000`), which is the default state when no additional alternatives have been created.
+
+#### 2. The 0xFFFFFFFF Sentinel Value
+
+Two projects (`Untitled.logicx` and `Untitled 1.logicx`) use the directory name `4294967295` (= `0xFFFFFFFF` = `UINT32_MAX`) instead of `000`.
+
+**Characteristics of sentinel-value projects:**
+- No `ProjectData` file (the directory contains only an empty `Undo Data.nosync/` folder)
+- No `Resources/` directory and no `ProjectInformation.plist`
+- No `Media/` directory
+- No `MetaData.plist`, `DisplayState.plist`, `DisplayStateArchive`, or `WindowImage.jpg`
+
+**Interpretation:** `0xFFFFFFFF` is a "never saved" / "no committed alternative" sentinel. These are projects that were created (Logic allocates the bundle directory structure on disk) but never saved by the user. Logic creates the `Alternatives/4294967295/` directory and `Undo Data.nosync/` immediately on project creation as a workspace for undo data, but the actual `ProjectData` is only written on first explicit save, at which point the sentinel directory would be replaced with `000/`. This is a classic use of `UINT32_MAX` as a "null" or "uninitialized" marker in a `UInt32` index space.
+
+#### 3. Shared Audio Files (Media Directory)
+
+- Audio files live in `<project>.logicx/Media/Audio Files/` at the **bundle root**, outside of any alternative.
+- All alternatives reference the same shared pool of audio files.
+- The `MetaData.plist` inside each alternative lists which audio files are actively used (`AudioFiles` key) vs unused (`UnusedAudioFiles` key), with paths relative to `Media/` (e.g., `"Audio Files/Record#22.aif"`).
+- This means switching alternatives changes the project state but never duplicates audio data.
+
+#### 4. Active Alternative Tracking via ProjectInformation.plist
+
+The active alternative is tracked in `Resources/ProjectInformation.plist` at the bundle root. Key fields:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `BundleVersion` | Integer | Always `2` in observed projects |
+| `LastSavedFrom` | String | Logic version string (e.g., `"Logic Pro X 10.7.7 (5762)"`) |
+| `HasProjectFolder` | Boolean | Whether project uses a project folder |
+| `projectAssetFlags` | Integer | Asset management flags (observed: `8265`) |
+| `VariantNames` | Dictionary | **Maps alternative index to display name** |
+| `VariantNamesV2` | Dictionary | **Maps alternative index to name template** |
+| `ExternalRecordPath` | Data | Bookmark data for external recording path (optional) |
+
+**`VariantNames`** is the critical field for alternatives:
+- Keys are string-encoded alternative indices (`"0"`, `"1"`, `"2"`, ...) that correspond to directory names (`000`, `001`, `002`, ...)
+- Values are user-visible alternative names (e.g., `"test"`, `"RiffIdea"`, `"Mix A"`)
+- Single-alternative projects have just `{"0": "<project_name>"}`
+
+**`VariantNamesV2`** uses the same key structure but with template tokens:
+- `"{PROJECT_NAME}"` means the alternative name matches the project filename
+- Custom names would appear as literal strings here
+
+**Note:** There is no explicit "active alternative index" field in this plist. The active alternative is likely determined by:
+1. The most recently modified `ProjectData` file (by filesystem timestamp)
+2. Runtime state maintained by Logic Pro in memory (not persisted to a separate field)
+3. Possibly encoded within the `ProjectData` binary itself
+
+Since all observed projects have only one alternative, the active-tracking mechanism for multi-alternative projects could not be directly confirmed. The `VariantNames` dictionary key set implicitly defines which alternatives exist.
+
+#### 5. Per-Alternative State Breakdown
+
+Each alternative directory contains independent copies of:
+
+| File | Format | Content |
+|------|--------|---------|
+| `ProjectData` | Custom binary (magic: `23 47 C0 AB`) | Full project state: tracks, regions, plugins, mixer, arrangement markers, tempo map |
+| `MetaData.plist` | XML plist | Summary metadata: BPM, key, time sig, sample rate, track count, audio file references |
+| `DisplayState.plist` | XML plist | UI state: screensets, window frames, inspector visibility, editor positions, zoom levels |
+| `DisplayStateArchive` | Binary plist (NSKeyedArchiver) | Same UI state as `DisplayState.plist` but in archived binary format |
+| `WindowImage.jpg` | JPEG (progressive, 1920px wide) | Thumbnail screenshot of project window (used in Finder Quick Look and alternative picker) |
+| `Undo Data.nosync/` | Directory | Per-alternative undo history; `.nosync` suffix prevents iCloud Drive sync |
+| `Project File Backups/` | Directory (00-09) | Rolling auto-save backups, each containing `ProjectData` + `MetaData.plist` |
+
+#### 6. ProjectData Binary Header Comparison
+
+All `ProjectData` files share the same magic bytes and overall structure:
+
+```
+Offset  test.logicx/000    RiffIdea.logicx/000   Backup 00 (test)
+0x00    23 47 C0 AB        23 47 C0 AB            23 47 C0 AB         (magic)
+0x04    C6 09              C9 09                  C6 09               (version/flags)
+0x06    03 00 04 00 00 00  03 00 04 00 00 00      03 00 04 00 00 00   (common header)
+0x0C    01 00 08 00        01 00 08 00            01 00 08 00         (common header)
+0x10    9F 9D 2A 00        58 AF 29 00            08 69 2A 00         (varies: file size or checksum)
+0x18    67 6E 6F 53        67 6E 6F 53            67 6E 6F 53         ("gnoS" = "Song" reversed)
+```
+
+The version byte at offset `0x04` differs between Logic versions (`C6 09` for 10.7.4, `C9 09` for 10.7.7). The value at `0x10-0x13` varies per save and likely represents a content-dependent size or hash.
+
+#### 7. Programmatic Switching Feasibility
+
+**AppleScript:** Logic Pro has minimal AppleScript support. There is no documented AppleScript command to switch alternatives. The File > Project Alternatives menu is the primary UI for switching.
+
+**Accessibility API:** The Alternatives submenu can be navigated via System Events / Accessibility:
+- Menu path: `File > Project Alternatives > [alternative name]`
+- This is the most viable programmatic approach for switching alternatives at runtime.
+
+**Direct file manipulation (offline):** Since the active alternative is not explicitly stored in a single field:
+- Modifying `ProjectInformation.plist` alone is insufficient to switch alternatives.
+- Logic reads the `ProjectData` from the alternative directory on project open; the mechanism for selecting which directory to read is internal to Logic.
+- **Safest offline approach**: Rename/swap alternative directories (e.g., rename `001/` to `000/` and vice versa), but this is fragile and risks data corruption.
+
+**Recommendation for MCP integration:**
+1. **Runtime switching**: Use Accessibility API to navigate `File > Project Alternatives > [name]` menu.
+2. **Reading alternative data**: The existing `ProjectDataParser.findProjectData()` already scans `Alternatives/000` through `Alternatives/009` with a fallback directory scan. It could be extended to enumerate all alternatives and parse each independently.
+3. **Listing alternatives**: Parse `Resources/ProjectInformation.plist` `VariantNames` dictionary to get the name-to-index mapping without opening each `ProjectData`.
+
+### Summary Table
+
+| Aspect | Finding |
+|--------|---------|
+| Storage location | `<project>.logicx/Alternatives/<NNN>/` (zero-padded 3-digit index) |
+| Audio sharing | All alternatives share `<project>.logicx/Media/Audio Files/` |
+| Name registry | `Resources/ProjectInformation.plist` > `VariantNames` dict |
+| Active tracking | No explicit persisted field found; likely runtime/implicit |
+| Sentinel 0xFFFFFFFF | "Never saved" placeholder for newly created, unsaved projects |
+| Per-alternative state | `ProjectData` (binary), `MetaData.plist`, `DisplayState.plist`, `DisplayStateArchive`, `WindowImage.jpg` |
+| Backups | Up to 10 rolling backups per alternative in `Project File Backups/00-09/` |
+| Programmatic switching | Accessibility API menu navigation is most viable; no AppleScript support |
+| Parser support | `ProjectDataParser.findProjectData()` already handles multi-alternative scanning |

--- a/reference/LOGIC_BINARY_SPEC.md
+++ b/reference/LOGIC_BINARY_SPEC.md
@@ -1,0 +1,390 @@
+# Logic Pro ProjectData: Binary Specification
+
+This document provides a technical specification for the internal structure and data mapping of the proprietary ProjectData file found within Logic Pro project packages (.logicx).
+
+## 1. File Structure Overview
+
+The ProjectData file is a binary container consisting of a global header followed by a sequence of structured data chunks.
+
+- Location: .logicx/Alternatives/[Index]/ProjectData
+- Some tooling (including `logic_extractor.py`) can also operate on a raw ProjectData file path.
+- Magic Bytes (Offsets 0x00-0x03): 23 47 C0 AB
+- Versioning (Offsets 0x04-0x07): Varies by Logic Pro version (e.g., D0 09 03 00).
+- Global Table Offset: The chunk sequence typically begins at offset 0x18.
+- **Global Settings (Plist-derived)**:
+  - Time Signatures: Extracted from `MetaData.plist` or `ProjectInformation.plist` (looking for `TimeSignature` keys). Defaults to 4/4 if missing.
+  - Sample Rate, BPM, Key, Frame Rate.
+
+---
+
+## 2. Chunk Architecture (36-Byte Header)
+
+Every data block is preceded by a standardized 36-byte header that defines the chunk type, identity, and size.
+
+| Offset | Size | Field    | Description                                                                   |
+| :----- | :--- | :------- | :---------------------------------------------------------------------------- |
+| 0x00   | 4B   | ID       | 4-character identifier, stored in reverse byte order (e.g., "ivnE" for Envi). |
+| 0x04   | 6B   | Metadata | Internal versioning and type flags.                                           |
+| 0x0A   | 4B   | OID      | Object Identifier. Used for cross-referencing between chunks.                 |
+| 0x0E   | 8B   | Padding  | Reserved or static binary structure.                                          |
+| 0x16   | 6B   | Anchor   | Static signature. Typically 02 00 00 00 [01/02] 00.                           |
+| 0x1C   | 8B   | Length   | 64-bit Little Endian integer representing the body size in bytes.             |
+
+### Discovery Pattern
+
+Chunks can be located within a file by scanning for the anchor signature (02 00 00 00 . 00). The 4-byte chunk ID is located exactly 22 bytes before the start of this signature. In practice, this signature can also occur inside payloads, so validate that:
+
+1. The header is a full 36 bytes.
+2. The length field fits inside the file bounds.
+3. The anchor bytes at 0x16 match the detected signature.
+
+---
+
+## 3. Event Sequences (EvSq) and Tempo Encoding
+
+EvSq chunks store the project timeline, including MIDI data, automation, and tempo events.
+
+### Tempo Event Signature
+
+Tempo changes follow a specific 20-byte pattern:
+7F 00 00 01 [MM MM MM MM] [00 00 00 00] [PP PP PP PP PP PP PP PP]
+
+- Millitempo (4B): The tempo value stored as an integer (BPM x 10,000). To calculate BPM, divide the Little Endian integer by 10,000.
+- Tick Position (8B): The absolute timeline position in ticks.
+- Resolution: Logic Pro standard resolution is 3840 ticks per bar in 4/4 time.
+- Bar Calculation: (Ticks / 3840) + 1.
+
+**Extractor Note:** `logic_extractor.py` now preserves the raw tick position in the JSON output (`tempo_map[].tick`) so downstream tooling can avoid rounding error when converting to seconds.
+
+### MIDI Event Encoding
+
+Events are stored in 12-byte structures interleaved with tempo events.
+
+- **Structure**: `[Status Byte] [Data 1] [Data 2] [Reserved] [Position (8B)]`
+- **Status Byte**:
+  - High Nibble (Type): `0x9` (Note On), `0x8` (Note Off), `0xB` (Control Change), `0xC` (Program Change).
+  - Low Nibble (Channel): `0x0`-`0xF` (Channels 1-16).
+- **Position**: 8-byte Little Endian integer representing absolute tick position.
+
+---
+
+## 4. Sequence & Track Objects (MSeq / Trak)
+
+### MSeq (Sequence Object)
+
+MSeq entries appear to represent high-level sequence/track objects. In this file, the following layout was consistent:
+
+- **Name Length**: 2-byte Little Endian at offset 0x10.
+- **Name**: ASCII string starting at 0x12, `name_len` bytes.
+
+Example names observed: `Click Track`, `Drums`, `NSP Quad Cortex`, `Track Alternatives`, `Global Harmonies`.
+
+### Trak (Track Object)
+
+Trak chunks are fixed-length (58 bytes) in this ProjectData. The body does **not** appear to contain a region list.
+
+Observed fields:
+
+- **MSeq Reference**: 4-byte Little Endian at offset 0x08 (references an MSeq OID).
+- **UUID**: 16 bytes at offset 0x18 (format as standard UUID).
+- **Flags**: 4 bytes at offset 0x28 (unknown / UI state).
+
+Track names are commonly stored in TxSq/TxSt chunks (RTF text), cleaned and mapped by OID when MSeq references are absent.
+
+---
+
+## 5. Mixer and Track Parameters (AuCO / ivnE)
+
+Mixer and channel strip data are primarily stored in Audio Channel Objects (AuCO).
+
+### Volume Calculation
+
+Volume levels are stored as 32-bit integers using a proprietary logarithmic scale.
+
+- Unity Gain (0 dB) Reference: 1509949440 (00 80 00 5A)
+- Decibel Formula: dB = 40 \* log10(Value / 1509949440)
+- Note: A value of 0 indicates negative infinity dB.
+
+### Panning
+
+- Offset: 0x59 within the AuCO body.
+- Range: 0 (Hard Left) to 127 (Hard Right).
+- Center: 64.
+
+### Channel Strip Name
+
+- Offset: 0x3C within the AuCO body.
+- Encoding: null-terminated ASCII.
+- Example values: `Audio 1`, `Audio 2`, `Audio 3`.
+
+### Output Routing Labels
+
+- **Pattern Scan**: The extractor scans `AuCO` chunks for strings containing "Output", "Bus", or "Stereo Out".
+- **Usage**: Identifies the physical output or bus assignment (e.g., `Output 1-2`) useful for grouping stems.
+
+### Track Hierarchy and Routing
+
+Additional chunks define track properties and routing:
+
+- **AuCn**: Presence indicates active routing or auxiliary channel status.
+- **AuCU**: Presence and count indicates automation lanes.
+- **Trak**: Defines the arrangement track.
+  - **Region Mapping**: The body contains 4-byte Little Endian OIDs. These match the OIDs of Audio Regions (AuRg), linking them to this specific track.
+
+Extractor additions:
+
+- `channel_strip.config_records`: Summary of AuCO record lengths and byte-offset value counts. For length 241 records, the extractor reports byte values at offsets `0x50` and `0x51` (decimal 80/81) as `length_details["241"].offset_80_counts` and `offset_81_counts`, plus pair counts. In a send on/off toggle test, these bytes shifted (e.g., `0x08 -> 0x00` at 0x50 and `0x0A -> 0x08` at 0x51) indicating a likely send enable/bus slot flag.
+- `channel_strip.routing_records`: Summary of AuCn record lengths and u32 head samples.
+- `channel_strip.automation_records`: Summary of AuCU record lengths and decoded plist root keys (when present). For 76-byte AuCU records:
+  - `len76_field_counts` reports u16 values at offsets `0x10` and `0x12` (decimal 16/18) plus u32 values at offsets `0x10` and `0x18` (decimal 16/24).
+  - `len76_records` is a per‑record list with decoded fields including `send_level_db` (derived from `u32_offset_24` using the standard `raw_to_db` scale), a stable `index`, and `send_enabled_guess` (true when `u16_offset_18 == 0`, false when `u16_offset_18 == 0x0100`, otherwise null).
+  
+In send on/off tests:
+  - `u16_offset_18` flipped from `0x0000` (send on) to `0x0100` (send off).
+  - `u32_offset_24` matched the standard volume scale (e.g., `0x5A000000` = unity/0 dB). Sending level to `-inf` set this field to `0x00000000`, which converts to about `-144 dB` via the existing `raw_to_db` formula.
+  - Additional validation: `-6 dB` produced `u32_offset_24 = 0x3FE00000` (≈ -5.95 dB) and `+6 dB` produced `u32_offset_24 = 0x7F000000` (≈ +5.98 dB), confirming the same scale with quantization.
+
+---
+
+## 6. Assets and Regions (AuFl / AuRg)
+
+Logic Pro separates the definition of audio files from their placement on the timeline.
+
+### Audio File References (AuFl)
+
+- Content: Original file paths or aliases.
+- Encoding: UTF-16LE.
+- Payload Offset: Typically begins at offset 0x0A relative to the chunk body start.
+
+### Audio Regions (AuRg)
+
+- **Linkage**: The OID in the AuRg chunk header corresponds to an AuFl OID. In this file, AuRg OIDs are **not unique** (they map to audio assets), so regions must be uniquely identified by a composite key (e.g., OID + start ticks + name).
+- **Timeline Placement**:
+  - Legacy mode: Start Position is an 8-byte Little Endian tick value at body offset `0x30`; duration can appear at `0x38`/`0x40`.
+  - Bar-field mode (newly observed): Start/length are encoded as bar values across `0x10..0x1F`:
+    - start bar = `u32@0x10 + (u32@0x14 >> 16)/65536`
+    - length bars = `u32@0x18 + (u32@0x1C >> 16)/65536`
+    - ticks are derived with `3840 ticks/bar`.
+  - **Important**: `u32@0x48` may alias `name_len << 16` (because `name_len` lives at `0x4A`), so it is now treated as a low-confidence legacy fallback.
+
+### Region Name
+
+- Name Length: 2-byte Little Endian at offset 0x4A.
+- Name: ASCII string at 0x4C, length `name_len`.
+- Example values: `Rec#03.31`, `Click Track.10`, `The Last Light.4`.
+
+### Region → Track Association (Heuristic)
+
+Track association does **not** appear directly in Trak. Instead, AuRg bodies contain track references at **variable offsets depending on AuRg length**. The extractor uses a heuristic:
+
+1. Group AuRg bodies by length.
+2. For each length, scan offsets to find positions that frequently contain Trak OIDs.
+3. Use the most frequent offsets for that length as candidate track refs.
+
+Additional signal (best-effort):
+
+- **Song / USEl (Explicit Tables)**: These chunks contain explicit `[TrackOID, Count, RegionOID...]` mapping tables. The extractor now prioritizes these tables over heuristics when present.
+- **Co-occurrence**: Proximity-based heuristic (nearest Trak OID within a short window) used as a fallback.
+- **Confidence Scoring**: The extractor assigns a confidence score (0.0 - 1.0) and source label (e.g., `song_usel_table`, `aurg_offset`, `name_prefix`) to every link.
+- **Song / USEl Tables**: Some sections appear to encode explicit `[track_oid, count, region_oid * count]` tables. The extractor now detects these tables and prefers them as a high-confidence source when the best match is dominant.
+
+This heuristic is documented in code (`logic_extractor.py`) and should be treated as “best-effort” until a definitive mapping is known.
+
+**Extractor Output:** When a region is mapped to a track, `logic_extractor.py` records:
+
+- `regions[].track_oid`, `regions[].track_confidence`, `regions[].track_source`
+- `regions[].timing_source`: Which timing decoder was used (`legacy:*` or `bar_fields_0x10_0x1C`).
+- `regions[].track_sources` (optional): List of contributing sources when multiple signals agree (e.g., `["aurg_offset", "name_tokens"]`).
+- `tracks[].regions[]` entries as objects: `{ oid, confidence, source }`
+- `tracks[].region_mapping_stats`: `{ total, by_source: { <source>: count } }`
+- `tracks[].track_id`: Stable identifier for cross‑project matching. Prefers `uuid`, otherwise falls back to `mseq_oid`, then normalized name, then OID.
+- `tracks[].name_norm`: Normalized track name tokens (lowercased, stopwords removed) when a name is present.
+- `tracks[].display_name`: Best-effort human-friendly name used by render planning; falls back to `Track <oid>` when only placeholder names are available.
+- `tracks[].name_raw` / `tracks[].name_is_generic`: Preserve the original extracted name and flag generic placeholders (e.g. `*Automation`).
+- `tracks[].track_stack` / `tracks[].is_summing_track_stack`: Best-effort stack classification metadata (`type`, `source`, `confidence`) and boolean summing flag.
+- `tracks[].parent_track_oid`, `tracks[].stack_root_track_oid`, `tracks[].stack_depth`, `tracks[].stack_child_oids`: Best-effort hierarchy fields inferred from MSeq linkage.
+- `tracks[].top_level_stack_name`: Best-effort canonical stack grouping label (`Midi Triggers`, `Click Track`, `Backing Track`, `Release Track`) from environment labels + track/region keywords.
+- `tracks[].synthetic` / `tracks[].synthetic_source` (optional): Synthetic catalog tracks created from unmapped environment labels when a concrete Trak mapping is unavailable. These carry names/stack hints but no regions.
+- `summary.track_hierarchy[]`: Flattened inferred parent/child edges with source and confidence.
+- `summary.top_level_stacks[]`: Group summary with stack name, member track OIDs/names, and aggregate region counts.
+- `summary.region_timing_mode` / `summary.timeline_tick_offset`: Decoder mode and optional global tick offset normalization applied when tempo/region data are stored in absolute timeline space.
+- `summary.environment_name_catalog[]`: Unmapped environment labels promoted into the synthetic track catalog (`oid`, `name`, `stack_hint`).
+- `summary.region_oid_reuse`: AuRg OID reuse diagnostics (`total_regions`, `unique_region_oids`, `max_region_oid_reuse`) and whether Song/USEl table mapping was enabled.
+- `summary.region_alias_refinement`: Post-processing diagnostics for alias-based region remapping (`retargeted_count`, `assigned_count`) and optional pass-level details when multi-pass refinement is used.
+- `summary.region_orphan_rec_assignment`: Diagnostics for generic orphan `Rec#..` region assignment pass (`assigned_count`) when unresolved regions are mapped via prefix-to-track fallback.
+
+---
+
+## 7. Plugin Data
+
+Plugin usage is recorded in specific chunks identified by a null ID.
+
+- **ID**: `00 00 00 00` (Null Bytes)
+- **Identification**: These chunks are detected by the standard header structure but with a zeroed ID.
+- **Content**: The body typically contains ASCII signatures of the plugin names (e.g., "Serum", "Valhalla", "Compressor", "Kontakt").
+
+---
+
+## 8. Text and Metadata (TxSt / TxSq)
+
+Text-based data, including track names and markers, is frequently stored in Rich Text Format (RTF).
+
+- Identifiers: TxSt (Text String) or TxSq (Text Sequence) chunks.
+- Format: RTF data starts with the standard {\rtf1 header.
+- Parsing: Extract payload text after the \fs24 (font size) or similar formatting tags.
+- **Arrangement Markers**: `TxSq` chunks often contain global arrangement markers (Verse, Chorus) distinguished from track names by context or specific text patterns.
+
+---
+
+## 9. Auxiliary Metadata Chunks (Observed)
+
+These chunk types appear in this ProjectData and contain useful metadata, but are not fully decoded:
+
+- **SngO**: NSKeyedArchiver plist. Contains keys like `arrangementMarkerTitleList`.
+- **GenM**: JSON and/or NSKeyedArchiver plist. Includes Drummer model state and arrangement metadata.
+- **CorM**: MIDI port names (e.g., `IAC Driver`, `Logic Pro Virtual In`).
+- **Hypr**: Automation parameter list (e.g., `Volume`, `Modulation`, `Pitch Bend`).
+- **Layr**: Environment layer names (e.g., `All Objects`, `Mixer`).
+- **ScSt**: Score/notation instrument set names (e.g., `Guitar`, `Bass 4`).
+- **InSt**: Score set root (e.g., `Score Set`).
+- **Trns**: Transition metadata (no obvious strings).
+- **Envi**: Environment objects. The extractor parses a best‑effort object record (name + column `x` coordinate + class id) and emits `summary.environment_objects`.
+- **USEl**: Large string-heavy chunk; likely selection/state data.
+
+These are currently extracted only as raw strings (see `logic_extractor.py`).
+
+---
+
+## 10. Non-ASCII Chunk Families (Decoded)
+
+Several chunk IDs are non-ASCII and encode embedded plists or fixed tables. The extractor now decodes these **best-effort** and records a summary in `summary.non_ascii_chunks`.
+
+Observed families:
+
+- **0x00000002** (len ~675,000; 3 copies): Mixed payload. Contains many **NSKeyedArchiver** segments plus length‑prefixed ASCII take names (e.g., `Drums_bip.18`). Dominant plist roots include `{"Shared": {"LoopFamily": {"LoopName": <name>, "LoopId": <int>}}}` (loop entries), `{"Cb": {"LoopFamilyName": <name>, "IsFamilyLoop": <bool>}}}` (loop families), and a small `contentTagLayoutName` plist (e.g., `Automatic`).
+- **0x000000E0** (len ~167,936): Similar **NSKeyedArchiver** segments (arrangement marker type map, loop families, edit metadata) plus many port/bus/track strings.
+- **0x0000004C / 0x000000A8** (len ~133,888): **NSKeyedArchiver** plists with `Cb` keys like `lastEditedDate` (NS.time seconds since 2001‑01‑01), `persistentAGCPreparedFlag`, and `nameUserModified`.
+- **0x00000004 / 0xFFFFFFFF**: **NSKeyedArchiver** plist containing `Shared.arrangementMarkerTitleList`, a map of slot → `{type: n}` (no titles).
+- **0x00000040** (len ~338,944): Dense **string table** with environment labels and GM instrument names.
+- **0x00000400** (len 136; ~224 copies): Fixed record layout (34 x `u32`). Indices `12/13` and `32/33` behave like UI coordinates when scaled by `/256`. Extractor emits `layout_tables` with `x1/y1/x2/y2`.
+- **0xFFFF0001**: Short ASCII payload (e.g., `Delete Tracks`).
+
+Extractor output shape:
+
+- `summary.non_ascii_chunks.string_tables[]`: `{ id, count, length, string_count, strings_sample[] }`
+- `summary.non_ascii_chunks.numeric_tables[]`: `{ id, count, length, track_oid_hits, region_oid_hits, top_pairs[] }` (heuristic; track/region OIDs are small, so expect false positives)
+- `summary.non_ascii_chunks.plists[]`: `{ id, count, length, keys[], root_keys[], strings_sample[] }`
+- `summary.non_ascii_chunks.layout_tables[]`: `{ id, count, scale, fields, records[] }` where each record includes `x1/y1/x2/y2` plus `source_env`/`target_env` when an `Envi` object matches the x‑column.
+- `summary.non_ascii_chunks.decoded.loop_entries[]`: `{ loop_name, loop_id, source }`
+- `summary.non_ascii_chunks.decoded.loop_families[]`: `{ family_name, is_family_loop, source }`
+- `summary.non_ascii_chunks.decoded.edit_metadata[]`: `{ last_edited_ns_time, last_edited_iso, name_user_modified, persistent_agc_prepared_flag, source }`
+- `summary.non_ascii_chunks.decoded.content_tag_layouts[]`: `{ layout_name, source }`
+- `summary.non_ascii_chunks.decoded.arrangement_marker_types[]`: `{ slot, type, source }`
+- `summary.non_ascii_chunks.misc[]`: `{ id, count, length }`
+
+Environment object extraction:
+
+- `summary.environment_objects[]`: `{ oid, name, x, class_id, length, name_offset, name_len, name_prefix_u16[], header_u32{}, y_positions[], y_decode_candidates[] }`.
+  - `x` is the environment column coordinate from the `Envi` chunk.
+  - `name_offset/name_len` are derived by scanning for the first length‑prefixed ASCII name.
+  - `name_prefix_u16` are the three u16 values immediately before the name length (useful for reverse‑engineering).
+  - `header_u32` captures u32 fields at offsets `0x00..0x1C` (raw header values).
+  - `y_positions` are derived from layout tables (no stable y‑coordinate observed inside `Envi`).
+  - `y_decode_candidates` is present only if a direct encoding match is detected (none observed for this file).
+- `summary.environment_layout_map`: `{ x -> { name?, y_positions[], track_oid? } }` compact index for column‑level lookup (JSON keys are strings).
+- `summary.environment_y_decode_report`: `{ top_encodings[], object_samples[], objects_scanned }` best‑effort report of near‑miss y‑decode patterns.
+
+---
+
+## 11. Global String Discovery and Heuristics
+
+Beyond structured chunks, significant metadata is recovered by scanning the entire binary for string patterns.
+
+### String Scanner
+
+The extractor scans for contiguous printable ASCII sequences (len > 6) and categorizes them:
+
+- **Performance Metadata**: Keywords like `vocal`, `stem`, `bpm`, `verse`, `chorus`.
+- **Project Notes**: Longer text blocks (>10 chars) often containing user notes or RTF fragments.
+- **System Noise**: Paths (`/usr/lib`, `/System/`), copyright strings, and library references are filtered out.
+
+---
+
+## 12. Implementation Notes for Parsing
+
+1. Endianness: All multi-byte integers (Length, OID, Ticks, Millitempo) are Little Endian.
+2. Chunk IDs: IDs are 4-byte characters. They must be byte-reversed for human-readable labels (e.g., binary 45 6E 76 69 is read as ivnE but represents the Envi chunk).
+3. Non-Contiguity: While chunks are often sequential, some files may contain padding between blocks. The anchor-based discovery method is more reliable than purely sequential parsing.
+
+---
+
+## 13. Arrangement Markers, Time Signature, Routing (Extractor State)
+
+### Arrangement Markers
+
+- The extractor uses TxSq RTF strings as arrangement marker names and records them in `summary.arrangement_markers`.
+- Primary decode path uses an explicit marker sequence table found in a small `EvSq` chunk (`EvSq(oid=0)` in this file):
+  - 16-byte triplet groups:
+    - head: `[18, start_tick, 0, ...]`
+    - marker row: `[marker_oid, 0x88000000, marker_type, duration_ticks]`
+    - tail: `[0, 0x88000000, 0, 0]`
+  - marker row `marker_oid` is joined to TxSq marker `oid`
+  - decoded rows are exposed in `summary.arrangement_marker_sequence_decode.events[]`
+  - marker placement source: `evsq_type18_sequence_unique` (single start per marker) or `evsq_type18_sequence_first`
+  - when available, `position_duration_ticks` and `position_end_tick` are emitted per marker
+- Secondary decode path (fallback) uses marker-linked `EvSq(oid=4)` 80-byte records:
+  - row type `u32[0] == 36`
+  - marker/object reference `u32[11]` (joined to TxSq marker `oid`)
+  - timeline tick `u32[1]`
+  - sequence index `u32[10]`
+  - lane id `u32[4]`
+  - decoded rows are exposed in `summary.arrangement_marker_decode.events[]`
+  - marker placement source: `evsq_type36_index0` or `evsq_type36_single_tick`
+- Each marker includes `oid` and `position_candidates[]` (decoded candidates with tick and source-specific fields).
+- `summary.arrangement_marker_position_stats` now reports decode details:
+  - `decoded_sequence_events`
+  - `decoded_sequence_ambiguous`
+  - `decoded_events`
+  - `decoded_ambiguous`
+  - `heuristics_used`
+- Legacy lexical/track heuristics remain available only when `summary.arrangement_marker_allow_heuristics` is set truthy.
+
+### Time Signature
+
+- `summary.time_signature_map` is populated from MetaData.plist / ProjectInformation.plist if available.
+- If no explicit time signature is found, the extractor defaults to **4/4 at bar 1** with source `assumed_default`.
+
+### Bar-Number Mapping (Current Decode)
+
+- The extractor emits `summary.bar_number_mapping_decode` and `summary.bar_number_mapping_stats`.
+- Primary decoded source is an `EvSq` type-96 tempo bridge (small `len=432` chunks in this file):
+  - row A: `[96, sequence_tick, 0, 0x0100007F|0x8100007F]`
+  - row B: `[tempo_raw, 0x88400000, tempo_tick_abs, 0]`
+  - `tempo_raw` is decoded as `BPM * 10000`
+  - normalized `tempo_tick` subtracts `summary.timeline_tick_offset` when present
+  - decoded rows are emitted as `bar_number_mapping_decode.anchors[]`
+  - adjacent anchor deltas are emitted as `bar_number_mapping_decode.segments[]`
+- Candidate bridge chunks and alignment scores are emitted in `bar_number_mapping_decode.bridge_candidates[]` (top-ranked entries only).
+- A secondary explicit bar-anchor decode is emitted from type-48 triplets:
+  - head: `[48, tick, 0x02000000, ...]`
+  - row: `[48, 0x88000000, bar_raw, tick]`
+  - tail: `[0, 0x88000000, 0, 0]`
+  - decoded rows are emitted in `bar_number_mapping_decode.explicit_bar_anchor_decode.events[]`
+  - both `bar_raw` and signed interpretation `bar_signed` are preserved
+  - cross-checks against the tempo bridge interpolation are emitted in `bar_number_mapping_decode.explicit_bar_anchor_decode.cross_check_vs_tempo_bridge[]`
+- A Song-table companion decode is emitted when `Song` bodies contain 24-byte node tables:
+  - candidate records are parsed as `u32x6` at best alignment
+  - type-20 nodes expose dense bar-domain values (`bar_nodes_head` / `bar_nodes_tail`)
+  - type-14 nodes expose marker-domain values (observed marker OID set: `0,4,8,...,36`)
+  - arrangement-marker-specific node hits are exposed as `arrangement_marker_nodes[]`
+  - linked-node hints are emitted in `bar_number_mapping_decode.song_bar_node_decode.bar_edge_sample[]` and `marker_edge_sample[]`
+  - same payload is mirrored at `summary.bar_number_mapping_song_decode` for convenience
+  - summary count is emitted as `summary.bar_number_mapping_stats.song_bar_node_count`
+- Marker projections through the tempo bridge are emitted in `bar_number_mapping_decode.marker_projection[]` and summarized in `summary.bar_number_mapping_stats.marker_projection_count`.
+
+### Routing
+
+- `AuCn` presence flags routing/aux status.
+- `AuCO` may contain output labels (e.g., `Output 1`, `Bus 1`, `Stereo Out`); these are extracted into `channel_strip.output` when present.
+- `channel_strip.config_records` provides per‑strip summaries of AuCO record lengths and byte-offset stats (currently offsets 0x50/0x51 for length‑241 records).
+- `channel_strip.routing_records` and `channel_strip.automation_records` provide per‑strip summaries of AuCn/AuCU record lengths and decoded plist root keys.

--- a/reference/LOGIC_BINARY_SPEC.md
+++ b/reference/LOGIC_BINARY_SPEC.md
@@ -388,3 +388,45 @@ The extractor scans for contiguous printable ASCII sequences (len > 6) and categ
 - `AuCO` may contain output labels (e.g., `Output 1`, `Bus 1`, `Stereo Out`); these are extracted into `channel_strip.output` when present.
 - `channel_strip.config_records` provides per‑strip summaries of AuCO record lengths and byte-offset stats (currently offsets 0x50/0x51 for length‑241 records).
 - `channel_strip.routing_records` and `channel_strip.automation_records` provide per‑strip summaries of AuCn/AuCU record lengths and decoded plist root keys.
+
+---
+
+## 15. TxSq — Arrangement Marker Text
+
+Projects with explicit arrangement markers (e.g. samples 2 and 3) carry
+8 `TxSq` chunks each. Sample 1 has none.
+
+Two payload shapes coexist:
+
+### Short-ASCII Section Name (~104-106 bytes)
+
+Body layout (observed for project-2 `TxSq(oid=36)`):
+
+```
+0000: 68 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+0010: 62 00 00 00 68 00 00 00 14 00 ff 01 1b 1b 2f 2f   ..........//QR
+0020: 51 52 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+...
+0060: 00 00 49 6e 74 72 6f 00                           ..Intro.
+```
+
+- `u32@0x00` — body length indicator.
+- `u32@0x10` = `0x62` — fixed marker.
+- `u32@0x14` = body length (repeat).
+- Bytes `2F 2F 51 52` at 0x1E are the literal ASCII `"//QR"` tag — the
+  short-TxSq discriminator.
+- A null-terminated ASCII section name appears near the tail (observed
+  around body offset `0x62`). The decoder locates the first printable
+  ASCII run after the `"//QR"` tag.
+
+Observed names in the bundled fixtures:
+`Intro`, `Verse`, `Chorus`, `Bridge`.
+
+### RTF Section Name (~480-484 bytes)
+
+Larger TxSq chunks carry RTF payloads (`{\rtf1 ... \fs24 <text> }`) —
+these are the same encoding used by track names. The existing parser
+extracts these; the TxSq marker decoder emits them as `source = .rtf`
+when the short-ASCII slot is empty.
+
+Decoder: `TxSqMarkerDecoder.decode(data:) -> [TxSqMarker]`.

--- a/reference/RE_FINDINGS.md
+++ b/reference/RE_FINDINGS.md
@@ -1,0 +1,87 @@
+# Reverse Engineering Findings Log
+
+This log captures concrete findings from `ProjectData` analysis, including discoveries that may help decode data beyond arrangement markers.
+
+## 2026-02-09 (Current Pass)
+
+- `USEl` payloads contain embedded 80-byte event rows that decode like `EvSq` rows.
+- The best 80-byte alignment offset in `USEl` varies by chunk (examples observed: `11`, `12`, `57`, `63`), but decoded event content is stable.
+- Decoding `USEl` 80-byte rows reproduces the same marker-linked type-36 event set seen in `EvSq(oid=4)`, including the same tick/OID pairs.
+- Marker-linked type-36 events are stable across many project snapshots:
+  - marker OIDs: `4, 8, 12, 16, 20, 24, 28, 32, 36`
+  - consistent 27-event set with ticks in range `521280..3536339`.
+- A separate explicit marker sequence table exists in `EvSq(oid=0, len=448)` using 16-byte triplets:
+  - head `[18, start_tick, 0, ...]`
+  - marker row `[marker_oid, 0x88000000, marker_type, duration_ticks]`
+  - tail `[0, 0x88000000, 0, 0]`
+- This type-18 table encodes marker order exactly as the arrangement lane sequence observed in the screenshot:
+  - `28 -> 20 -> 16 -> 4 -> 8 -> 32 -> 24 -> 12 -> 36`
+- In that table, `duration_ticks` on each marker row equals `next_start_tick - start_tick` for all non-terminal rows, indicating explicit section span encoding.
+- A dedicated tempo-bridge table exists in small `EvSq` chunks (`len=432`, seen at `oid=0` and `oid=64`) with repeated 16-byte pairs:
+  - row A `[96, sequence_tick, 0, 0x0100007F|0x8100007F]`
+  - row B `[tempo_raw, 0x88400000, tempo_tick_abs, 0]`
+  - `tempo_raw` decodes as `BPM * 10000` and `tempo_tick_abs` matches the absolute pre-offset tempo timeline.
+- A separate small `EvSq(oid=0, len=192)` triplet structure contains explicit bar-like anchors:
+  - head `[48, tick, 0x02000000, ...]`
+  - row `[48, 0x88000000, bar_raw, tick]`
+  - tail `[0, 0x88000000, 0, 0]`
+  - observed decoded rows include `(tick=1651200, bar_raw=420)` and `(tick=1654080, bar_raw=421)` plus a pre-roll style value `bar_raw=65526` (signed-16 interpretation `-10`).
+- `SngO`/`GenM` `NSKeyedArchiver` data includes `Shared.arrangementMarkerTitleList`, but observed content is type metadata (`slot -> { type }`) only; no marker titles or position ticks were found there.
+- `TxSq` contains arrangement marker titles (`oid` `4..36` and notes at `oid=40`), while nearby `TxSt` entries with overlapping OIDs are unrelated score/text style labels (e.g., `Page Numbers`, `Bar Numbers`, etc.).
+- Multiple chunk families embed the same small arrangement-marker plist (`arrangementMarkerTitleList`), including large `PluginData` and non-ASCII chunk families; this appears to be replicated metadata, not timeline position data.
+- OIDs are not globally unique across chunk families. The same OID can refer to unrelated records in different chunk types (`TxSt`, `AuFl`, `AuRg`, `GenM`, `Envi`, `MSeq`, `EvSq`, etc.), so joins must remain chunk-type scoped.
+- Several non-marker object IDs from type-36 rows (e.g., `40`, `44`, `48`, `52`, `56`, `60`, `64`, `68`, `120`, `124`, `128`, `144`, `152`, `168`, `172`, `232`, `236`, `240`, `244`, `248`, `264`, `268`) appear to map to loop/section-related entities and may be useful for broader timeline decoding.
+- Embedded 80-byte rows inside the large `PluginData` body include `type=32` records with timeline ticks and a field that flips between `1024`/`1025` near `tick=3,811,619`; this likely represents timeline/ruler state metadata and is a candidate source for future bar-number decoding.
+- In the largest `PluginData` chunk (`len=4,856,566`), 80-byte row decoding is strongly alignment-sensitive; the strongest stable decode is at alignment `1` (99 rows with sentinel signature `u32[7]=0x3FFFFFFF` and `u32[9]=0x88000000`).
+- That aligned `PluginData` type-32 table is heavily repeated with near-identical row templates across the file, indicating replicated state snapshots rather than a single canonical timeline table.
+- In those type-32 rows:
+  - `u32[1]` behaves like a timeline tick and repeatedly lands near known section boundaries (`~1,144,320`, `~1,582,080`, `~2,096,640`, `~2,875,859`, `~3,807,779`, `~4,462,499`, `~4,557,059`).
+  - `u32[4]` and `u32[8]` behave like object/lane references (small ID domains), not direct bar counters.
+  - `u32[3]` toggles between small state values (`1`, `1024`, `1025`) and appears to be a mode/state flag.
+- Type-36 rows in the same binary neighborhood share the same sentinel pattern and carry per-lane/event references; these rows remain event-layer metadata and still do not expose a direct absolute bar-number field.
+- `Trns(oid=0,len=468)` contains compact global timeline constants including a literal `3840`, `4096`, and pre-roll-like signed values (`0xFFFF`-style), suggesting transport/grid configuration storage separate from arrangement section events.
+- Re-evaluated `PluginData` pattern `[144, tick, ..., 64, 0x89000000, 0, 240]` is MIDI-style event data (`type 144` + companion `type 64`) with beat-like `960` tick spacing, not a standalone bar-axis table.
+- Across `EvSq`, the only observed `0x7F0000xx` bridge signatures are `0x0100007F` (and a single `0x8100007F` variant), both tied to tempo bridge rows; no additional sibling signatures were observed that would directly encode time-signature/bar transforms.
+- `Song` bodies contain structured 24-byte (`u32x6`) node tables with stable type domains:
+  - type-14 nodes carry marker-domain values (`0,4,8,...,36`) and linked-list style edges (`14 -> 14` in fields `u32[4:6]`).
+  - type-20 nodes carry dense bar-domain values (mostly `+4` steps) and linked-list style edges (`20 -> 20` in fields `u32[4:6]`).
+- In the strongest `Song` decode candidate (`len=55796`, alignment `20`), the arrangement marker OID set `{4,8,12,16,20,24,28,32,36}` is present explicitly inside type-14 nodes, confirming the marker domain exists in this table family even though marker->bar joins are not yet decoded.
+- The type-20 bar node chains are deterministic and monotonic within snapshots (examples observed up through `bar ~848` in `len=12876` snapshots), but a direct, decoded join from these bar nodes to arrangement marker sequence ticks remains unresolved.
+- In larger `Song` snapshots, node records frequently carry non-typed/hash-like link payloads in `u32[2:6]`, while smaller snapshots retain clearer typed edge chains (`14 -> 14`, `20 -> 20`), suggesting these tables are snapshot/state variants of the same graph structure.
+
+## Working Hypotheses
+
+- `USEl` may preserve active edit-state snapshots with embedded event tables; extracting stable timeline layers may require selecting the right logical snapshot, not just latest chunk by file order.
+- Type-18 sequence tables likely represent arrangement-lane sections, while marker-linked type-36 rows likely represent a different timeline lane/use-case.
+
+## Song Node Graph / Marker-Bar Join (Decoded)
+
+- **Song Node Graph Identified**: The `Song` chunk body (specifically the largest one, alignment often near 20 or 9500) contains a graph of 24-byte nodes (`u32x6`).
+- **Node Types**:
+  - **Type 14**: "Marker Domain" nodes. Records often (but not always) correspond to Marker OIDs.
+  - **Type 20**: "Bar Domain" nodes. Records appear densely (step 4 instructions in ID space).
+- **Common ID Space (Join Key)**: The second field `rec[1]` acts as a unified ID space shared between Type 14 and Type 20.
+  - When a Type 14 node and a Type 20 node share the same `rec[1]`, they represent the same logical point (the Join).
+  - The ID space seems to step regularly (e.g., 68, 72, 76, 80...).
+- **Graph Structure**:
+  - `rec[4]` and `rec[5]` act as **Typed Links**: `(TargetType, TargetID)`.
+  - Type 14 nodes often form linked lists (e.g. `(14, 72) -> (14, 76)`).
+  - Type 20 nodes often form linked lists (e.g. `(20, 68) -> (20, 72)`).
+  - Cross-type links are implicit via `rec[1]` identity (structural intersection).
+  - **Node Roles**: A single ID (e.g., OID 20) can map to multiple Type-20 nodes:
+    - **Data Node**: Carries payload in `rec[2], rec[3]` (High word often `0xF016...`). Link fields often zero or garbage.
+    - **Link Node**: Carries structural links in `rec[4], rec[5]`. Payload fields often zero.
+- **Payloads**:
+  - `rec[2]` and `rec[3]` contain payload data (Bar/Tick info).
+  - Payload existence is distributed: Sometimes a Type 14 node carries data while the corresponding Type 20 node is just a placeholder link, or (more commonly for bars) vice versa.
+  - Common payload constant `rec[3] = 0xF016884F` (`4027672655`) is observed in both types when data is present.
+- **Extractor Implementation**: `logic_extractor.py` now extracts this graph into `summary.song_node_graph`, providing:
+  - `marker_map`: Map of `rec[1] -> { type14: [nodes], type20: [nodes] }`.
+  - `sequence`: Sorted list of keys useful for timeline reconstruction.
+  - **Correlation**: The extractor now injects `graph_payload_u32` (from Data Nodes) and `graph_links_20` (from Link Nodes) directly into `arrangement_markers`, allowing correlation of Markers with Song Graph data.
+    - **Payload Analysis (2026-02-09 - Conclusion)**:
+      - Extensive analysis of `rec[2]` (Payload) and `rec[4]/rec[5]` (Data Node "Links") yields no standard numeric decoding.
+      - Values are non-monotonic with respect to time.
+      - Values do not map to file offsets or `PluginData` indices.
+      - **Conclusion**: The fields likely contain a hash or opaque Object ID that references an internal runtime object not serialized in a simple table.
+      - **Recommendation**: Rely on `EvSq` for absolute timing. Use Song Graph only for topological sequencing (A -> B).

--- a/reference/python_extractor_snippets.txt
+++ b/reference/python_extractor_snippets.txt
@@ -1,0 +1,77 @@
+def infer_tempo_tick_offset(tempo_map):
+    if not isinstance(tempo_map, list) or not tempo_map:
+        return 0
+    ticks = []
+    bars = []
+    for event in tempo_map:
+        if not isinstance(event, dict):
+            continue
+        tick = event.get("tick")
+        bar = event.get("bar")
+        if isinstance(tick, (int, float)):
+            ticks.append(int(tick))
+        if isinstance(bar, (int, float)):
+            bars.append(float(bar))
+    if not ticks:
+        return 0
+    first_tick = min(ticks)
+    first_bar = min(bars) if bars else 1.0
+    # Some projects store absolute bars/ticks with large pre-roll offsets.
+    if first_tick > 0 and first_bar >= 100.0:
+        return first_tick
+    return 0
+
+def infer_region_timing_mode(aurg_chunks):
+    total = 0
+    suspicious_len = 0
+    bar_valid = 0
+    legacy_starts = set()
+    for _, body in aurg_chunks:
+        total += 1
+        name_len = None
+        if len(body) >= 0x4C:
+            name_len = struct.unpack('<H', body[0x4A:0x4C])[0]
+        _, _, suspicious = infer_region_length_ticks_with_source(body, name_len=name_len)
+        if suspicious:
+            suspicious_len += 1
+        if len(body) >= 0x38:
+            legacy_starts.add(struct.unpack('<Q', body[0x30:0x38])[0])
+        if infer_region_bar_timing(body):
+            bar_valid += 1
+    if total <= 0:
+        return "legacy"
+    if bar_valid >= max(10, int(total * 0.5)) and suspicious_len >= max(10, int(total * 0.4)) and len(legacy_starts) <= 6:
+        return "bar_fields"
+    return "legacy"
+
+def build_track_ref_offsets_by_length(aurg_bodies, track_oids):
+    # Heuristic: for each AuRg length, find offsets that frequently contain track OIDs
+    offsets_by_len = {}
+    
+    # Pass 1: Find offsets using strong signals (Non-Zero)
+    valid_offsets_histogram = {} # offset -> count of lengths that use it (or total chunks?)
+    
+    for length, bodies in aurg_bodies.items():
+        counts = {}
+        total = len(bodies)
+        if total == 0:
+            continue
+        for body in bodies:
+            max_scan = min(len(body), 0xC0)
+            for off in range(0, max_scan, 4):
+                val = struct.unpack('<I', body[off:off+4])[0]
+                if val in track_oids and val != 0:
+                    counts[off] = counts.get(off, 0) + 1
+        
+        if counts:
+            # keep top offsets (by frequency), include ratio for confidence
+            ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:6]
+            entries = []
+            best_off = ranked[0][0]
+            
+            # Boost global histogram
+            valid_offsets_histogram[best_off] = valid_offsets_histogram.get(best_off, 0) + total
+            
+            for off, cnt in ranked:
+                ratio = cnt / float(total)
+                # Only keep offsets that show up with some consistency

--- a/reference/python_hierarchy_snippets.txt
+++ b/reference/python_hierarchy_snippets.txt
@@ -1,0 +1,663 @@
+
+    aliases = track.get("name_aliases")
+    if isinstance(aliases, list):
+        for alias in aliases:
+            candidate = clean_track_label_candidate(alias)
+            if candidate:
+                promoted_name = candidate
+                promoted_source = {
+                    "source": "alias_promoted",
+                    "name": candidate,
+                    "score": 55,
+                    "generic": False
+                }
+                break
+
+    if not promoted_name:
+        inferred_name, inferred_source = infer_track_name_from_regions(track, region_lookup)
+        if inferred_name:
+            promoted_name = inferred_name
+            promoted_source = inferred_source
+
+            existing_aliases = track.get("name_aliases", [])
+            if not isinstance(existing_aliases, list):
+                existing_aliases = []
+            lowered_existing = {str(a).lower() for a in existing_aliases if isinstance(a, str)}
+            if inferred_name.lower() not in lowered_existing:
+                existing_aliases.insert(0, inferred_name)
+            track["name_aliases"] = existing_aliases
+
+    if not promoted_name:
+        return
+
+    track["name"] = promoted_name
+    norm, _ = normalize_tokens(promoted_name)
+    if norm:
+        track["name_norm"] = norm
+
+    if promoted_source:
+        sources = track.get("name_sources", [])
+        if not isinstance(sources, list):
+            sources = []
+        duplicate = False
+        for source_entry in sources:
+            if not isinstance(source_entry, dict):
+                continue
+            if source_entry.get("source") == promoted_source.get("source") and source_entry.get("name") == promoted_source.get("name"):
+                duplicate = True
+                break
+        if not duplicate:
+            sources.append(promoted_source)
+        track["name_sources"] = sources
+
+def resolve_track_display_name(track):
+    if not isinstance(track, dict):
+        return "Track"
+
+    primary = track.get("name")
+    if isinstance(primary, str) and primary.strip() and not is_generic_track_name(primary):
+        return primary.strip()
+
+    aliases = track.get("name_aliases")
+    if isinstance(aliases, list):
+        for alias in aliases:
+            candidate = clean_track_label_candidate(alias)
+            if candidate:
+                return candidate
+
+    return f"Track {track.get('oid')}"
+
+def refresh_track_runtime_fields(track, region_lookup):
+    if not isinstance(track, dict):
+        return
+    promote_track_name(track, region_lookup)
+    track["display_name"] = resolve_track_display_name(track)
+    track["name_is_generic"] = is_generic_track_name(track.get("name")) if track.get("name") else True
+    stack_meta = classify_track_stack(track)
+    track["track_stack"] = stack_meta
+    track["is_summing_track_stack"] = stack_meta.get("is_summing")
+    track["track_id"] = build_track_id(
+        track.get("oid"),
+        uuid=track.get("uuid"),
+        mseq_oid=track.get("mseq_oid"),
+        name=track.get("name") or track.get("display_name")
+    )
+
+def classify_track_stack(track):
+    if not isinstance(track, dict):
+        return {
+            "type": "unknown",
+            "is_summing": False,
+            "source": "invalid_track",
+            "confidence": 0.0
+        }
+
+    labels = []
+    for key in ("name", "name_raw", "display_name"):
+        value = track.get(key)
+        if isinstance(value, str) and value.strip():
+            labels.append(value.strip())
+    aliases = track.get("name_aliases")
+    if isinstance(aliases, list):
+        for alias in aliases:
+            if isinstance(alias, str) and alias.strip():
+                labels.append(alias.strip())
+
+    lowered_labels = " ".join(labels).lower()
+    if "summing" in lowered_labels and "stack" in lowered_labels:
+        return {
+            "type": "summing",
+            "is_summing": True,
+            "source": "name_keyword",
+            "confidence": 0.95
+        }
+    if "folder stack" in lowered_labels or "track automation root folder" in lowered_labels:
+        return {
+            "type": "folder",
+            "is_summing": False,
+            "source": "name_keyword",
+            "confidence": 0.9
+        }
+
+    output_label = track.get("channel_strip", {}).get("output")
+    if isinstance(output_label, str) and output_label.strip():
+        lowered_output = output_label.lower().strip()
+        if lowered_output.startswith("bus "):
+            return {
+                "type": "summing",
+                "is_summing": True,
+                "source": "channel_output_bus",
+                "confidence": 0.55
+            }
+        if lowered_output.startswith("output ") or "stereo out" in lowered_output:
+            return {
+                "type": "none",
+                "is_summing": False,
+                "source": "channel_output_main",
+                "confidence": 0.5
+            }
+
+    if isinstance(track.get("flags_raw"), int):
+        return {
+            "type": "unknown",
+            "is_summing": False,
+            "source": "trak_flags_raw",
+            "confidence": 0.2
+        }
+
+    return {
+        "type": "unknown",
+        "is_summing": False,
+        "source": "insufficient_data",
+        "confidence": 0.0
+    }
+
+def build_track_hierarchy(final_tracks, mseq_parent_refs):
+    hierarchy_edges = []
+    if not isinstance(final_tracks, dict) or not final_tracks:
+        return hierarchy_edges
+
+    track_by_oid = final_tracks
+    track_keys = {}
+    key_to_tracks = {}
+
+    for oid, track in track_by_oid.items():
+        keys = set()
+        if isinstance(oid, int):
+            keys.add(oid)
+        mseq_oid = track.get("mseq_oid")
+        if isinstance(mseq_oid, int):
+            keys.add(mseq_oid)
+        track_keys[oid] = keys
+        for key in keys:
+            key_to_tracks.setdefault(key, set()).add(oid)
+
+    candidates = {}
+
+    def add_candidate(child_oid, parent_oid, confidence, source):
+        if child_oid == parent_oid:
+            return
+        if child_oid not in track_by_oid or parent_oid not in track_by_oid:
+            return
+        key = (child_oid, parent_oid)
+        existing = candidates.get(key)
+        if existing is None or confidence > existing.get("confidence", 0.0):
+            candidates[key] = {
+                "child_oid": child_oid,
+                "parent_oid": parent_oid,
+                "confidence": round(float(confidence), 2),
+                "source": source
+            }
+
+    # Heuristic 1: Shared MSeq key membership. Prefer non-generic anchor as parent.
+    for key, members in key_to_tracks.items():
+        if len(members) < 2:
+            continue
+        member_list = [track_by_oid[m] for m in members if m in track_by_oid]
+        if len(member_list) < 2:
+            continue
+
+        def anchor_sort(track):
+            stack_type = track.get("track_stack", {}).get("type")
+            stack_bonus = 0
+            if stack_type in ("summing", "folder"):
+                stack_bonus = 1
+            return (
+                0 if not track.get("name_is_generic", False) else 1,
+                -stack_bonus,
+                -(len(track.get("regions", []))),
+                track.get("oid", 0)
+            )
+
+        anchor = sorted(member_list, key=anchor_sort)[0]
+        anchor_oid = anchor.get("oid")
+        if anchor_oid is None:
+            continue
+
+        for member in member_list:
+            child_oid = member.get("oid")
+            if child_oid is None or child_oid == anchor_oid:
+                continue
+            conf = 0.85 if member.get("name_is_generic", False) else 0.55
+            add_candidate(child_oid, anchor_oid, conf, "shared_mseq_key")
+
+    # Heuristic 2: Explicit MSeq ref at offset 0x08 from MSeq bodies.
+    if isinstance(mseq_parent_refs, dict):
+        for child_oid, keys in track_keys.items():
+            child_track = track_by_oid.get(child_oid, {})
+            child_generic = child_track.get("name_is_generic", False)
+            for key in keys:
+                parent_key = mseq_parent_refs.get(key)
+                if parent_key is None:
+                    continue
+                parent_oids = key_to_tracks.get(parent_key, set())
+                for parent_oid in parent_oids:
+                    if parent_oid == child_oid:
+                        continue
+                    parent_track = track_by_oid.get(parent_oid, {})
+                    parent_generic = parent_track.get("name_is_generic", False)
+                    conf = 0.35
+                    if child_generic and not parent_generic:
+                        conf = 0.8
+                    elif child_generic and parent_generic:
+                        conf = 0.45
+                    elif (not child_generic) and (not parent_generic):
+                        conf = 0.4
+                    if parent_track.get("track_stack", {}).get("type") in ("summing", "folder"):
+                        conf += 0.1
+                    add_candidate(child_oid, parent_oid, conf, "mseq_ref_off8")
+
+    parent_of = {}
+
+    def creates_cycle(child_oid, parent_oid):
+        seen = {child_oid}
+        current = parent_oid
+        while current is not None:
+            if current in seen:
+                return True
+            seen.add(current)
+            current = parent_of.get(current)
+        return False
+
+    by_child = {}
+    for edge in candidates.values():
+        by_child.setdefault(edge["child_oid"], []).append(edge)
+
+    for child_oid, options in by_child.items():
+        ranked = sorted(
+            options,
+            key=lambda e: (
+                -e.get("confidence", 0.0),
+                -len(track_by_oid.get(e.get("parent_oid"), {}).get("regions", [])),
+                e.get("parent_oid", 0)
+            )
+        )
+        selected = None
+        for edge in ranked:
+            if edge.get("confidence", 0.0) < 0.5:
+                continue
+            parent_oid = edge.get("parent_oid")
+            if parent_oid is None:
+                continue
+            if creates_cycle(child_oid, parent_oid):
+                continue
+            selected = edge
+            break
+        if selected:
+            parent_of[child_oid] = selected["parent_oid"]
+
+    children_of = {}
+    for child_oid, parent_oid in parent_of.items():
+        children_of.setdefault(parent_oid, set()).add(child_oid)
+
+    def resolve_root(start_oid):
+        current = start_oid
+        seen = {start_oid}
+        depth = 0
+        while current in parent_of:
+            nxt = parent_of.get(current)
+            if nxt is None or nxt in seen:
+                break
+            seen.add(nxt)
+            current = nxt
+            depth += 1
+            if depth > 128:
+                break
+        return current, depth
+
+    for oid, track in track_by_oid.items():
+        parent_oid = parent_of.get(oid)
+        if parent_oid is not None:
+            track["parent_track_oid"] = parent_oid
+        root_oid, depth = resolve_root(oid)
+        track["stack_root_track_oid"] = root_oid
+        track["stack_depth"] = depth
+        track["stack_child_oids"] = sorted(list(children_of.get(oid, set())))
+        root_track = track_by_oid.get(root_oid)
+        if isinstance(root_track, dict):
+            root_name = root_track.get("display_name") or root_track.get("name")
+            if isinstance(root_name, str) and root_name.strip():
+                track["stack_root_name"] = root_name
+        track["in_track_stack"] = depth > 0 or len(track.get("stack_child_oids", [])) > 0
+
+    for child_oid, parent_oid in parent_of.items():
+        child_track = track_by_oid.get(child_oid, {})
+        parent_track = track_by_oid.get(parent_oid, {})
+        source = "inferred"
+        confidence = 0.5
+        for edge in by_child.get(child_oid, []):
+            if edge.get("parent_oid") == parent_oid:
+                source = edge.get("source", source)
+                confidence = edge.get("confidence", confidence)
+                break
+        hierarchy_edges.append({
+            "parent_track_oid": parent_oid,
+            "parent_track_name": parent_track.get("display_name") or parent_track.get("name"),
+            "child_track_oid": child_oid,
+            "child_track_name": child_track.get("display_name") or child_track.get("name"),
+            "source": source,
+            "confidence": round(float(confidence), 2)
+        })
+
+    hierarchy_edges.sort(key=lambda e: (e.get("parent_track_oid", 0), e.get("child_track_oid", 0)))
+    return hierarchy_edges
+
+def infer_canonical_stack_name(text):
+    if not isinstance(text, str):
+        return None
+    lowered = text.lower().strip()
+    if not lowered:
+        return None
+
+    if "midi triggers" in lowered or "midi trigger" in lowered:
+        return "Midi Triggers"
+    if "click track" in lowered or lowered == "click" or "midi click" in lowered:
+        return "Click Track"
+    if "backing track" in lowered:
+        return "Backing Track"
+    if "release track" in lowered:
+        return "Release Track"
+
+    if "cortex midi" in lowered and "quad cortex" in lowered:
+        return "Midi Triggers"
+    if "nano cortex midi" in lowered:
+        return "Midi Triggers"
+    if "intro track" in lowered:
+        return "Release Track"
+    if "live effects" in lowered or "riser" in lowered:
+        return "Release Track"
+    if "transition" in lowered:
+        return "Release Track"
+    if "backing" in lowered and ("fx" in lowered or "instrumental" in lowered):
+        return "Backing Track"
+    return None
+
+def infer_track_top_level_stack(track, region_lookup):
+    if not isinstance(track, dict):
+        return None
+
+    fragments = []
+    for key in ("display_name", "name", "name_raw", "stack_root_name"):
+        value = track.get(key)
+        if isinstance(value, str) and value.strip():
+            fragments.append(value.strip())
+    aliases = track.get("name_aliases")
+    if isinstance(aliases, list):
+        for alias in aliases:
+            if isinstance(alias, str) and alias.strip():
+                fragments.append(alias.strip())
+    for ref in track.get("regions", [])[:120]:
+        region_oid = ref.get("oid") if isinstance(ref, dict) else ref
+        region = region_lookup.get(region_oid) if isinstance(region_lookup, dict) else None
+        if not isinstance(region, dict):
+            continue
+        for key in ("name", "file"):
+            value = region.get(key)
+            if isinstance(value, str) and value.strip():
+                fragments.append(value.strip())
+
+    # Strong explicit signal from names/aliases.
+    explicit_hits = []
+    for fragment in fragments:
+    if "backing" in lowered and ("fx" in lowered or "instrumental" in lowered):
+        return "Backing Track"
+    return None
+
+def infer_track_top_level_stack(track, region_lookup):
+    if not isinstance(track, dict):
+        return None
+
+    fragments = []
+    for key in ("display_name", "name", "name_raw", "stack_root_name"):
+        value = track.get(key)
+        if isinstance(value, str) and value.strip():
+            fragments.append(value.strip())
+    aliases = track.get("name_aliases")
+    if isinstance(aliases, list):
+        for alias in aliases:
+            if isinstance(alias, str) and alias.strip():
+                fragments.append(alias.strip())
+    for ref in track.get("regions", [])[:120]:
+        region_oid = ref.get("oid") if isinstance(ref, dict) else ref
+        region = region_lookup.get(region_oid) if isinstance(region_lookup, dict) else None
+        if not isinstance(region, dict):
+            continue
+        for key in ("name", "file"):
+            value = region.get(key)
+            if isinstance(value, str) and value.strip():
+                fragments.append(value.strip())
+
+    # Strong explicit signal from names/aliases.
+    explicit_hits = []
+    for fragment in fragments:
+        canonical = infer_canonical_stack_name(fragment)
+        if canonical:
+            explicit_hits.append(canonical)
+    if explicit_hits:
+        distinct = sorted(set(explicit_hits))
+        if len(distinct) == 1:
+            return {
+                "name": distinct[0],
+                "confidence": 0.95,
+                "source": "explicit_name",
+                "evidence": distinct[0]
+            }
+
+        display_lower = str(track.get("display_name") or track.get("name") or "").lower()
+        if "midi" in display_lower:
+            chosen = "Midi Triggers"
+        elif "click" in display_lower:
+            chosen = "Click Track"
+        elif "backing" in display_lower:
+            chosen = "Backing Track"
+        elif any(token in display_lower for token in ("release", "riser", "fx", "transition")):
+            chosen = "Release Track"
+        elif "Backing Track" in distinct:
+            chosen = "Backing Track"
+        elif "Midi Triggers" in distinct:
+            chosen = "Midi Triggers"
+        elif "Click Track" in distinct:
+            chosen = "Click Track"
+        else:
+            chosen = distinct[0]
+        return {
+            "name": chosen,
+            "confidence": 0.78,
+            "source": "explicit_name_ambiguous",
+            "evidence": ",".join(distinct)
+        }
+
+    joined = " | ".join(fragments).lower()
+    scores = {
+        "Midi Triggers": 0.0,
+        "Click Track": 0.0,
+        "Backing Track": 0.0,
+        "Release Track": 0.0
+    }
+
+    weights = {
+        "Midi Triggers": [
+            ("midi triggers", 10.0), ("midi trigger", 9.0), ("quad cortex midi", 8.0),
+            ("nano cortex midi", 8.0), ("cortex midi", 6.0), ("trigger", 4.0), ("midi", 2.0)
+        ],
+        "Click Track": [
+            ("click track", 10.0), ("midi click", 8.0), ("click", 3.0), ("metronome", 6.0)
+        ],
+        "Backing Track": [
+            ("backing track", 10.0), ("backing", 5.0), ("instrumental", 6.0),
+            ("synth", 4.0), ("choir", 4.0), ("stem", 1.0), ("bip", 3.0)
+        ],
+        "Release Track": [
+            ("release track", 10.0), ("release", 8.0), ("live effects", 8.0),
+            ("riser", 8.0), ("fx", 6.0), ("transition", 5.0),
+            ("outro", 4.0), ("intro track", 4.0), ("impact", 5.0)
+        ]
+    }
+
+    for stack_name, patterns in weights.items():
+        for pattern, weight in patterns:
+            if pattern in joined:
+                scores[stack_name] += weight
+
+    if scores["Midi Triggers"] > 0 and "click track" in joined and "trigger" not in joined and "cortex midi" not in joined:
+        scores["Midi Triggers"] -= 2.5
+    if scores["Click Track"] > 0 and "backing track" in joined and "click track" not in joined:
+        scores["Click Track"] -= 1.5
+    if scores["Release Track"] > 0 and "click track" in joined and "release" not in joined:
+        scores["Release Track"] -= 2.0
+
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    best_name, best_score = ranked[0]
+    second_score = ranked[1][1] if len(ranked) > 1 else 0.0
+    if best_score < 6.0:
+        return None
+    if best_score < (second_score + 1.5):
+        return None
+
+    confidence = min(0.9, 0.55 + (best_score / 20.0))
+    return {
+        "name": best_name,
+        "confidence": round(confidence, 2),
+        "source": "keyword_scoring",
+        "evidence": f"{best_name}:{round(best_score, 2)}"
+    }
+
+def assign_named_top_level_stacks(final_tracks, region_lookup, environment_labels, environment_layout_map):
+    if not isinstance(final_tracks, dict):
+        return []
+
+    release_title_hints = build_release_title_hints(environment_layout_map, environment_labels)
+
+    discovered = set()
+    for raw in environment_labels or []:
+        canonical = infer_canonical_stack_name(raw)
+        if canonical:
+            discovered.add(canonical)
+    if isinstance(environment_layout_map, dict):
+        for payload in environment_layout_map.values():
+            if not isinstance(payload, dict):
+                continue
+            canonical = infer_canonical_stack_name(payload.get("name"))
+            if canonical:
+                discovered.add(canonical)
+
+    stack_members = {
+        "Midi Triggers": set(),
+        "Click Track": set(),
+        "Backing Track": set(),
+        "Release Track": set()
+    }
+
+    for oid, track in final_tracks.items():
+        info = infer_track_top_level_stack(track, region_lookup)
+        if not info:
+            region_count = len(track.get("regions", []))
+            display_lower = str(track.get("display_name") or track.get("name") or "").lower()
+            if "midi" in display_lower or "trigger" in display_lower:
+                info = {"name": "Midi Triggers", "confidence": 0.45, "source": "fallback_display"}
+            elif "click" in display_lower:
+                info = {"name": "Click Track", "confidence": 0.45, "source": "fallback_display"}
+            elif any(token in display_lower for token in ("release", "riser", "fx", "transition", "intro track")):
+                info = {"name": "Release Track", "confidence": 0.4, "source": "fallback_display"}
+            elif any(token in display_lower for token in ("drum", "backing", "synth", "choir", "guitar", "texture", "harmony", "comp", "rec")):
+                info = {"name": "Backing Track", "confidence": 0.33, "source": "fallback_display"}
+            elif region_count > 0:
+                info = {"name": "Backing Track", "confidence": 0.35, "source": "fallback_default"}
+            else:
+                continue
+
+        # Override with stronger primary-name hints to stabilize release/backing classification.
+        primary_label = track.get("display_name") or track.get("name") or track.get("name_raw") or ""
+        primary_norm, primary_tokens = normalize_tokens(primary_label)
+        primary_has_backing = bool(primary_tokens.intersection(BACKING_FUNCTION_TOKENS))
+        primary_is_release_title = bool(primary_norm and primary_norm in release_title_hints)
+        if primary_has_backing:
+            info = {
+                "name": "Backing Track",
+                "confidence": 0.88,
+                "source": "primary_name_hint",
+                "evidence": primary_label
+            }
+        elif primary_is_release_title:
+            info = {
+                "name": "Release Track",
+                "confidence": 0.88,
+                "source": "primary_name_hint",
+                "evidence": primary_label
+            }
+
+        stack_name = info.get("name")
+        if stack_name not in stack_members:
+            continue
+        track["top_level_stack_name"] = stack_name
+        track["top_level_stack_confidence"] = info.get("confidence")
+        track["top_level_stack_source"] = info.get("source")
+        track["top_level_stack_evidence"] = info.get("evidence")
+        stack_members[stack_name].add(oid)
+        discovered.add(stack_name)
+
+    ordered = ["Midi Triggers", "Click Track", "Backing Track", "Release Track"]
+    output = []
+    for stack_name in ordered:
+        members = sorted(list(stack_members.get(stack_name, set())))
+        b'Compressor', b'Channel EQ', b'Gain', b'Limiter', b'Kontakt', b'Serum',
+        b'FabFilter', b'Omnisphere', b'Valhalla', b'Echo', b'Reverb'
+    ]
+
+    audio_files = {}
+    mseq_names = {}
+    mseq_parent_refs = {}
+    trak_entries = {}
+    channel_strips = {}
+    tx_texts = {}
+    aurg_chunks = []
+    song_bodies = []
+    usel_bodies = []
+    evsq_chunks = []
+    midi_ports = set()
+    env_labels = set()
+    environment_objects = []
+    env_seen = set()
+    non_ascii_chunks = []
+
+    for ch in iter_chunks(data):
+        cid = ch["cid"]
+        oid = ch["oid"]
+        body = ch["body"]
+        cid_bytes = ch["cid_bytes"]
+
+        if not all(32 <= b < 127 for b in cid_bytes):
+            # Skip plugin data (null ID) and zero-length placeholders
+            if cid_bytes != b'\x00\x00\x00\x00' and ch["length"] > 0:
+                non_ascii_chunks.append(ch)
+
+        if cid == "AuFl":
+            try:
+                name_len = struct.unpack('<H', body[8:10])[0]
+                if 0 < name_len < 1000:
+                    raw_bytes = body[10 : 10 + (name_len * 2)]
+                    path = raw_bytes.decode('utf-16le', errors='ignore')
+                    audio_files[oid] = os.path.basename(path)
+                    project["summary"]["audio_assets"].append({"name": path, "oid": oid})
+            except Exception:
+                pass
+
+        elif cid == "MSeq":
+            name = parse_mseq_name(body)
+            if name:
+                mseq_names[oid] = name
+            if len(body) >= 0x0C:
+                try:
+                    ref_oid = struct.unpack('<I', body[0x08:0x0C])[0]
+                    if ref_oid and ref_oid != oid:
+                        mseq_parent_refs[oid] = ref_oid
+                except Exception:
+                    pass
+
+        elif cid == "Trak":
+            entry = trak_entries.get(oid, {"oid": oid})
+            if len(body) >= 0x0C:
+                mseq_oid = struct.unpack('<I', body[0x08:0x0C])[0]
+                if mseq_oid:
+                    entry["mseq_oid"] = mseq_oid
+            if len(body) >= 0x28:

--- a/reference/python_track_ref_heuristic.txt
+++ b/reference/python_track_ref_heuristic.txt
@@ -1,0 +1,106 @@
+def build_track_ref_offsets_by_length(aurg_bodies, track_oids):
+    # Heuristic: for each AuRg length, find offsets that frequently contain track OIDs
+    offsets_by_len = {}
+    
+    # Pass 1: Find offsets using strong signals (Non-Zero)
+    valid_offsets_histogram = {} # offset -> count of lengths that use it (or total chunks?)
+    
+    for length, bodies in aurg_bodies.items():
+        counts = {}
+        total = len(bodies)
+        if total == 0:
+            continue
+        for body in bodies:
+            max_scan = min(len(body), 0xC0)
+            for off in range(0, max_scan, 4):
+                val = struct.unpack('<I', body[off:off+4])[0]
+                if val in track_oids and val != 0:
+                    counts[off] = counts.get(off, 0) + 1
+        
+        if counts:
+            # keep top offsets (by frequency), include ratio for confidence
+            ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:6]
+            entries = []
+            best_off = ranked[0][0]
+            
+            # Boost global histogram
+            valid_offsets_histogram[best_off] = valid_offsets_histogram.get(best_off, 0) + total
+            
+            for off, cnt in ranked:
+                ratio = cnt / float(total)
+                # Only keep offsets that show up with some consistency
+                if ratio >= 0.2 or cnt >= 5:
+                    entries.append({"offset": off, "count": cnt, "ratio": round(ratio, 3)})
+            if entries:
+                offsets_by_len[length] = entries
+
+    # Pass 2: For lengths with no candidates, scan for offsets that are consistently Valid (mostly 0)
+    allow_zero = 0 in track_oids
+    
+    for length, bodies in aurg_bodies.items():
+        if length in offsets_by_len:
+def infer_region_bar_timing(body):
+    if len(body) < 0x20:
+        return None
+    try:
+        start_bar_i = struct.unpack('<I', body[0x10:0x14])[0]
+        start_bar_frac_raw = struct.unpack('<I', body[0x14:0x18])[0]
+        length_bar_i = struct.unpack('<I', body[0x18:0x1C])[0]
+        length_bar_frac_raw = struct.unpack('<I', body[0x1C:0x20])[0]
+    except Exception:
+        return None
+
+    # Fraction appears in the high 16 bits (e.g. 0xB7310000 -> 0.715...)
+    start_bar = float(start_bar_i) + ((start_bar_frac_raw >> 16) / 65536.0)
+    length_bar = float(length_bar_i) + ((length_bar_frac_raw >> 16) / 65536.0)
+    if start_bar <= 0.0 or length_bar <= 0.0:
+        return None
+    if start_bar > 200000 or length_bar > 50000:
+        return None
+
+    start_ticks_abs = int(round((start_bar - 1.0) * 3840.0))
+    length_ticks = int(round(length_bar * 3840.0))
+--
+def infer_tempo_tick_offset(tempo_map):
+    if not isinstance(tempo_map, list) or not tempo_map:
+        return 0
+    ticks = []
+    bars = []
+    for event in tempo_map:
+        if not isinstance(event, dict):
+            continue
+        tick = event.get("tick")
+        bar = event.get("bar")
+        if isinstance(tick, (int, float)):
+            ticks.append(int(tick))
+        if isinstance(bar, (int, float)):
+            bars.append(float(bar))
+    if not ticks:
+        return 0
+    first_tick = min(ticks)
+    first_bar = min(bars) if bars else 1.0
+    # Some projects store absolute bars/ticks with large pre-roll offsets.
+    if first_tick > 0 and first_bar >= 100.0:
+        return first_tick
+--
+def infer_region_timing_mode(aurg_chunks):
+    total = 0
+    suspicious_len = 0
+    bar_valid = 0
+    legacy_starts = set()
+    for _, body in aurg_chunks:
+        total += 1
+        name_len = None
+        if len(body) >= 0x4C:
+            name_len = struct.unpack('<H', body[0x4A:0x4C])[0]
+        _, _, suspicious = infer_region_length_ticks_with_source(body, name_len=name_len)
+        if suspicious:
+            suspicious_len += 1
+        if len(body) >= 0x38:
+            legacy_starts.add(struct.unpack('<Q', body[0x30:0x38])[0])
+        if infer_region_bar_timing(body):
+            bar_valid += 1
+    if total <= 0:
+        return "legacy"
+    if bar_valid >= max(10, int(total * 0.5)) and suspicious_len >= max(10, int(total * 0.4)) and len(legacy_starts) <= 6:
+        return "bar_fields"

--- a/reference/python_trak_envi.txt
+++ b/reference/python_trak_envi.txt
@@ -1,0 +1,359 @@
+        elif cid == "Trak":
+            entry = trak_entries.get(oid, {"oid": oid})
+            if len(body) >= 0x0C:
+                mseq_oid = struct.unpack('<I', body[0x08:0x0C])[0]
+                if mseq_oid:
+                    entry["mseq_oid"] = mseq_oid
+            if len(body) >= 0x28:
+                uuid = format_uuid(body[0x18:0x28])
+                if uuid:
+                    entry["uuid"] = uuid
+            if len(body) >= 0x2C:
+                entry["flags_raw"] = struct.unpack('<I', body[0x28:0x2C])[0]
+            trak_entries[oid] = entry
+
+        elif cid in ["AuCO", "AuCn", "AuCU"]:
+            if oid not in channel_strips:
+                channel_strips[oid] = {
+                    "oid": oid,
+                    "mixer": {},
+                    "routing": False,
+                    "automation_lanes": 0,
+                    "_config_records": [],
+                    "_routing_records": [],
+                    "_automation_records": []
+                }
+            if cid == "AuCO":
+                channel_strips[oid]["_config_records"].append(body)
+                try:
+                    v_raw = struct.unpack('<I', body[0x74:0x78])[0]
+                    p_raw = body[0x59]
+                    name = read_null_terminated_ascii(body, 0x3C, 64)
+                    output_label = None
+                    for s in re.findall(b'[\x20-\x7E]{4,}', body):
+                        if b'Output' in s or b'Bus' in s or b'Stereo Out' in s:
+                            output_label = s.decode('ascii', errors='ignore').strip()
+                            break
+                    channel_strips[oid]["mixer"] = {"vol": raw_to_db(v_raw), "pan": p_raw}
+                    if name:
+                        channel_strips[oid]["name"] = name
+                    if output_label:
+                        channel_strips[oid]["output"] = output_label
+                except Exception:
+                    pass
+            elif cid == "AuCn":
+                channel_strips[oid]["routing"] = True
+                channel_strips[oid]["_routing_records"].append(body)
+            elif cid == "AuCU":
+                channel_strips[oid]["automation_lanes"] += 1
+                channel_strips[oid]["_automation_records"].append(body)
+
+        elif cid == "AuRg":
+            aurg_chunks.append((oid, body))
+
+        elif cid in ["TxSq", "TxSt"]:
+            try:
+                txt = body.decode('ascii', errors='ignore')
+                if "{" in txt:
+                    cleaned = clean_logic_text(txt)
+                    if cleaned:
+                        tx_texts[oid] = cleaned
+                        if len(cleaned) > 2:
+                            project["summary"]["markers"].append({"name": cleaned, "oid": oid})
+                            if cid == "TxSq":
+                                project["summary"]["arrangement_markers"].append({
+                                    "name": cleaned,
+                                    "source": "txsq",
+                                    "oid": oid
+                                })
+            except Exception:
+                pass
+
+        elif cid == "EvSq":
+            evsq_chunks.append({
+                "oid": oid,
+                "body": body,
+                "start": ch.get("start")
+            })
+    environment_objects = []
+    env_seen = set()
+    non_ascii_chunks = []
+
+    for ch in iter_chunks(data):
+        cid = ch["cid"]
+        oid = ch["oid"]
+        body = ch["body"]
+        cid_bytes = ch["cid_bytes"]
+
+        if not all(32 <= b < 127 for b in cid_bytes):
+            # Skip plugin data (null ID) and zero-length placeholders
+            if cid_bytes != b'\x00\x00\x00\x00' and ch["length"] > 0:
+                non_ascii_chunks.append(ch)
+
+        if cid == "AuFl":
+            try:
+                name_len = struct.unpack('<H', body[8:10])[0]
+                if 0 < name_len < 1000:
+                    raw_bytes = body[10 : 10 + (name_len * 2)]
+                    path = raw_bytes.decode('utf-16le', errors='ignore')
+                    audio_files[oid] = os.path.basename(path)
+                    project["summary"]["audio_assets"].append({"name": path, "oid": oid})
+            except Exception:
+                pass
+
+        elif cid == "MSeq":
+            name = parse_mseq_name(body)
+            if name:
+                mseq_names[oid] = name
+            if len(body) >= 0x0C:
+                try:
+                    ref_oid = struct.unpack('<I', body[0x08:0x0C])[0]
+                    if ref_oid and ref_oid != oid:
+                        mseq_parent_refs[oid] = ref_oid
+                except Exception:
+                    pass
+
+        elif cid == "Trak":
+            entry = trak_entries.get(oid, {"oid": oid})
+
+    for name in catalog_names:
+        norm, _ = normalize_tokens(name)
+        base_track_id = f"env:{norm}" if norm else f"env:{next_oid}"
+        track_id = base_track_id
+        suffix = 2
+        while track_id in used_track_ids:
+            track_id = f"{base_track_id}:{suffix}"
+            suffix += 1
+        used_track_ids.add(track_id)
+
+        stack_hint = infer_stack_hint_from_label(name, release_title_hints=release_title_hints)
+        entry = {
+            "oid": next_oid,
+            "mseq_oid": None,
+            "uuid": None,
+            "regions": [],
+            "name": name,
+            "name_raw": name,
+            "display_name": name,
+            "name_is_generic": False,
+            "name_aliases": [name],
+            "name_norm": norm or None,
+            "track_id": track_id,
+            "track_stack": {
+                "type": "none",
+                "is_summing": False,
+                "source": "environment_label_catalog",
+                "confidence": 0.2
+            },
+            "is_summing_track_stack": False,
+            "synthetic": True,
+            "synthetic_source": "environment_label_catalog"
+        }
+        if stack_hint:
+            entry["top_level_stack_name"] = stack_hint
+            entry["top_level_stack_confidence"] = 0.35
+            entry["top_level_stack_source"] = "environment_label_catalog"
+        final_tracks[next_oid] = entry
+        synthetic_entries.append({
+            "oid": next_oid,
+            "name": name,
+            "stack_hint": stack_hint
+        })
+        next_oid += 1
+
+    return synthetic_entries
+
+def curate_track_aliases(track, release_title_hints=None):
+    if not isinstance(track, dict):
+        return
+
+    aliases = track.get("name_aliases")
+    if not isinstance(aliases, list) or not aliases:
+        return
+
+    primary = track.get("display_name") or track.get("name") or track.get("name_raw") or ""
+    primary_lower = str(primary).lower()
+    primary_norm, primary_tokens = normalize_tokens(primary)
+    release_hints = release_title_hints if isinstance(release_title_hints, set) else set()
+
+    midi_tokens = {"midi", "trigger", "triggers", "cortex", "quad", "nano", "wled"}
+    midi_primary = bool(primary_tokens.intersection(midi_tokens))
+    master_primary = ("master live project" in primary_lower) or (primary_norm in {"master live", "master live project"})
+    release_primary = bool(primary_norm and primary_norm in release_hints)
+
+    filtered = []
+    seen = set()
+    for alias in aliases:
+        if not isinstance(alias, str) or not alias.strip():
+            continue
+        alias_value = alias.strip()
+        alias_norm, alias_tokens = normalize_tokens(alias_value)
+        if not alias_norm and not alias_value.startswith("*"):
+            continue
+
+        if master_primary and alias_norm:
+            keep_master_alias = (
+                "master" in alias_tokens
+                or "automation" in alias_tokens
+                or alias_norm in {"master live", "master live project"}
+        "not assigned",
+        "input view",
+        "input notes",
+        "preview",
+        "master",
+        "stereo out",
+        "physical input",
+        "sequencer input",
+        "gm device",
+        "edit output",
+        "output 4",
+        "output 25-26",
+        "output 27-28",
+        "output 29-30",
+        "output 31-32"
+    }
+    role_tokens = {"click", "backing", "release", "midi", "trigger", "triggers"}
+    canonical_stack_labels = {"midi triggers", "click track", "backing track", "release track"}
+    midi_profile_tokens = {"midi", "trigger", "triggers", "cortex", "quad", "nano", "wled"}
+    release_title_hints = build_release_title_hints(environment_layout_map, environment_labels)
+
+    environment_names = set()
+    for raw in environment_labels or []:
+        if isinstance(raw, str) and raw.strip():
+            environment_names.add(raw.strip())
+    if isinstance(environment_layout_map, dict):
+        for payload in environment_layout_map.values():
+            if not isinstance(payload, dict):
+                continue
+            name = payload.get("name")
+            if isinstance(name, str) and name.strip():
+                environment_names.add(name.strip())
+
+    # Build token profiles per track from name + aliases + region names/files.
+    track_profiles = {}
+    for oid, track in final_tracks.items():
+        fragments = []
+        name = track.get("name")
+        if isinstance(name, str) and name.strip():
+            fragments.append(name.strip())
+        display_name = track.get("display_name")
+        if isinstance(display_name, str) and display_name.strip():
+            fragments.append(display_name.strip())
+        root_name = track.get("stack_root_name")
+        if isinstance(root_name, str) and root_name.strip():
+            fragments.append(root_name.strip())
+        stack_name = track.get("top_level_stack_name")
+        if isinstance(stack_name, str) and stack_name.strip():
+            fragments.append(stack_name.strip())
+        aliases = track.get("name_aliases")
+        if isinstance(aliases, list):
+            for alias in aliases:
+                if isinstance(alias, str) and alias.strip():
+                    fragments.append(alias.strip())
+
+        norms = []
+        tokens = set()
+        seen_fragment = set()
+        for fragment in fragments:
+            lowered = fragment.lower()
+            if lowered in seen_fragment:
+                continue
+            seen_fragment.add(lowered)
+            norm, tok = normalize_tokens(fragment)
+            if norm:
+                norms.append(norm)
+            tokens.update(tok)
+
+        track_profiles[oid] = {
+            "region_count": len(track.get("regions", [])),
+            "norms": norms,
+            "tokens": tokens
+        }
+
+    # Score environment labels against each region-carrying track.
+    env_to_winners = {}
+    for env_name in sorted(environment_names):
+        if not is_sane_name(env_name):
+            continue
+        lowered_env = env_name.lower().strip()
+        if lowered_env.startswith("@"):
+    return cleaned in generic
+
+def build_track_name_candidates(oid, entry, mseq_names, tx_texts, channel_strips):
+    candidates = []
+
+    mseq_oid = entry.get("mseq_oid")
+    if mseq_oid in mseq_names and is_sane_name(mseq_names.get(mseq_oid)):
+        candidates.append(("mseq_link", mseq_names.get(mseq_oid)))
+
+    # In many projects Trak OID == MSeq OID; use this when explicit links are absent.
+    if oid in mseq_names and is_sane_name(mseq_names.get(oid)):
+        candidates.append(("mseq_self", mseq_names.get(oid)))
+
+    if oid in tx_texts and is_sane_name(tx_texts.get(oid)):
+        candidates.append(("tx_text", tx_texts.get(oid)))
+
+    cs_name = channel_strips.get(oid, {}).get("name")
+    if is_sane_name(cs_name):
+        candidates.append(("channel_strip", cs_name))
+
+    scored = []
+    base_priority = {
+        "mseq_link": 100,
+        "mseq_self": 95,
+        "tx_text": 70,
+        "channel_strip": 60
+    }
+    for source, name in candidates:
+        score = base_priority.get(source, 0)
+        if is_generic_track_name(name):
+            score -= 35
+        scored.append({
+            "source": source,
+            "name": name,
+            "score": score,
+            "generic": is_generic_track_name(name)
+        })
+
+    scored.sort(key=lambda x: (x["score"], x["source"]), reverse=True)
+
+    selected = None
+--
+        }
+
+    output_label = track.get("channel_strip", {}).get("output")
+    if isinstance(output_label, str) and output_label.strip():
+        lowered_output = output_label.lower().strip()
+        if lowered_output.startswith("bus "):
+            return {
+                "type": "summing",
+                "is_summing": True,
+                "source": "channel_output_bus",
+                "confidence": 0.55
+            }
+        if lowered_output.startswith("output ") or "stereo out" in lowered_output:
+            return {
+                "type": "none",
+                "is_summing": False,
+                "source": "channel_output_main",
+                "confidence": 0.5
+--
+            "track_hierarchy": [],
+            "top_level_stacks": [],
+            "channel_strips": [],
+            "plugins": [],
+            "midi_ports": [],
+            "environment_labels": [],
+            "environment_objects": [],
+            "environment_layout_map": [],
+            "environment_name_catalog": [],
+            "environment_y_decode_report": {},
+            "non_ascii_chunks": {},
+            "region_oid_reuse": {},
+            "region_alias_refinement": {},
+            "region_orphan_rec_assignment": {}
+        }
+    }
+
+    # 1. Parse Plist Metadata (if we have a .logicx base dir)
+--


### PR DESCRIPTION
Decodes Logic Pro short-form TxSq chunks with //QR discriminator and RTF fallback to extract arrangement marker section names (Intro/Verse/Chorus/Bridge). 6/6 tests pass. Independent of ProjectDataParser.