### PR TITLE
Support alternate Logic Pro bundle IDs

### DIFF
--- a/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
+++ b/Sources/LogicProMCP/Channels/AppleScriptChannel.swift
@@ -78,12 +78,12 @@ actor AppleScriptChannel: Channel {
 
     private func newProjectScript() -> String {
         """
-        tell application "Logic Pro"
+        tell \(ProcessUtils.logicProAppleScriptTarget)
             activate
             delay 0.5
         end tell
         tell application "System Events"
-            tell process "Logic Pro"
+            tell process "\(ServerConfig.logicProProcessName)"
                 click menu item "New..." of menu "File" of menu bar 1
             end tell
         end tell
@@ -93,7 +93,7 @@ actor AppleScriptChannel: Channel {
     private func openProjectScript(path: String) -> String {
         let escaped = path.replacingOccurrences(of: "\"", with: "\\\"")
         return """
-        tell application "Logic Pro"
+        tell \(ProcessUtils.logicProAppleScriptTarget)
             activate
             open POSIX file "\(escaped)"
         end tell
@@ -111,7 +111,7 @@ actor AppleScriptChannel: Channel {
             saveClause = "saving yes"
         }
         return """
-        tell application "Logic Pro"
+        tell \(ProcessUtils.logicProAppleScriptTarget)
             close front document \(saveClause)
         end tell
         """
@@ -119,7 +119,7 @@ actor AppleScriptChannel: Channel {
 
     private func saveProjectScript() -> String {
         """
-        tell application "Logic Pro"
+        tell \(ProcessUtils.logicProAppleScriptTarget)
             save front document
         end tell
         """
@@ -127,7 +127,7 @@ actor AppleScriptChannel: Channel {
 
     private func transportScript(action: String) -> String {
         """
-        tell application "Logic Pro"
+        tell \(ProcessUtils.logicProAppleScriptTarget)
             \(action)
         end tell
         """

--- a/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/ProjectDispatcher.swift
@@ -79,30 +79,29 @@ struct ProjectDispatcher {
             if ProcessUtils.isLogicProRunning {
                 return CallTool.Result(content: [.text("Logic Pro is already running")], isError: false)
             }
-            let script = "tell application \"Logic Pro\" to activate"
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            process.arguments = ["-e", script]
-            do {
-                try process.run()
-                process.waitUntilExit()
-                return CallTool.Result(content: [.text("Logic Pro launched")], isError: false)
-            } catch {
-                return CallTool.Result(content: [.text("Failed to launch Logic Pro: \(error)")], isError: true)
+
+            let scripts = ServerConfig.logicProBundleIDs.map {
+                "tell application id \"\($0)\" to activate"
+            } + ["tell application \"\(ServerConfig.logicProProcessName)\" to activate"]
+
+            for script in scripts {
+                if (try? runAppleScript(script)) == true {
+                    return CallTool.Result(content: [.text("Logic Pro launched")], isError: false)
+                }
             }
+
+            return CallTool.Result(content: [.text("Failed to launch Logic Pro")], isError: true)
 
         case "quit":
             if !ProcessUtils.isLogicProRunning {
                 return CallTool.Result(content: [.text("Logic Pro is not running")], isError: false)
             }
-            let script = "tell application \"Logic Pro\" to quit"
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            process.arguments = ["-e", script]
             do {
-                try process.run()
-                process.waitUntilExit()
-                return CallTool.Result(content: [.text("Logic Pro quit")], isError: false)
+                let script = "tell \(ProcessUtils.logicProAppleScriptTarget) to quit"
+                if try runAppleScript(script) {
+                    return CallTool.Result(content: [.text("Logic Pro quit")], isError: false)
+                }
+                return CallTool.Result(content: [.text("Failed to quit Logic Pro")], isError: true)
             } catch {
                 return CallTool.Result(content: [.text("Failed to quit Logic Pro: \(error)")], isError: true)
             }
@@ -113,5 +112,14 @@ struct ProjectDispatcher {
                 isError: true
             )
         }
+    }
+
+    private static func runAppleScript(_ script: String) throws -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
     }
 }

--- a/Sources/LogicProMCP/Server/ServerConfig.swift
+++ b/Sources/LogicProMCP/Server/ServerConfig.swift
@@ -42,6 +42,7 @@ struct ServerConfig: Sendable {
     static let channelHealthCheckTimeout: TimeInterval = 3.0
 
     // MARK: - Logic Pro
-    static let logicProBundleID = "com.apple.logic10"
+    static let logicProBundleIDs = ["com.apple.logic10", "com.apple.mobilelogic"]
+    static let logicProBundleID = logicProBundleIDs[0]
     static let logicProProcessName = "Logic Pro"
 }

--- a/Sources/LogicProMCP/Utilities/PermissionChecker.swift
+++ b/Sources/LogicProMCP/Utilities/PermissionChecker.swift
@@ -39,7 +39,7 @@ enum PermissionChecker {
             return false
         }
         let script = NSAppleScript(source: """
-            tell application "Logic Pro" to return name
+            tell \(ProcessUtils.logicProAppleScriptTarget) to return name
         """)
         var errorInfo: NSDictionary?
         _ = script?.executeAndReturnError(&errorInfo)

--- a/Sources/LogicProMCP/Utilities/ProcessUtils.swift
+++ b/Sources/LogicProMCP/Utilities/ProcessUtils.swift
@@ -3,24 +3,39 @@ import AppKit
 
 /// Utilities for finding and interacting with the Logic Pro process.
 enum ProcessUtils {
+    /// Returns the running Logic Pro application, supporting known bundle IDs.
+    static func logicProApp() -> NSRunningApplication? {
+        for bundleID in ServerConfig.logicProBundleIDs {
+            let apps = NSRunningApplication.runningApplications(
+                withBundleIdentifier: bundleID
+            )
+            if let app = apps.first {
+                return app
+            }
+        }
+        return nil
+    }
+
     /// Returns the PID of Logic Pro if running, nil otherwise.
     static func logicProPID() -> pid_t? {
-        let apps = NSRunningApplication.runningApplications(
-            withBundleIdentifier: ServerConfig.logicProBundleID
-        )
-        return apps.first?.processIdentifier
+        logicProApp()?.processIdentifier
+    }
+
+    /// AppleScript application target for the running Logic Pro variant.
+    static var logicProAppleScriptTarget: String {
+        if let bundleID = logicProApp()?.bundleIdentifier {
+            return "application id \"\(bundleID)\""
+        }
+        return "application \"\(ServerConfig.logicProProcessName)\""
     }
 
     /// Whether Logic Pro is currently running.
     static var isLogicProRunning: Bool {
-        logicProPID() != nil
+        logicProApp() != nil
     }
 
     /// Bring Logic Pro to front (used sparingly — most operations don't need focus).
     static func activateLogicPro() -> Bool {
-        guard let app = NSRunningApplication.runningApplications(
-            withBundleIdentifier: ServerConfig.logicProBundleID
-        ).first else { return false }
-        return app.activate()
+        logicProApp()?.activate() ?? false
     }
 }


### PR DESCRIPTION
## Summary

Fixes #23.

This updates Logic Pro app detection to support more than one known bundle identifier. In particular, it adds support for Logic Pro installs exposed as `com.apple.mobilelogic`, while preserving the existing `com.apple.logic10` behavior.

Changes:
- add `ServerConfig.logicProBundleIDs`
- centralize running app lookup in `ProcessUtils.logicProApp()`
- route PID lookup and app activation through the detected running app
- target AppleScript at the detected bundle identifier when possible
- make project launch try each known bundle identifier before falling back to the display name

## Testing

- `swift build -c release`
- `swift test`
