### PR TITLE
Fix advertised MIDI and MMC routing

### DIFF
--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -98,10 +98,17 @@ actor CoreMIDIChannel: Channel {
         // MARK: - CC
 
         case "midi.send_chord":
-            let notes = params["notes"]?
-                .split(separator: ",")
-                .compactMap { UInt8($0.trimmingCharacters(in: .whitespaces)) }
-                ?? []
+            guard let notesParam = params["notes"] else {
+                return .error("send_chord requires 'notes' as comma-separated MIDI notes")
+            }
+            var notes: [UInt8] = []
+            for token in notesParam.split(separator: ",", omittingEmptySubsequences: false) {
+                let noteToken = token.trimmingCharacters(in: .whitespaces)
+                guard let note = UInt8(noteToken), note <= 127 else {
+                    return .error("send_chord requires valid MIDI note numbers; invalid token: '\(noteToken)'")
+                }
+                notes.append(note)
+            }
             guard !notes.isEmpty else {
                 return .error("send_chord requires 'notes' as comma-separated MIDI notes")
             }
@@ -170,7 +177,13 @@ actor CoreMIDIChannel: Channel {
             guard let hexString = params["bytes"] ?? params["data"] else {
                 return .error("send_sysex requires 'bytes' or 'data' (hex string, e.g. 'F0 7F 7F 06 02 F7')")
             }
-            let bytes = hexString.split(separator: " ").compactMap { UInt8($0, radix: 16) }
+            var bytes: [UInt8] = []
+            for token in hexString.split(whereSeparator: \.isWhitespace) {
+                guard let byte = UInt8(token, radix: 16) else {
+                    return .error("Malformed SysEx: invalid hex token '\(token)'")
+                }
+                bytes.append(byte)
+            }
             guard bytes.first == 0xF0, bytes.last == 0xF7 else {
                 return .error("SysEx must start with F0 and end with F7")
             }
@@ -214,9 +227,21 @@ actor CoreMIDIChannel: Channel {
         subframes: UInt8
     )? {
         if let time = params["time"] ?? params["position"] {
-            let parts = time.split(separator: ":").compactMap { UInt8($0) }
-            guard parts.count == 4 else { return nil }
-            return (parts[0], parts[1], parts[2], parts[3], params["subframes"].flatMap(UInt8.init) ?? 0)
+            let tokens = time.split(separator: ":", omittingEmptySubsequences: false)
+            guard tokens.count == 4 else { return nil }
+            var parts: [UInt8] = []
+            for token in tokens {
+                guard let value = UInt8(token) else { return nil }
+                parts.append(value)
+            }
+            guard let subframes = parseOptionalSubframes(params) else { return nil }
+            return validatedSMPTETime(
+                hours: parts[0],
+                minutes: parts[1],
+                seconds: parts[2],
+                frames: parts[3],
+                subframes: subframes
+            )
         }
 
         guard let hours = params["hours"].flatMap(UInt8.init),
@@ -225,6 +250,41 @@ actor CoreMIDIChannel: Channel {
               let frames = params["frames"].flatMap(UInt8.init) else {
             return nil
         }
-        return (hours, minutes, seconds, frames, params["subframes"].flatMap(UInt8.init) ?? 0)
+        guard let subframes = parseOptionalSubframes(params) else { return nil }
+        return validatedSMPTETime(
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds,
+            frames: frames,
+            subframes: subframes
+        )
+    }
+
+    private static func parseOptionalSubframes(_ params: [String: String]) -> UInt8? {
+        guard let rawSubframes = params["subframes"] else { return 0 }
+        return UInt8(rawSubframes)
+    }
+
+    private static func validatedSMPTETime(
+        hours: UInt8,
+        minutes: UInt8,
+        seconds: UInt8,
+        frames: UInt8,
+        subframes: UInt8
+    ) -> (
+        hours: UInt8,
+        minutes: UInt8,
+        seconds: UInt8,
+        frames: UInt8,
+        subframes: UInt8
+    )? {
+        guard hours <= 23,
+              minutes <= 59,
+              seconds <= 59,
+              frames <= 59,
+              subframes <= 99 else {
+            return nil
+        }
+        return (hours, minutes, seconds, frames, subframes)
     }
 }

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -23,23 +23,23 @@ actor CoreMIDIChannel: Channel {
         switch operation {
         // MARK: - Transport (MMC)
 
-        case "transport.play":
+        case "transport.play", "mmc.play":
             await engine.sendSysEx(MMCCommands.play())
             return .success("MMC play sent")
 
-        case "transport.stop":
+        case "transport.stop", "mmc.stop":
             await engine.sendSysEx(MMCCommands.stop())
             return .success("MMC stop sent")
 
-        case "transport.pause":
+        case "transport.pause", "mmc.pause":
             await engine.sendSysEx(MMCCommands.pause())
             return .success("MMC pause sent")
 
-        case "transport.record_strobe":
+        case "transport.record", "transport.record_strobe", "mmc.record_strobe":
             await engine.sendSysEx(MMCCommands.recordStrobe())
             return .success("MMC record strobe sent")
 
-        case "transport.record_exit":
+        case "transport.record_exit", "mmc.record_exit":
             await engine.sendSysEx(MMCCommands.recordExit())
             return .success("MMC record exit sent")
 
@@ -51,16 +51,18 @@ actor CoreMIDIChannel: Channel {
             await engine.sendSysEx(MMCCommands.rewind())
             return .success("MMC rewind sent")
 
-        case "transport.locate":
-            guard let h = params["hours"].flatMap(UInt8.init),
-                  let m = params["minutes"].flatMap(UInt8.init),
-                  let s = params["seconds"].flatMap(UInt8.init),
-                  let f = params["frames"].flatMap(UInt8.init) else {
-                return .error("locate requires hours, minutes, seconds, frames")
+        case "transport.locate", "mmc.locate":
+            guard let time = Self.parseSMPTETime(params) else {
+                return .error("locate requires 'time' (HH:MM:SS:FF) or hours, minutes, seconds, frames")
             }
-            let sf = params["subframes"].flatMap(UInt8.init) ?? 0
-            await engine.sendSysEx(MMCCommands.locate(hours: h, minutes: m, seconds: s, frames: f, subframes: sf))
-            return .success("MMC locate sent to \(h):\(m):\(s):\(f).\(sf)")
+            await engine.sendSysEx(MMCCommands.locate(
+                hours: time.hours,
+                minutes: time.minutes,
+                seconds: time.seconds,
+                frames: time.frames,
+                subframes: time.subframes
+            ))
+            return .success("MMC locate sent to \(time.hours):\(time.minutes):\(time.seconds):\(time.frames).\(time.subframes)")
 
         // MARK: - Note Send
 
@@ -95,6 +97,26 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - CC
 
+        case "midi.send_chord":
+            let notes = params["notes"]?
+                .split(separator: ",")
+                .compactMap { UInt8($0.trimmingCharacters(in: .whitespaces)) }
+                ?? []
+            guard !notes.isEmpty else {
+                return .error("send_chord requires 'notes' as comma-separated MIDI notes")
+            }
+            let channel = params["channel"].flatMap(UInt8.init) ?? 0
+            let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
+            let durationMs = params["duration_ms"].flatMap(UInt64.init) ?? 250
+            for note in notes {
+                await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
+            }
+            try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
+            for note in notes {
+                await engine.sendNoteOff(channel: channel, note: note)
+            }
+            return .success("Chord \(notes.map(String.init).joined(separator: ",")) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
+
         case "midi.send_cc":
             guard let controller = params["controller"].flatMap(UInt8.init),
                   let value = params["value"].flatMap(UInt8.init) else {
@@ -106,7 +128,7 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - Program Change
 
-        case "midi.program_change":
+        case "midi.program_change", "midi.send_program_change":
             guard let program = params["program"].flatMap(UInt8.init) else {
                 return .error("program_change requires 'program' (0-127)")
             }
@@ -117,8 +139,16 @@ actor CoreMIDIChannel: Channel {
         // MARK: - Pitch Bend
 
         case "midi.pitch_bend":
-            guard let value = params["value"].flatMap(UInt16.init) else {
+            guard let value = params["value"].flatMap(UInt16.init), value <= 16_383 else {
                 return .error("pitch_bend requires 'value' (0-16383, center=8192)")
+            }
+            let channel = params["channel"].flatMap(UInt8.init) ?? 0
+            await engine.sendPitchBend(channel: channel, value: value)
+            return .success("Pitch bend \(value) on ch \(channel)")
+
+        case "midi.send_pitch_bend":
+            guard let value = Self.parseSignedPitchBend(params["value"]) else {
+                return .error("send_pitch_bend requires 'value' (-8192...8191)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendPitchBend(channel: channel, value: value)
@@ -126,9 +156,9 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - Aftertouch
 
-        case "midi.aftertouch":
-            guard let pressure = params["pressure"].flatMap(UInt8.init) else {
-                return .error("aftertouch requires 'pressure' (0-127)")
+        case "midi.aftertouch", "midi.send_aftertouch":
+            guard let pressure = (params["pressure"] ?? params["value"]).flatMap(UInt8.init) else {
+                return .error("aftertouch requires 'pressure' or 'value' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendAftertouch(channel: channel, pressure: pressure)
@@ -137,8 +167,8 @@ actor CoreMIDIChannel: Channel {
         // MARK: - Raw SysEx
 
         case "midi.send_sysex":
-            guard let hexString = params["bytes"] else {
-                return .error("send_sysex requires 'bytes' (hex string, e.g. 'F0 7F 7F 06 02 F7')")
+            guard let hexString = params["bytes"] ?? params["data"] else {
+                return .error("send_sysex requires 'bytes' or 'data' (hex string, e.g. 'F0 7F 7F 06 02 F7')")
             }
             let bytes = hexString.split(separator: " ").compactMap { UInt8($0, radix: 16) }
             guard bytes.first == 0xF0, bytes.last == 0xF7 else {
@@ -146,6 +176,15 @@ actor CoreMIDIChannel: Channel {
             }
             await engine.sendSysEx(bytes)
             return .success("SysEx sent (\(bytes.count) bytes)")
+
+        case "midi.create_virtual_port":
+            let name = params["name"] ?? "LogicProMCP-Virtual"
+            do {
+                try await engine.createVirtualPort(named: name)
+                return .success("Virtual MIDI port created: \(name)")
+            } catch {
+                return .error("Failed to create virtual MIDI port '\(name)': \(error)")
+            }
 
         default:
             return .error("Unknown CoreMIDI operation: \(operation)")
@@ -159,5 +198,33 @@ actor CoreMIDIChannel: Channel {
         } else {
             return .unavailable("CoreMIDI client not initialized")
         }
+    }
+
+    private static func parseSignedPitchBend(_ rawValue: String?) -> UInt16? {
+        guard let rawValue, let intValue = Int(rawValue) else { return nil }
+        guard (-8192...8191).contains(intValue) else { return nil }
+        return UInt16(intValue + 8192)
+    }
+
+    private static func parseSMPTETime(_ params: [String: String]) -> (
+        hours: UInt8,
+        minutes: UInt8,
+        seconds: UInt8,
+        frames: UInt8,
+        subframes: UInt8
+    )? {
+        if let time = params["time"] ?? params["position"] {
+            let parts = time.split(separator: ":").compactMap { UInt8($0) }
+            guard parts.count == 4 else { return nil }
+            return (parts[0], parts[1], parts[2], parts[3], params["subframes"].flatMap(UInt8.init) ?? 0)
+        }
+
+        guard let hours = params["hours"].flatMap(UInt8.init),
+              let minutes = params["minutes"].flatMap(UInt8.init),
+              let seconds = params["seconds"].flatMap(UInt8.init),
+              let frames = params["frames"].flatMap(UInt8.init) else {
+            return nil
+        }
+        return (hours, minutes, seconds, frames, params["subframes"].flatMap(UInt8.init) ?? 0)
     }
 }

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -188,14 +188,17 @@ actor MIDIEngine {
             Log.warn("MIDIEngine not running — dropping message", subsystem: "midi")
             return
         }
+        let sources = ([virtualSource] + additionalVirtualSources).filter { $0 != 0 }
         bytes.withUnsafeBufferPointer { buffer in
             guard let baseAddress = buffer.baseAddress else { return }
             var packetList = MIDIPacketList()
             var packet = MIDIPacketListInit(&packetList)
             packet = MIDIPacketListAdd(&packetList, MemoryLayout<MIDIPacketList>.size, packet, 0, bytes.count, baseAddress)
-            let status = MIDIReceived(virtualSource, &packetList)
-            if status != noErr {
-                Log.error("MIDIReceived failed with status \(status)", subsystem: "midi")
+            for source in sources {
+                let status = MIDIReceived(source, &packetList)
+                if status != noErr {
+                    Log.error("MIDIReceived failed with status \(status)", subsystem: "midi")
+                }
             }
         }
     }

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -7,6 +7,8 @@ actor MIDIEngine {
     private var client: MIDIClientRef = 0
     private var virtualSource: MIDIEndpointRef = 0
     private var virtualDestination: MIDIEndpointRef = 0
+    private var additionalVirtualSources: [MIDIEndpointRef] = []
+    private var additionalVirtualDestinations: [MIDIEndpointRef] = []
     private var isRunning = false
 
     /// Stream of inbound MIDI packets from Logic Pro via the virtual destination.
@@ -65,9 +67,17 @@ actor MIDIEngine {
     /// Tear down all CoreMIDI resources.
     func stop() {
         guard isRunning else { return }
+        for source in additionalVirtualSources where source != 0 {
+            MIDIEndpointDispose(source)
+        }
+        for destination in additionalVirtualDestinations where destination != 0 {
+            MIDIEndpointDispose(destination)
+        }
         if virtualSource != 0 { MIDIEndpointDispose(virtualSource) }
         if virtualDestination != 0 { MIDIEndpointDispose(virtualDestination) }
         if client != 0 { MIDIClientDispose(client) }
+        additionalVirtualSources.removeAll()
+        additionalVirtualDestinations.removeAll()
         virtualSource = 0
         virtualDestination = 0
         client = 0
@@ -77,6 +87,36 @@ actor MIDIEngine {
     }
 
     var isActive: Bool { isRunning && client != 0 }
+
+    /// Create an additional virtual source/destination pair.
+    func createVirtualPort(named name: String) throws {
+        if !isRunning {
+            try start()
+        }
+
+        var source: MIDIEndpointRef = 0
+        var destination: MIDIEndpointRef = 0
+        let sourceName = "\(name)-Out" as CFString
+        let destinationName = "\(name)-In" as CFString
+
+        var status = MIDISourceCreate(client, sourceName, &source)
+        guard status == noErr else {
+            throw MIDIEngineError.sourceCreationFailed(status)
+        }
+
+        let continuation = self.inboundContinuation
+        status = MIDIDestinationCreateWithBlock(client, destinationName, &destination) { packetList, _ in
+            let packets = packetList.pointee
+            MIDIFeedback.parse(packetList: packets, into: continuation)
+        }
+        guard status == noErr else {
+            MIDIEndpointDispose(source)
+            throw MIDIEngineError.destinationCreationFailed(status)
+        }
+
+        additionalVirtualSources.append(source)
+        additionalVirtualDestinations.append(destination)
+    }
 
     // MARK: - Send: Notes
 

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -12,7 +12,9 @@ final class CoreMIDIChannelTests: XCTestCase {
             ("midi.send_program_change", ["program": "8", "channel": "1"]),
             ("midi.send_pitch_bend", ["value": "-8192", "channel": "1"]),
             ("midi.send_aftertouch", ["value": "64", "channel": "1"]),
+            ("midi.send_aftertouch", ["pressure": "64", "channel": "1"]),
             ("midi.send_sysex", ["data": "F0 7F 7F 06 02 F7"]),
+            ("midi.send_sysex", ["bytes": "F0 7F 7F 06 02 F7"]),
             ("midi.create_virtual_port", ["name": "Test Port"]),
         ]
 
@@ -36,6 +38,8 @@ final class CoreMIDIChannelTests: XCTestCase {
         )
 
         XCTAssertTrue(result.isSuccess, "midi.pitch_bend should keep accepting raw 14-bit values")
+
+        await channel.stop()
     }
 
     func testCoreMIDIHandlesAdvertisedMMCOperations() async {
@@ -47,6 +51,8 @@ final class CoreMIDIChannelTests: XCTestCase {
             ("mmc.record_strobe", [:]),
             ("mmc.pause", [:]),
             ("mmc.locate", ["time": "00:00:01:12"]),
+            ("mmc.locate", ["hours": "0", "minutes": "0", "seconds": "1", "frames": "12", "subframes": "0"]),
+            ("transport.locate", ["position": "00:00:01:12"]),
         ]
 
         for testCase in cases {
@@ -56,5 +62,32 @@ final class CoreMIDIChannelTests: XCTestCase {
                 "\(testCase.operation) should be handled, got: \(result.message)"
             )
         }
+
+        await channel.stop()
+    }
+
+    func testCoreMIDIRejectsMalformedMIDIParameters() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let cases: [(operation: String, params: [String: String])] = [
+            ("midi.send_chord", ["notes": "60,bad,67"]),
+            ("midi.send_chord", ["notes": "60,128,67"]),
+            ("midi.send_chord", ["notes": "60,,67"]),
+            ("midi.send_sysex", ["data": "F0 7F nope F7"]),
+            ("mmc.locate", ["time": "00:60:01:12"]),
+            ("mmc.locate", ["time": "00:00:01:12:"]),
+            ("mmc.locate", ["hours": "0", "minutes": "0", "seconds": "1", "frames": "60"]),
+            ("mmc.locate", ["time": "00:00:01:12", "subframes": "100"]),
+        ]
+
+        for testCase in cases {
+            let result = await channel.execute(operation: testCase.operation, params: testCase.params)
+            XCTAssertFalse(
+                result.isSuccess,
+                "\(testCase.operation) should reject malformed params, got: \(result.message)"
+            )
+        }
+
+        await channel.stop()
     }
 }

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import LogicProMCP
+
+final class CoreMIDIChannelTests: XCTestCase {
+    func testCoreMIDIHandlesAdvertisedMIDIOperations() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let cases: [(operation: String, params: [String: String])] = [
+            ("midi.send_note", ["note": "60", "velocity": "100", "channel": "1", "duration_ms": "0"]),
+            ("midi.send_chord", ["notes": "60,64,67", "velocity": "100", "channel": "1", "duration_ms": "0"]),
+            ("midi.send_cc", ["controller": "1", "value": "64", "channel": "1"]),
+            ("midi.send_program_change", ["program": "8", "channel": "1"]),
+            ("midi.send_pitch_bend", ["value": "-8192", "channel": "1"]),
+            ("midi.send_aftertouch", ["value": "64", "channel": "1"]),
+            ("midi.send_sysex", ["data": "F0 7F 7F 06 02 F7"]),
+            ("midi.create_virtual_port", ["name": "Test Port"]),
+        ]
+
+        for testCase in cases {
+            let result = await channel.execute(operation: testCase.operation, params: testCase.params)
+            XCTAssertTrue(
+                result.isSuccess,
+                "\(testCase.operation) should be handled, got: \(result.message)"
+            )
+        }
+
+        await channel.stop()
+    }
+
+    func testCoreMIDIKeepsLegacyPitchBendAlias() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let result = await channel.execute(
+            operation: "midi.pitch_bend",
+            params: ["value": "0", "channel": "1"]
+        )
+
+        XCTAssertTrue(result.isSuccess, "midi.pitch_bend should keep accepting raw 14-bit values")
+    }
+
+    func testCoreMIDIHandlesAdvertisedMMCOperations() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let cases: [(operation: String, params: [String: String])] = [
+            ("mmc.play", [:]),
+            ("mmc.stop", [:]),
+            ("mmc.record_strobe", [:]),
+            ("mmc.pause", [:]),
+            ("mmc.locate", ["time": "00:00:01:12"]),
+        ]
+
+        for testCase in cases {
+            let result = await channel.execute(operation: testCase.operation, params: testCase.params)
+            XCTAssertTrue(
+                result.isSuccess,
+                "\(testCase.operation) should be handled, got: \(result.message)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #25.

This updates the CoreMIDI path so the operation names and params advertised by `logic_midi` are actually handled at runtime.

Changes:
- handle advertised `midi.send_*` operation names in `CoreMIDIChannel`
- handle routed `mmc.*` operation names in `CoreMIDIChannel`
- accept documented params for SysEx, aftertouch, signed pitch bend, and MMC locate
- implement `midi.send_chord`
- implement `midi.create_virtual_port` by creating an additional CoreMIDI source/destination pair
- keep existing internal aliases such as `midi.pitch_bend` where they already existed
- add regression tests for advertised MIDI/MMC operations

## Testing

- Verified pre-fix failure: new regression tests failed with 11 MIDI/MMC routing or parameter failures.
- `swift test`
