### PR TITLE
fix: implement advertised CoreMIDI virtual-port operations

### DIFF
--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -23,23 +23,23 @@ actor CoreMIDIChannel: Channel {
         switch operation {
         // MARK: - Transport (MMC)
 
-        case "transport.play":
+        case "transport.play", "mmc.play":
             await engine.sendSysEx(MMCCommands.play())
             return .success("MMC play sent")
 
-        case "transport.stop":
+        case "transport.stop", "mmc.stop":
             await engine.sendSysEx(MMCCommands.stop())
             return .success("MMC stop sent")
 
-        case "transport.pause":
+        case "transport.pause", "mmc.pause":
             await engine.sendSysEx(MMCCommands.pause())
             return .success("MMC pause sent")
 
-        case "transport.record_strobe":
+        case "transport.record_strobe", "mmc.record_strobe":
             await engine.sendSysEx(MMCCommands.recordStrobe())
             return .success("MMC record strobe sent")
 
-        case "transport.record_exit":
+        case "transport.record_exit", "mmc.record_exit":
             await engine.sendSysEx(MMCCommands.recordExit())
             return .success("MMC record exit sent")
 
@@ -51,16 +51,12 @@ actor CoreMIDIChannel: Channel {
             await engine.sendSysEx(MMCCommands.rewind())
             return .success("MMC rewind sent")
 
-        case "transport.locate":
-            guard let h = params["hours"].flatMap(UInt8.init),
-                  let m = params["minutes"].flatMap(UInt8.init),
-                  let s = params["seconds"].flatMap(UInt8.init),
-                  let f = params["frames"].flatMap(UInt8.init) else {
-                return .error("locate requires hours, minutes, seconds, frames")
+        case "transport.locate", "mmc.locate":
+            guard let position = parseLocatePosition(params) else {
+                return .error("locate requires hours/minutes/seconds/frames, time, or bar")
             }
-            let sf = params["subframes"].flatMap(UInt8.init) ?? 0
-            await engine.sendSysEx(MMCCommands.locate(hours: h, minutes: m, seconds: s, frames: f, subframes: sf))
-            return .success("MMC locate sent to \(h):\(m):\(s):\(f).\(sf)")
+            await engine.sendSysEx(MMCCommands.locate(hours: position.hours, minutes: position.minutes, seconds: position.seconds, frames: position.frames, subframes: position.subframes))
+            return .success("MMC locate sent to \(position.description)")
 
         // MARK: - Note Send
 
@@ -75,6 +71,22 @@ actor CoreMIDIChannel: Channel {
             try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
             await engine.sendNoteOff(channel: channel, note: note)
             return .success("Note \(note) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
+
+        case "midi.send_chord":
+            guard let notes = parseNoteList(params["notes"]) else {
+                return .error("send_chord requires 'notes' (comma-separated 0-127 values)")
+            }
+            let channel = params["channel"].flatMap(UInt8.init) ?? 0
+            let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
+            let durationMs = params["duration_ms"].flatMap(UInt64.init) ?? 250
+            for note in notes {
+                await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
+            }
+            try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
+            for note in notes {
+                await engine.sendNoteOff(channel: channel, note: note)
+            }
+            return .success("Chord \(notes.map(String.init).joined(separator: ",")) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
 
         case "midi.note_on":
             guard let note = params["note"].flatMap(UInt8.init) else {
@@ -106,7 +118,7 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - Program Change
 
-        case "midi.program_change":
+        case "midi.program_change", "midi.send_program_change":
             guard let program = params["program"].flatMap(UInt8.init) else {
                 return .error("program_change requires 'program' (0-127)")
             }
@@ -116,9 +128,9 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - Pitch Bend
 
-        case "midi.pitch_bend":
-            guard let value = params["value"].flatMap(UInt16.init) else {
-                return .error("pitch_bend requires 'value' (0-16383, center=8192)")
+        case "midi.pitch_bend", "midi.send_pitch_bend":
+            guard let value = parsePitchBendValue(params["value"], operation: operation) else {
+                return .error("pitch_bend requires 'value' (-8192 to 8191 or 0-16383)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendPitchBend(channel: channel, value: value)
@@ -126,9 +138,9 @@ actor CoreMIDIChannel: Channel {
 
         // MARK: - Aftertouch
 
-        case "midi.aftertouch":
-            guard let pressure = params["pressure"].flatMap(UInt8.init) else {
-                return .error("aftertouch requires 'pressure' (0-127)")
+        case "midi.aftertouch", "midi.send_aftertouch":
+            guard let pressure = (params["pressure"] ?? params["value"]).flatMap(UInt8.init) else {
+                return .error("aftertouch requires 'pressure' or 'value' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendAftertouch(channel: channel, pressure: pressure)
@@ -137,15 +149,30 @@ actor CoreMIDIChannel: Channel {
         // MARK: - Raw SysEx
 
         case "midi.send_sysex":
-            guard let hexString = params["bytes"] else {
-                return .error("send_sysex requires 'bytes' (hex string, e.g. 'F0 7F 7F 06 02 F7')")
+            guard let data = params["bytes"] ?? params["data"] else {
+                return .error("send_sysex requires 'bytes' or 'data' (hex string, e.g. 'F0 7F 7F 06 02 F7')")
             }
-            let bytes = hexString.split(separator: " ").compactMap { UInt8($0, radix: 16) }
+            guard let bytes = parseMIDIBytes(data) else {
+                return .error("send_sysex requires valid hex bytes")
+            }
             guard bytes.first == 0xF0, bytes.last == 0xF7 else {
                 return .error("SysEx must start with F0 and end with F7")
             }
             await engine.sendSysEx(bytes)
             return .success("SysEx sent (\(bytes.count) bytes)")
+
+        // MARK: - Virtual Ports
+
+        case "midi.create_virtual_port":
+            guard let name = params["name"], !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error("create_virtual_port requires 'name'")
+            }
+            do {
+                try await engine.createVirtualPort(name: name)
+                return .success("Virtual MIDI port created: \(name)")
+            } catch {
+                return .error("Failed to create virtual MIDI port: \(error)")
+            }
 
         default:
             return .error("Unknown CoreMIDI operation: \(operation)")
@@ -159,5 +186,119 @@ actor CoreMIDIChannel: Channel {
         } else {
             return .unavailable("CoreMIDI client not initialized")
         }
+    }
+
+    private struct LocatePosition {
+        let hours: UInt8
+        let minutes: UInt8
+        let seconds: UInt8
+        let frames: UInt8
+        let subframes: UInt8
+        let description: String
+    }
+
+    private func parseLocatePosition(_ params: [String: String]) -> LocatePosition? {
+        if let time = params["time"] {
+            return parseLocateTime(time, subframes: params["subframes"].flatMap(UInt8.init) ?? 0)
+        }
+
+        if let bar = params["bar"].flatMap(Int.init) {
+            let totalSeconds = max(bar - 1, 0) * 2
+            return locatePosition(totalSeconds: totalSeconds, description: "bar \(bar)")
+        }
+
+        guard let hours = params["hours"].flatMap(UInt8.init),
+              let minutes = params["minutes"].flatMap(UInt8.init),
+              let seconds = params["seconds"].flatMap(UInt8.init),
+              let frames = params["frames"].flatMap(UInt8.init) else {
+            return nil
+        }
+        let subframes = params["subframes"].flatMap(UInt8.init) ?? 0
+        return LocatePosition(
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds,
+            frames: frames,
+            subframes: subframes,
+            description: "\(hours):\(minutes):\(seconds):\(frames).\(subframes)"
+        )
+    }
+
+    private func parseLocateTime(_ time: String, subframes: UInt8) -> LocatePosition? {
+        let parts = time.split(separator: ":")
+        guard parts.count == 4 || parts.count == 5,
+              let hours = UInt8(parts[0]),
+              let minutes = UInt8(parts[1]),
+              let seconds = UInt8(parts[2]),
+              let frames = UInt8(parts[3]) else {
+            return nil
+        }
+        let parsedSubframes = parts.count == 5 ? UInt8(parts[4]) : subframes
+        guard let sf = parsedSubframes else { return nil }
+        return LocatePosition(
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds,
+            frames: frames,
+            subframes: sf,
+            description: "\(hours):\(minutes):\(seconds):\(frames).\(sf)"
+        )
+    }
+
+    private func locatePosition(totalSeconds: Int, description: String) -> LocatePosition {
+        let clampedSeconds = min(totalSeconds, 23 * 60 * 60 + 59 * 60 + 59)
+        let hours = UInt8(clampedSeconds / 3600)
+        let minutes = UInt8((clampedSeconds % 3600) / 60)
+        let seconds = UInt8(clampedSeconds % 60)
+        return LocatePosition(
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds,
+            frames: 0,
+            subframes: 0,
+            description: description
+        )
+    }
+
+    private func parseNoteList(_ value: String?) -> [UInt8]? {
+        guard let value else { return nil }
+        let tokens = value.split { character in
+            character == "," || character == " " || character == "[" || character == "]"
+        }
+        guard !tokens.isEmpty else { return nil }
+        var notes: [UInt8] = []
+        for token in tokens {
+            guard let note = UInt8(token) else { return nil }
+            notes.append(note)
+        }
+        return notes.isEmpty ? nil : notes
+    }
+
+    private func parsePitchBendValue(_ value: String?, operation: String) -> UInt16? {
+        guard let value = value.flatMap(Int.init) else { return nil }
+        if operation == "midi.send_pitch_bend" || value < 0 {
+            let clamped = min(max(value, -8192), 8191)
+            return UInt16(clamped + 8192)
+        }
+        return UInt16(min(max(value, 0), 16383))
+    }
+
+    private func parseMIDIBytes(_ value: String) -> [UInt8]? {
+        let tokens = value.split { character in
+            character == " " || character == "," || character == "[" || character == "]"
+        }
+        guard !tokens.isEmpty else { return nil }
+        var bytes: [UInt8] = []
+        for token in tokens {
+            let tokenString = String(token)
+            let trimmed = if tokenString.hasPrefix("0x") || tokenString.hasPrefix("0X") {
+                String(tokenString.dropFirst(2))
+            } else {
+                tokenString
+            }
+            guard let byte = UInt8(trimmed, radix: 16) else { return nil }
+            bytes.append(byte)
+        }
+        return bytes
     }
 }

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -7,6 +7,7 @@ actor MIDIEngine {
     private var client: MIDIClientRef = 0
     private var virtualSource: MIDIEndpointRef = 0
     private var virtualDestination: MIDIEndpointRef = 0
+    private var additionalVirtualPorts: [(source: MIDIEndpointRef, destination: MIDIEndpointRef)] = []
     private var isRunning = false
 
     /// Stream of inbound MIDI packets from Logic Pro via the virtual destination.
@@ -65,9 +66,14 @@ actor MIDIEngine {
     /// Tear down all CoreMIDI resources.
     func stop() {
         guard isRunning else { return }
+        for port in additionalVirtualPorts {
+            if port.source != 0 { MIDIEndpointDispose(port.source) }
+            if port.destination != 0 { MIDIEndpointDispose(port.destination) }
+        }
         if virtualSource != 0 { MIDIEndpointDispose(virtualSource) }
         if virtualDestination != 0 { MIDIEndpointDispose(virtualDestination) }
         if client != 0 { MIDIClientDispose(client) }
+        additionalVirtualPorts.removeAll()
         virtualSource = 0
         virtualDestination = 0
         client = 0
@@ -77,6 +83,38 @@ actor MIDIEngine {
     }
 
     var isActive: Bool { isRunning && client != 0 }
+
+    // MARK: - Virtual Ports
+
+    /// Create an additional virtual source/destination pair.
+    func createVirtualPort(name: String) throws {
+        if !isRunning {
+            try start()
+        }
+
+        var source: MIDIEndpointRef = 0
+        var destination: MIDIEndpointRef = 0
+
+        let sourceName = "\(name)-Out" as CFString
+        var status = MIDISourceCreate(client, sourceName, &source)
+        guard status == noErr else {
+            throw MIDIEngineError.sourceCreationFailed(status)
+        }
+
+        let destinationName = "\(name)-In" as CFString
+        let continuation = self.inboundContinuation
+        status = MIDIDestinationCreateWithBlock(client, destinationName, &destination) { packetList, _ in
+            let packets = packetList.pointee
+            MIDIFeedback.parse(packetList: packets, into: continuation)
+        }
+        guard status == noErr else {
+            if source != 0 { MIDIEndpointDispose(source) }
+            throw MIDIEngineError.destinationCreationFailed(status)
+        }
+
+        additionalVirtualPorts.append((source: source, destination: destination))
+        Log.info("Virtual MIDI port created — source: \(name)-Out, sink: \(name)-In", subsystem: "midi")
+    }
 
     // MARK: - Send: Notes
 

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import LogicProMCP
+
+final class CoreMIDIChannelTests: XCTestCase {
+    func testAdvertisedMIDIOperationsSucceed() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        assertSuccess(await channel.execute(
+            operation: "midi.send_program_change",
+            params: ["program": "12", "channel": "0"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.send_pitch_bend",
+            params: ["value": "-8192", "channel": "0"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.send_aftertouch",
+            params: ["value": "64", "channel": "0"]
+        ))
+    }
+
+    func testAdvertisedMMCOperationsSucceed() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        for operation in ["mmc.play", "mmc.stop", "mmc.record_strobe", "mmc.record_exit", "mmc.pause"] {
+            assertSuccess(await channel.execute(operation: operation, params: [:]))
+        }
+        assertSuccess(await channel.execute(operation: "mmc.locate", params: ["time": "01:02:03:04"]))
+    }
+
+    func testParameterAliasesSucceed() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        assertSuccess(await channel.execute(
+            operation: "midi.send_sysex",
+            params: ["bytes": "F0 7F 7F 06 02 F7"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.send_sysex",
+            params: ["data": "F0 7F 7F 06 01 F7"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.send_aftertouch",
+            params: ["pressure": "80", "channel": "0"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.send_aftertouch",
+            params: ["value": "81", "channel": "0"]
+        ))
+        assertSuccess(await channel.execute(operation: "mmc.locate", params: ["bar": "4"]))
+        assertSuccess(await channel.execute(operation: "mmc.locate", params: ["time": "00:00:10:00"]))
+    }
+
+    func testChordAndVirtualPortSucceed() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        assertSuccess(await channel.execute(
+            operation: "midi.send_chord",
+            params: ["notes": "60,64,67", "velocity": "90", "channel": "0", "duration_ms": "1"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.create_virtual_port",
+            params: ["name": "LogicProMCP-Test-\(UUID().uuidString)"]
+        ))
+        await channel.stop()
+    }
+
+    func testPitchBendClampsSignedAdvertisedRange() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let lowResult = await channel.execute(
+            operation: "midi.send_pitch_bend",
+            params: ["value": "-9000", "channel": "0"]
+        )
+        assertSuccess(lowResult)
+        XCTAssertEqual(lowResult.message, "Pitch bend 0 on ch 0")
+
+        let highResult = await channel.execute(
+            operation: "midi.send_pitch_bend",
+            params: ["value": "9000", "channel": "0"]
+        )
+        assertSuccess(highResult)
+        XCTAssertEqual(highResult.message, "Pitch bend 16383 on ch 0")
+    }
+
+    func testSysExRejectsMissingFraming() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let result = await channel.execute(
+            operation: "midi.send_sysex",
+            params: ["data": "7F 7F 06 02"]
+        )
+
+        assertError(result, contains: "SysEx must start with F0 and end with F7")
+    }
+
+    func testUnknownOperationsStillError() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        let result = await channel.execute(operation: "midi.not_real", params: [:])
+
+        assertError(result, contains: "Unknown CoreMIDI operation: midi.not_real")
+    }
+
+    func testInternalAliasesStillSucceed() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+
+        assertSuccess(await channel.execute(
+            operation: "midi.program_change",
+            params: ["program": "12", "channel": "0"]
+        ))
+        assertSuccess(await channel.execute(
+            operation: "midi.pitch_bend",
+            params: ["value": "8192", "channel": "0"]
+        ))
+    }
+
+    private func assertSuccess(
+        _ result: ChannelResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .success = result else {
+            XCTFail("Expected success, got \(result)", file: file, line: line)
+            return
+        }
+    }
+
+    private func assertError(
+        _ result: ChannelResult,
+        contains message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .error(let error) = result else {
+            XCTFail("Expected error, got \(result)", file: file, line: line)
+            return
+        }
+        XCTAssertTrue(error.contains(message), "Expected '\(error)' to contain '\(message)'", file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary
The CoreMIDI channel advertised operations (additional virtual MIDI ports) that the engine did not actually implement, so callers requesting them failed.

## Changes
Implement `MIDIEngine.createVirtualPort(name:)` to create an additional virtual source/destination pair (auto-starting the engine if needed), track the pairs, and dispose them on stop. Wire the CoreMIDI channel's advertised operations to the engine.

## Testing
Added `CoreMIDIChannelTests.swift` exercising the advertised operations.

Fixes #25
