### PR TITLE
Logic Pro 12 AX tree fixes, OSC continuation guard, and server-side send_chord/send_sequence

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -69,13 +69,15 @@ enum AXHelpers {
         of element: AXUIElement,
         role: String? = nil,
         title: String? = nil,
-        identifier: String? = nil
+        identifier: String? = nil,
+        description: String? = nil
     ) -> AXUIElement? {
         let children = getChildren(element)
         for child in children {
             if let role, getRole(child) != role { continue }
             if let title, getTitle(child) != title { continue }
             if let identifier, getIdentifier(child) != identifier { continue }
+            if let description, getDescription(child) != description { continue }
             return child
         }
         return nil
@@ -88,6 +90,7 @@ enum AXHelpers {
         role: String? = nil,
         title: String? = nil,
         identifier: String? = nil,
+        description: String? = nil,
         maxDepth: Int = 10
     ) -> AXUIElement? {
         guard maxDepth > 0 else { return nil }
@@ -96,12 +99,13 @@ enum AXHelpers {
             let roleMatch = role == nil || getRole(child) == role
             let titleMatch = title == nil || getTitle(child) == title
             let idMatch = identifier == nil || getIdentifier(child) == identifier
-            if roleMatch && titleMatch && idMatch {
+            let descMatch = description == nil || getDescription(child) == description
+            if roleMatch && titleMatch && idMatch && descMatch {
                 return child
             }
             if let found = findDescendant(
                 of: child, role: role, title: title, identifier: identifier,
-                maxDepth: maxDepth - 1
+                description: description, maxDepth: maxDepth - 1
             ) {
                 return found
             }

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -120,7 +120,16 @@ enum AXValueExtractors {
     static func extractTransportState(from transport: AXUIElement) -> TransportState {
         var state = TransportState()
 
-        // Logic Pro 12: transport toggles are AXCheckBox with value 0/1
+        // Logic Pro 12: transport toggles are AXCheckBox with value 0/1.
+        // Track which controls the checkbox pass resolved, so the legacy
+        // button fallback fills in only the gaps -- mixed AX trees exist
+        // (checkbox Play alongside button Record/Cycle/Metronome), and a
+        // button must never overwrite a checkbox-resolved state.
+        var resolvedPlay = false
+        var resolvedRecord = false
+        var resolvedCycle = false
+        var resolvedMetronome = false
+
         let checkboxes = AXHelpers.findAllDescendants(of: transport, role: kAXCheckBoxRole, maxDepth: 4)
         for cb in checkboxes {
             let desc = AXHelpers.getDescription(cb) ?? AXHelpers.getTitle(cb) ?? ""
@@ -129,27 +138,32 @@ enum AXValueExtractors {
 
             if descLower == "play" {
                 state.isPlaying = pressed
+                resolvedPlay = true
             } else if descLower == "record" {
                 state.isRecording = pressed
+                resolvedRecord = true
             } else if descLower == "cycle" {
                 state.isCycleEnabled = pressed
+                resolvedCycle = true
             } else if descLower.contains("metronome") || descLower.contains("click") {
                 state.isMetronomeEnabled = pressed
+                resolvedMetronome = true
             }
         }
 
-        // Legacy fallback: some versions use AXButton
-        if !checkboxes.contains(where: { (AXHelpers.getDescription($0) ?? "").lowercased() == "play" }) {
+        // Legacy fallback: some versions use AXButton. Consult buttons only
+        // for controls the checkbox pass left unresolved.
+        if !(resolvedPlay && resolvedRecord && resolvedCycle && resolvedMetronome) {
             let buttons = AXHelpers.findAllDescendants(of: transport, role: kAXButtonRole, maxDepth: 4)
             for button in buttons {
                 let desc = AXHelpers.getDescription(button) ?? AXHelpers.getTitle(button) ?? ""
                 let pressed = extractButtonState(button) ?? false
                 let descLower = desc.lowercased()
 
-                if descLower.contains("play") { state.isPlaying = pressed }
-                else if descLower.contains("record") && !descLower.contains("arm") { state.isRecording = pressed }
-                else if descLower.contains("cycle") || descLower.contains("loop") { state.isCycleEnabled = pressed }
-                else if descLower.contains("metronome") || descLower.contains("click") { state.isMetronomeEnabled = pressed }
+                if !resolvedPlay, descLower.contains("play") { state.isPlaying = pressed }
+                else if !resolvedRecord, descLower.contains("record") && !descLower.contains("arm") { state.isRecording = pressed }
+                else if !resolvedCycle, descLower.contains("cycle") || descLower.contains("loop") { state.isCycleEnabled = pressed }
+                else if !resolvedMetronome, descLower.contains("metronome") || descLower.contains("click") { state.isMetronomeEnabled = pressed }
             }
         }
 

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -60,6 +60,7 @@ actor ChannelRouter {
         // MIDI — CoreMIDI only
         "midi.send_note":             [.coreMIDI],
         "midi.send_chord":            [.coreMIDI],
+        "midi.send_sequence":         [.coreMIDI],
         "midi.send_cc":               [.coreMIDI],
         "midi.send_program_change":   [.coreMIDI],
         "midi.send_pitch_bend":       [.coreMIDI],

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -100,12 +100,8 @@ actor CoreMIDIChannel: Channel {
             return .success("Chord [\(chordNotes.map(String.init).joined(separator: ","))] on ch \(chordChannel) vel \(chordVelocity) dur \(chordDurationMs)ms")
 
         case "midi.send_sequence":
-            // Parse JSON-encoded sequence of timed events
-            // Format: events is a JSON array string, each element:
-            //   {"type":"note","note":60,"velocity":100,"channel":0,"duration_ms":250,"time_ms":0}
-            //   {"type":"chord","notes":[60,64,67],"velocity":100,"channel":0,"duration_ms":500,"time_ms":1000}
-            //   {"type":"rest","duration_ms":250,"time_ms":500}
-            //   {"type":"cc","controller":1,"value":127,"channel":0,"time_ms":0}
+            // Parse JSON-encoded sequence of timed events -- returns IMMEDIATELY, plays in background.
+            // This prevents the MCP connection from timing out on long sequences.
             guard let eventsJSON = params["events"] else {
                 return .error("send_sequence requires 'events' (JSON array of timed events)")
             }
@@ -118,73 +114,84 @@ actor CoreMIDIChannel: Channel {
             }
 
             let seqChannel = params["channel"].flatMap(UInt8.init) ?? 0
-            var eventsPlayed = 0
-            var lastTimeMs: UInt64 = 0
+            let eventCount = events.count
 
-            // Sort events by time_ms for correct ordering
-            let sorted = events.sorted { ($0["time_ms"] as? UInt64 ?? 0) < ($1["time_ms"] as? UInt64 ?? 0) }
-
-            for event in sorted {
-                let eventType = event["type"] as? String ?? "note"
-                let timeMs = event["time_ms"] as? UInt64
-                    ?? (event["time_ms"] as? Int).map(UInt64.init) ?? 0
-
-                // Sleep until this event's scheduled time
-                if timeMs > lastTimeMs {
-                    let delta = timeMs - lastTimeMs
-                    try? await Task.sleep(nanoseconds: delta * 1_000_000)
-                }
-                lastTimeMs = timeMs
-
-                let ch = (event["channel"] as? Int).map(UInt8.init) ?? seqChannel
-
-                switch eventType {
-                case "note":
-                    let note = UInt8(event["note"] as? Int ?? 60)
-                    let vel = UInt8(event["velocity"] as? Int ?? 100)
-                    let dur = UInt64(event["duration_ms"] as? Int ?? 250)
-                    await engine.sendNoteOn(channel: ch, note: note, velocity: vel)
-                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
-                    await engine.sendNoteOff(channel: ch, note: note)
-                    // Advance lastTimeMs by the note duration so next event timing is relative to note end
-                    lastTimeMs += dur
-                    eventsPlayed += 1
-
-                case "chord":
-                    let notes: [Int] = event["notes"] as? [Int] ?? []
-                    let vel = UInt8(event["velocity"] as? Int ?? 100)
-                    let dur = UInt64(event["duration_ms"] as? Int ?? 500)
-                    for n in notes {
-                        await engine.sendNoteOn(channel: ch, note: UInt8(n), velocity: vel)
-                    }
-                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
-                    for n in notes {
-                        await engine.sendNoteOff(channel: ch, note: UInt8(n))
-                    }
-                    lastTimeMs += dur
-                    eventsPlayed += 1
-
-                case "rest":
-                    let dur = UInt64(event["duration_ms"] as? Int ?? 250)
-                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
-                    lastTimeMs += dur
-
-                case "cc":
-                    let controller = UInt8(event["controller"] as? Int ?? 0)
-                    let value = UInt8(event["value"] as? Int ?? 0)
-                    await engine.sendCC(channel: ch, controller: controller, value: value)
-                    eventsPlayed += 1
-
-                case "program_change":
-                    let program = UInt8(event["program"] as? Int ?? 0)
-                    await engine.sendProgramChange(channel: ch, program: program)
-                    eventsPlayed += 1
-
-                default:
-                    Log.warn("send_sequence: unknown event type '\(eventType)', skipping", subsystem: "midi")
-                }
+            // Estimate total duration from events for the response message
+            var estimatedDurationMs: UInt64 = 0
+            for event in events {
+                let timeMs = (event["time_ms"] as? Int).map(UInt64.init) ?? 0
+                let dur = (event["duration_ms"] as? Int).map(UInt64.init) ?? 0
+                let end = timeMs + dur
+                if end > estimatedDurationMs { estimatedDurationMs = end }
             }
-            return .success("Sequence complete: \(eventsPlayed) events played over \(lastTimeMs)ms")
+
+            // Fire and forget -- play sequence in detached task
+            let engineRef = self.engine
+            Task.detached {
+                let sorted = events.sorted {
+                    let a = ($0["time_ms"] as? Int).map(UInt64.init) ?? 0
+                    let b = ($1["time_ms"] as? Int).map(UInt64.init) ?? 0
+                    return a < b
+                }
+                var lastTimeMs: UInt64 = 0
+
+                for event in sorted {
+                    let eventType = event["type"] as? String ?? "note"
+                    let timeMs = (event["time_ms"] as? Int).map(UInt64.init) ?? 0
+
+                    if timeMs > lastTimeMs {
+                        let delta = timeMs - lastTimeMs
+                        try? await Task.sleep(nanoseconds: delta * 1_000_000)
+                    }
+                    lastTimeMs = timeMs
+
+                    let ch = (event["channel"] as? Int).map(UInt8.init) ?? seqChannel
+
+                    switch eventType {
+                    case "note":
+                        let note = UInt8(event["note"] as? Int ?? 60)
+                        let vel = UInt8(event["velocity"] as? Int ?? 100)
+                        let dur = UInt64(event["duration_ms"] as? Int ?? 250)
+                        await engineRef.sendNoteOn(channel: ch, note: note, velocity: vel)
+                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                        await engineRef.sendNoteOff(channel: ch, note: note)
+                        lastTimeMs += dur
+
+                    case "chord":
+                        let notes: [Int] = event["notes"] as? [Int] ?? []
+                        let vel = UInt8(event["velocity"] as? Int ?? 100)
+                        let dur = UInt64(event["duration_ms"] as? Int ?? 500)
+                        for n in notes {
+                            await engineRef.sendNoteOn(channel: ch, note: UInt8(n), velocity: vel)
+                        }
+                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                        for n in notes {
+                            await engineRef.sendNoteOff(channel: ch, note: UInt8(n))
+                        }
+                        lastTimeMs += dur
+
+                    case "rest":
+                        let dur = UInt64(event["duration_ms"] as? Int ?? 250)
+                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                        lastTimeMs += dur
+
+                    case "cc":
+                        let controller = UInt8(event["controller"] as? Int ?? 0)
+                        let value = UInt8(event["value"] as? Int ?? 0)
+                        await engineRef.sendCC(channel: ch, controller: controller, value: value)
+
+                    case "program_change":
+                        let program = UInt8(event["program"] as? Int ?? 0)
+                        await engineRef.sendProgramChange(channel: ch, program: program)
+
+                    default:
+                        Log.warn("send_sequence: unknown event type '\(eventType)', skipping", subsystem: "midi")
+                    }
+                }
+                Log.info("Sequence playback complete: \(sorted.count) events over \(lastTimeMs)ms", subsystem: "midi")
+            }
+
+            return .success("Sequence started: \(eventCount) events, ~\(estimatedDurationMs)ms duration (playing in background)")
 
         case "midi.note_on":
             guard let note = params["note"].flatMap(UInt8.init) else {

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -76,6 +76,116 @@ actor CoreMIDIChannel: Channel {
             await engine.sendNoteOff(channel: channel, note: note)
             return .success("Note \(note) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
 
+        case "midi.send_chord":
+            // Parse comma-separated notes
+            guard let notesStr = params["notes"], !notesStr.isEmpty else {
+                return .error("send_chord requires 'notes' (comma-separated MIDI note numbers)")
+            }
+            let chordNotes = notesStr.split(separator: ",").compactMap { UInt8($0.trimmingCharacters(in: .whitespaces)) }
+            guard !chordNotes.isEmpty else {
+                return .error("send_chord: no valid note numbers in '\(notesStr)'")
+            }
+            let chordChannel = params["channel"].flatMap(UInt8.init) ?? 0
+            let chordVelocity = params["velocity"].flatMap(UInt8.init) ?? 100
+            let chordDurationMs = params["duration_ms"].flatMap(UInt64.init) ?? 500
+            // All notes on simultaneously
+            for n in chordNotes {
+                await engine.sendNoteOn(channel: chordChannel, note: n, velocity: chordVelocity)
+            }
+            try? await Task.sleep(nanoseconds: chordDurationMs * 1_000_000)
+            // All notes off simultaneously
+            for n in chordNotes {
+                await engine.sendNoteOff(channel: chordChannel, note: n)
+            }
+            return .success("Chord [\(chordNotes.map(String.init).joined(separator: ","))] on ch \(chordChannel) vel \(chordVelocity) dur \(chordDurationMs)ms")
+
+        case "midi.send_sequence":
+            // Parse JSON-encoded sequence of timed events
+            // Format: events is a JSON array string, each element:
+            //   {"type":"note","note":60,"velocity":100,"channel":0,"duration_ms":250,"time_ms":0}
+            //   {"type":"chord","notes":[60,64,67],"velocity":100,"channel":0,"duration_ms":500,"time_ms":1000}
+            //   {"type":"rest","duration_ms":250,"time_ms":500}
+            //   {"type":"cc","controller":1,"value":127,"channel":0,"time_ms":0}
+            guard let eventsJSON = params["events"] else {
+                return .error("send_sequence requires 'events' (JSON array of timed events)")
+            }
+            guard let eventsData = eventsJSON.data(using: .utf8),
+                  let events = try? JSONSerialization.jsonObject(with: eventsData) as? [[String: Any]] else {
+                return .error("send_sequence: 'events' must be a valid JSON array")
+            }
+            guard !events.isEmpty else {
+                return .error("send_sequence: events array is empty")
+            }
+
+            let seqChannel = params["channel"].flatMap(UInt8.init) ?? 0
+            var eventsPlayed = 0
+            var lastTimeMs: UInt64 = 0
+
+            // Sort events by time_ms for correct ordering
+            let sorted = events.sorted { ($0["time_ms"] as? UInt64 ?? 0) < ($1["time_ms"] as? UInt64 ?? 0) }
+
+            for event in sorted {
+                let eventType = event["type"] as? String ?? "note"
+                let timeMs = event["time_ms"] as? UInt64
+                    ?? (event["time_ms"] as? Int).map(UInt64.init) ?? 0
+
+                // Sleep until this event's scheduled time
+                if timeMs > lastTimeMs {
+                    let delta = timeMs - lastTimeMs
+                    try? await Task.sleep(nanoseconds: delta * 1_000_000)
+                }
+                lastTimeMs = timeMs
+
+                let ch = (event["channel"] as? Int).map(UInt8.init) ?? seqChannel
+
+                switch eventType {
+                case "note":
+                    let note = UInt8(event["note"] as? Int ?? 60)
+                    let vel = UInt8(event["velocity"] as? Int ?? 100)
+                    let dur = UInt64(event["duration_ms"] as? Int ?? 250)
+                    await engine.sendNoteOn(channel: ch, note: note, velocity: vel)
+                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                    await engine.sendNoteOff(channel: ch, note: note)
+                    // Advance lastTimeMs by the note duration so next event timing is relative to note end
+                    lastTimeMs += dur
+                    eventsPlayed += 1
+
+                case "chord":
+                    let notes: [Int] = event["notes"] as? [Int] ?? []
+                    let vel = UInt8(event["velocity"] as? Int ?? 100)
+                    let dur = UInt64(event["duration_ms"] as? Int ?? 500)
+                    for n in notes {
+                        await engine.sendNoteOn(channel: ch, note: UInt8(n), velocity: vel)
+                    }
+                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                    for n in notes {
+                        await engine.sendNoteOff(channel: ch, note: UInt8(n))
+                    }
+                    lastTimeMs += dur
+                    eventsPlayed += 1
+
+                case "rest":
+                    let dur = UInt64(event["duration_ms"] as? Int ?? 250)
+                    try? await Task.sleep(nanoseconds: dur * 1_000_000)
+                    lastTimeMs += dur
+
+                case "cc":
+                    let controller = UInt8(event["controller"] as? Int ?? 0)
+                    let value = UInt8(event["value"] as? Int ?? 0)
+                    await engine.sendCC(channel: ch, controller: controller, value: value)
+                    eventsPlayed += 1
+
+                case "program_change":
+                    let program = UInt8(event["program"] as? Int ?? 0)
+                    await engine.sendProgramChange(channel: ch, program: program)
+                    eventsPlayed += 1
+
+                default:
+                    Log.warn("send_sequence: unknown event type '\(eventType)', skipping", subsystem: "midi")
+                }
+            }
+            return .success("Sequence complete: \(eventsPlayed) events played over \(lastTimeMs)ms")
+
         case "midi.note_on":
             guard let note = params["note"].flatMap(UInt8.init) else {
                 return .error("note_on requires 'note' (0-127)")

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -77,16 +77,30 @@ actor CoreMIDIChannel: Channel {
             return .success("Note \(note) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
 
         case "midi.send_chord":
-            // Parse comma-separated notes
+            // Parse comma-separated notes. Every token must parse and be in
+            // range -- silently dropping bad tokens would play a different
+            // chord than the caller asked for, and out-of-range values would
+            // otherwise be masked to unrelated notes by MIDIEngine.
             guard let notesStr = params["notes"], !notesStr.isEmpty else {
                 return .error("send_chord requires 'notes' (comma-separated MIDI note numbers)")
             }
-            let chordNotes = notesStr.split(separator: ",").compactMap { UInt8($0.trimmingCharacters(in: .whitespaces)) }
-            guard !chordNotes.isEmpty else {
-                return .error("send_chord: no valid note numbers in '\(notesStr)'")
+            var chordNotes: [UInt8] = []
+            for token in notesStr.split(separator: ",") {
+                let trimmed = token.trimmingCharacters(in: .whitespaces)
+                guard let note = UInt8(trimmed), note <= 127 else {
+                    return .error("send_chord: invalid note '\(trimmed)' -- each note must be 0-127")
+                }
+                chordNotes.append(note)
             }
-            let chordChannel = params["channel"].flatMap(UInt8.init) ?? 0
-            let chordVelocity = params["velocity"].flatMap(UInt8.init) ?? 100
+            guard !chordNotes.isEmpty else {
+                return .error("send_chord: no note numbers in '\(notesStr)'")
+            }
+            guard let chordChannel = Self.parseChannel(params["channel"], default: 0) else {
+                return .error("send_chord: 'channel' must be 0-15")
+            }
+            guard let chordVelocity = Self.parse7Bit(params["velocity"], default: 100) else {
+                return .error("send_chord: 'velocity' must be 0-127")
+            }
             let chordDurationMs = params["duration_ms"].flatMap(UInt64.init) ?? 500
             // All notes on simultaneously
             for n in chordNotes {
@@ -106,89 +120,77 @@ actor CoreMIDIChannel: Channel {
                 return .error("send_sequence requires 'events' (JSON array of timed events)")
             }
             guard let eventsData = eventsJSON.data(using: .utf8),
-                  let events = try? JSONSerialization.jsonObject(with: eventsData) as? [[String: Any]] else {
+                  let rawEvents = try? JSONSerialization.jsonObject(with: eventsData) as? [[String: Any]] else {
                 return .error("send_sequence: 'events' must be a valid JSON array")
             }
-            guard !events.isEmpty else {
+            guard !rawEvents.isEmpty else {
                 return .error("send_sequence: events array is empty")
             }
-
-            let seqChannel = params["channel"].flatMap(UInt8.init) ?? 0
-            let eventCount = events.count
-
-            // Estimate total duration from events for the response message
-            var estimatedDurationMs: UInt64 = 0
-            for event in events {
-                let timeMs = (event["time_ms"] as? Int).map(UInt64.init) ?? 0
-                let dur = (event["duration_ms"] as? Int).map(UInt64.init) ?? 0
-                let end = timeMs + dur
-                if end > estimatedDurationMs { estimatedDurationMs = end }
+            guard let seqChannel = Self.parseChannel(params["channel"], default: 0) else {
+                return .error("send_sequence: 'channel' must be 0-15")
             }
 
-            // Fire and forget -- play sequence in detached task
+            // Validate every event up front, so a bad payload is rejected here
+            // instead of being coerced (or trapping on UInt8 conversion, which
+            // would kill the whole server) mid-playback in the detached task.
+            var events: [SequenceEvent] = []
+            for (index, raw) in rawEvents.enumerated() {
+                do {
+                    events.append(try SequenceEvent(raw, defaultChannel: seqChannel))
+                } catch let error as SequenceEventError {
+                    return .error("send_sequence: event \(index): \(error.message)")
+                } catch {
+                    return .error("send_sequence: event \(index): \(error)")
+                }
+            }
+
+            // Assign each event an absolute start on one timeline. Events keep
+            // their submitted order for equal explicit times (stable sort);
+            // events without time_ms play sequentially from the running cursor,
+            // preserving duration/rest-driven sequencing.
+            let scheduled = Self.schedule(events)
+            let eventCount = scheduled.count
+            let estimatedDurationMs = scheduled.map { $0.event.endOffset(from: $0.startMs) }.max() ?? 0
+
+            // Fire and forget -- play sequence in detached task. Note starts
+            // are slept-to against one monotonic origin and note-offs are
+            // dispatched independently, so a long duration never delays the
+            // next event's start.
             let engineRef = self.engine
             Task.detached {
-                let sorted = events.sorted {
-                    let a = ($0["time_ms"] as? Int).map(UInt64.init) ?? 0
-                    let b = ($1["time_ms"] as? Int).map(UInt64.init) ?? 0
-                    return a < b
-                }
-                var lastTimeMs: UInt64 = 0
-
-                for event in sorted {
-                    let eventType = event["type"] as? String ?? "note"
-                    let timeMs = (event["time_ms"] as? Int).map(UInt64.init) ?? 0
-
-                    if timeMs > lastTimeMs {
-                        let delta = timeMs - lastTimeMs
-                        try? await Task.sleep(nanoseconds: delta * 1_000_000)
-                    }
-                    lastTimeMs = timeMs
-
-                    let ch = (event["channel"] as? Int).map(UInt8.init) ?? seqChannel
-
-                    switch eventType {
-                    case "note":
-                        let note = UInt8(event["note"] as? Int ?? 60)
-                        let vel = UInt8(event["velocity"] as? Int ?? 100)
-                        let dur = UInt64(event["duration_ms"] as? Int ?? 250)
+                let origin = ContinuousClock.now
+                for (event, startMs) in scheduled {
+                    try? await Task.sleep(until: origin + .milliseconds(Int64(startMs)), clock: .continuous)
+                    switch event {
+                    case .note(_, let ch, let note, let vel, let dur):
                         await engineRef.sendNoteOn(channel: ch, note: note, velocity: vel)
-                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
-                        await engineRef.sendNoteOff(channel: ch, note: note)
-                        lastTimeMs += dur
-
-                    case "chord":
-                        let notes: [Int] = event["notes"] as? [Int] ?? []
-                        let vel = UInt8(event["velocity"] as? Int ?? 100)
-                        let dur = UInt64(event["duration_ms"] as? Int ?? 500)
-                        for n in notes {
-                            await engineRef.sendNoteOn(channel: ch, note: UInt8(n), velocity: vel)
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(Int64(dur)))
+                            await engineRef.sendNoteOff(channel: ch, note: note)
                         }
-                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
+
+                    case .chord(_, let ch, let notes, let vel, let dur):
                         for n in notes {
-                            await engineRef.sendNoteOff(channel: ch, note: UInt8(n))
+                            await engineRef.sendNoteOn(channel: ch, note: n, velocity: vel)
                         }
-                        lastTimeMs += dur
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(Int64(dur)))
+                            for n in notes {
+                                await engineRef.sendNoteOff(channel: ch, note: n)
+                            }
+                        }
 
-                    case "rest":
-                        let dur = UInt64(event["duration_ms"] as? Int ?? 250)
-                        try? await Task.sleep(nanoseconds: dur * 1_000_000)
-                        lastTimeMs += dur
+                    case .rest:
+                        break  // rests only occupy the timeline; scheduling already accounted for them
 
-                    case "cc":
-                        let controller = UInt8(event["controller"] as? Int ?? 0)
-                        let value = UInt8(event["value"] as? Int ?? 0)
+                    case .cc(_, let ch, let controller, let value):
                         await engineRef.sendCC(channel: ch, controller: controller, value: value)
 
-                    case "program_change":
-                        let program = UInt8(event["program"] as? Int ?? 0)
+                    case .programChange(_, let ch, let program):
                         await engineRef.sendProgramChange(channel: ch, program: program)
-
-                    default:
-                        Log.warn("send_sequence: unknown event type '\(eventType)', skipping", subsystem: "midi")
                     }
                 }
-                Log.info("Sequence playback complete: \(sorted.count) events over \(lastTimeMs)ms", subsystem: "midi")
+                Log.info("Sequence playback dispatched: \(scheduled.count) events over ~\(estimatedDurationMs)ms", subsystem: "midi")
             }
 
             return .success("Sequence started: \(eventCount) events, ~\(estimatedDurationMs)ms duration (playing in background)")
@@ -277,4 +279,178 @@ actor CoreMIDIChannel: Channel {
             return .unavailable("CoreMIDI client not initialized")
         }
     }
+}
+
+// MARK: - Parameter validation helpers
+
+extension CoreMIDIChannel {
+    /// Parse an optional string parameter as a MIDI channel (0-15).
+    /// Returns the default when absent, nil when present but invalid --
+    /// out-of-range channels must be rejected, not masked by MIDIEngine.
+    static func parseChannel(_ raw: String?, default def: UInt8) -> UInt8? {
+        guard let raw else { return def }
+        guard let value = UInt8(raw), value <= 15 else { return nil }
+        return value
+    }
+
+    /// Parse an optional string parameter as a 7-bit MIDI value (0-127).
+    static func parse7Bit(_ raw: String?, default def: UInt8) -> UInt8? {
+        guard let raw else { return def }
+        guard let value = UInt8(raw), value <= 127 else { return nil }
+        return value
+    }
+
+    /// Assign every event an absolute start time (ms) on one timeline.
+    /// Events are stably ordered by explicit time_ms (submitted order breaks
+    /// ties, so purely sequential input keeps its order). An event without
+    /// time_ms starts at the running cursor; note/chord/rest advance the
+    /// cursor by their duration, cc/program_change do not.
+    static func schedule(_ events: [SequenceEvent]) -> [(event: SequenceEvent, startMs: UInt64)] {
+        let ordered = events.enumerated()
+            .sorted { ($0.element.timeMs ?? 0, $0.offset) < ($1.element.timeMs ?? 0, $1.offset) }
+            .map(\.element)
+
+        var cursor: UInt64 = 0
+        var scheduled: [(event: SequenceEvent, startMs: UInt64)] = []
+        for event in ordered {
+            let start = event.timeMs ?? cursor
+            scheduled.append((event, start))
+            cursor = event.advancesTimeline ? start + event.durationMs : max(cursor, start)
+        }
+        return scheduled
+    }
+}
+
+// MARK: - Sequence events
+
+/// A fully validated send_sequence event. All range checks happen in the
+/// parser so the playback task never performs a trapping integer conversion.
+enum SequenceEvent: Sendable {
+    case note(timeMs: UInt64?, channel: UInt8, note: UInt8, velocity: UInt8, durationMs: UInt64)
+    case chord(timeMs: UInt64?, channel: UInt8, notes: [UInt8], velocity: UInt8, durationMs: UInt64)
+    case rest(timeMs: UInt64?, durationMs: UInt64)
+    case cc(timeMs: UInt64?, channel: UInt8, controller: UInt8, value: UInt8)
+    case programChange(timeMs: UInt64?, channel: UInt8, program: UInt8)
+
+    var timeMs: UInt64? {
+        switch self {
+        case .note(let t, _, _, _, _), .chord(let t, _, _, _, _), .rest(let t, _),
+             .cc(let t, _, _, _), .programChange(let t, _, _):
+            return t
+        }
+    }
+
+    var durationMs: UInt64 {
+        switch self {
+        case .note(_, _, _, _, let d), .chord(_, _, _, _, let d), .rest(_, let d):
+            return d
+        case .cc, .programChange:
+            return 0
+        }
+    }
+
+    /// Whether the event occupies time on the sequence timeline.
+    var advancesTimeline: Bool {
+        switch self {
+        case .note, .chord, .rest: return true
+        case .cc, .programChange: return false
+        }
+    }
+
+    /// Timeline position at which this event is finished, given its start.
+    func endOffset(from startMs: UInt64) -> UInt64 {
+        startMs + durationMs
+    }
+
+    init(_ raw: [String: Any], defaultChannel: UInt8) throws {
+        let type = raw["type"] as? String ?? "note"
+        let timeMs = try Self.optionalUInt64(raw, "time_ms")
+        let channel = try Self.bounded(raw, "channel", max: 15, default: defaultChannel)
+
+        switch type {
+        case "note":
+            guard raw["note"] != nil else {
+                throw SequenceEventError("'note' is required (0-127)")
+            }
+            self = .note(
+                timeMs: timeMs,
+                channel: channel,
+                note: try Self.bounded(raw, "note", max: 127, default: 0),
+                velocity: try Self.bounded(raw, "velocity", max: 127, default: 100),
+                durationMs: try Self.optionalUInt64(raw, "duration_ms") ?? 250
+            )
+
+        case "chord":
+            guard let rawNotes = raw["notes"] as? [Any], !rawNotes.isEmpty else {
+                throw SequenceEventError("'notes' is required (non-empty array of 0-127)")
+            }
+            var notes: [UInt8] = []
+            for member in rawNotes {
+                guard let n = member as? Int, (0...127).contains(n) else {
+                    throw SequenceEventError("'notes' contains invalid entry '\(member)' -- each note must be 0-127")
+                }
+                notes.append(UInt8(n))
+            }
+            self = .chord(
+                timeMs: timeMs,
+                channel: channel,
+                notes: notes,
+                velocity: try Self.bounded(raw, "velocity", max: 127, default: 100),
+                durationMs: try Self.optionalUInt64(raw, "duration_ms") ?? 500
+            )
+
+        case "rest":
+            self = .rest(
+                timeMs: timeMs,
+                durationMs: try Self.optionalUInt64(raw, "duration_ms") ?? 250
+            )
+
+        case "cc":
+            guard raw["controller"] != nil, raw["value"] != nil else {
+                throw SequenceEventError("'controller' and 'value' are required (0-127)")
+            }
+            self = .cc(
+                timeMs: timeMs,
+                channel: channel,
+                controller: try Self.bounded(raw, "controller", max: 127, default: 0),
+                value: try Self.bounded(raw, "value", max: 127, default: 0)
+            )
+
+        case "program_change":
+            guard raw["program"] != nil else {
+                throw SequenceEventError("'program' is required (0-127)")
+            }
+            self = .programChange(
+                timeMs: timeMs,
+                channel: channel,
+                program: try Self.bounded(raw, "program", max: 127, default: 0)
+            )
+
+        default:
+            throw SequenceEventError("unknown event type '\(type)' -- supported: note, chord, rest, cc, program_change")
+        }
+    }
+
+    /// Read an optional integer field, requiring 0...max when present.
+    private static func bounded(_ raw: [String: Any], _ key: String, max: Int, default def: UInt8) throws -> UInt8 {
+        guard let value = raw[key] else { return def }
+        guard let n = value as? Int, (0...max).contains(n) else {
+            throw SequenceEventError("'\(key)' must be an integer 0-\(max), got '\(value)'")
+        }
+        return UInt8(n)
+    }
+
+    /// Read an optional non-negative integer field as milliseconds.
+    private static func optionalUInt64(_ raw: [String: Any], _ key: String) throws -> UInt64? {
+        guard let value = raw[key] else { return nil }
+        guard let n = value as? Int, n >= 0 else {
+            throw SequenceEventError("'\(key)' must be a non-negative integer, got '\(value)'")
+        }
+        return UInt64(n)
+    }
+}
+
+struct SequenceEventError: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
 }

--- a/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/MIDIDispatcher.swift
@@ -12,7 +12,13 @@ struct MIDIDispatcher {
             Params by command: \
             send_note -> { note: Int, velocity: Int, channel: Int, duration_ms: Int }; \
             send_chord -> { notes: [Int], velocity: Int, channel: Int, duration_ms: Int }; \
-            send_sequence -> { events: [{type, note/notes, velocity, channel, duration_ms, time_ms}], channel: Int }; \
+            send_sequence -> { events: [...], channel: Int } where each event is one of \
+            {type:"note", note: Int, velocity: Int?, channel: Int?, duration_ms: Int?, time_ms: Int?}, \
+            {type:"chord", notes: [Int], velocity: Int?, channel: Int?, duration_ms: Int?, time_ms: Int?}, \
+            {type:"rest", duration_ms: Int?, time_ms: Int?}, \
+            {type:"cc", controller: Int, value: Int, channel: Int?, time_ms: Int?}, \
+            {type:"program_change", program: Int, channel: Int?, time_ms: Int?} \
+            (time_ms = absolute start; events without time_ms play sequentially); \
             send_cc -> { controller: Int, value: Int, channel: Int }; \
             send_program_change -> { program: Int, channel: Int }; \
             send_pitch_bend -> { value: Int, channel: Int } (-8192 to 8191); \
@@ -83,36 +89,63 @@ struct MIDIDispatcher {
             return CallTool.Result(content: [.text(result.message)], isError: !result.isSuccess)
 
         case "send_sequence":
-            // Accept events as a JSON array (already a Value array from MCP)
+            // Accept events as a JSON array (already a Value array from MCP).
+            // Reject anything that can't be represented instead of silently
+            // dropping it -- a mixed-validity request must not report success
+            // while playing fewer or altered events than submitted.
             let eventsJSON: String
             if let arr = params["events"]?.arrayValue {
-                // Convert MCP Value array back to JSON string for CoreMIDIChannel
                 var jsonEvents: [[String: Any]] = []
-                for item in arr {
-                    // Each item should be an object -- extract fields
-                    if case .object(let obj) = item {
-                        var dict: [String: Any] = [:]
-                        for (k, v) in obj {
-                            if let i = v.intValue { dict[k] = i }
-                            else if let d = v.doubleValue { dict[k] = Int(d) }
-                            else if let s = v.stringValue { dict[k] = s }
-                            else if let a = v.arrayValue {
-                                dict[k] = a.compactMap { $0.intValue ?? $0.doubleValue.map(Int.init) }
-                            }
-                        }
-                        jsonEvents.append(dict)
+                for (index, item) in arr.enumerated() {
+                    guard case .object(let obj) = item else {
+                        return CallTool.Result(
+                            content: [.text("send_sequence: event \(index) is not an object")],
+                            isError: true
+                        )
                     }
+                    var dict: [String: Any] = [:]
+                    for (k, v) in obj {
+                        if let i = v.intValue { dict[k] = i }
+                        else if let d = v.doubleValue { dict[k] = Int(d) }
+                        else if let s = v.stringValue { dict[k] = s }
+                        else if let a = v.arrayValue {
+                            var members: [Int] = []
+                            for (memberIndex, member) in a.enumerated() {
+                                if let i = member.intValue { members.append(i) }
+                                else if let d = member.doubleValue { members.append(Int(d)) }
+                                else {
+                                    return CallTool.Result(
+                                        content: [.text("send_sequence: event \(index) field '\(k)'[\(memberIndex)] is not a number")],
+                                        isError: true
+                                    )
+                                }
+                            }
+                            dict[k] = members
+                        }
+                        else {
+                            return CallTool.Result(
+                                content: [.text("send_sequence: event \(index) field '\(k)' has an unsupported type")],
+                                isError: true
+                            )
+                        }
+                    }
+                    jsonEvents.append(dict)
                 }
-                if let data = try? JSONSerialization.data(withJSONObject: jsonEvents),
-                   let str = String(data: data, encoding: .utf8) {
-                    eventsJSON = str
-                } else {
-                    eventsJSON = "[]"
+                guard let data = try? JSONSerialization.data(withJSONObject: jsonEvents),
+                      let str = String(data: data, encoding: .utf8) else {
+                    return CallTool.Result(
+                        content: [.text("send_sequence: failed to encode events")],
+                        isError: true
+                    )
                 }
+                eventsJSON = str
             } else if let str = params["events"]?.stringValue {
                 eventsJSON = str
             } else {
-                eventsJSON = "[]"
+                return CallTool.Result(
+                    content: [.text("send_sequence requires 'events' (array of event objects, or a JSON string)")],
+                    isError: true
+                )
             }
             let seqChannel = params["channel"]?.intValue ?? 1
             let seqResult = await router.route(

--- a/Sources/LogicProMCP/OSC/OSCClient.swift
+++ b/Sources/LogicProMCP/OSC/OSCClient.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Network
-import os
 
 /// Sends OSC messages to Logic Pro over UDP using Network.framework.
 actor OSCClient {
@@ -31,9 +30,11 @@ actor OSCClient {
                     Task { await self?.setReady(true) }
                     if guard_.tryConsume() { continuation.resume(returning: true) }
                 case .failed(let error):
+                    Task { await self?.setReady(false) }
                     Log.error("OSCClient connection failed: \(error)", subsystem: "osc")
                     if guard_.tryConsume() { continuation.resume(returning: false) }
                 case .cancelled:
+                    Task { await self?.setReady(false) }
                     Log.info("OSCClient connection cancelled", subsystem: "osc")
                     if guard_.tryConsume() { continuation.resume(returning: false) }
                 default:
@@ -45,6 +46,10 @@ actor OSCClient {
 
         if readyResult {
             self.connection = conn
+            // Set readiness synchronously: the Task dispatched by the state
+            // handler races with this method returning, and a caller's
+            // immediate send() must not see isReady == false.
+            self.isReady = true
             Log.info("OSCClient connected to \(host):\(port)", subsystem: "osc")
         } else {
             conn.cancel()

--- a/Sources/LogicProMCP/Utilities/OnceFlag.swift
+++ b/Sources/LogicProMCP/Utilities/OnceFlag.swift
@@ -1,0 +1,18 @@
+import Foundation
+import os
+
+/// Thread-safe one-shot flag for guarding CheckedContinuation resumption.
+/// `tryConsume()` returns `true` exactly once, regardless of how many
+/// threads call it concurrently.
+final class OnceFlag: @unchecked Sendable {
+    private var _consumed = false
+    private let _lock = OSAllocatedUnfairLock()
+
+    func tryConsume() -> Bool {
+        _lock.lock()
+        defer { _lock.unlock() }
+        if _consumed { return false }
+        _consumed = true
+        return true
+    }
+}

--- a/Sources/LogicProMCP/Utilities/OnceFlag.swift
+++ b/Sources/LogicProMCP/Utilities/OnceFlag.swift
@@ -4,15 +4,14 @@ import os
 /// Thread-safe one-shot flag for guarding CheckedContinuation resumption.
 /// `tryConsume()` returns `true` exactly once, regardless of how many
 /// threads call it concurrently.
-final class OnceFlag: @unchecked Sendable {
-    private var _consumed = false
-    private let _lock = OSAllocatedUnfairLock()
+final class OnceFlag: Sendable {
+    private let _consumed = OSAllocatedUnfairLock(initialState: false)
 
     func tryConsume() -> Bool {
-        _lock.lock()
-        defer { _lock.unlock() }
-        if _consumed { return false }
-        _consumed = true
-        return true
+        _consumed.withLock { consumed in
+            if consumed { return false }
+            consumed = true
+            return true
+        }
     }
 }

--- a/Tests/LogicProMCPTests/SequenceEventTests.swift
+++ b/Tests/LogicProMCPTests/SequenceEventTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import LogicProMCP
+
+/// Pure-logic tests for send_sequence validation and scheduling.
+/// No Logic Pro or CoreMIDI required.
+final class SequenceEventTests: XCTestCase {
+
+    // MARK: - Parsing: valid input
+
+    func testNoteParsesWithDefaults() throws {
+        let ev = try SequenceEvent(["type": "note", "note": 60], defaultChannel: 3)
+        guard case .note(let time, let ch, let note, let vel, let dur) = ev else {
+            return XCTFail("expected .note, got \(ev)")
+        }
+        XCTAssertNil(time)
+        XCTAssertEqual(ch, 3)
+        XCTAssertEqual(note, 60)
+        XCTAssertEqual(vel, 100)
+        XCTAssertEqual(dur, 250)
+    }
+
+    func testUntypedEventDefaultsToNote() throws {
+        let ev = try SequenceEvent(["note": 72], defaultChannel: 0)
+        guard case .note = ev else { return XCTFail("expected .note, got \(ev)") }
+    }
+
+    func testChordParsesAllNotes() throws {
+        let ev = try SequenceEvent(["type": "chord", "notes": [60, 64, 67]], defaultChannel: 0)
+        guard case .chord(_, _, let notes, _, _) = ev else {
+            return XCTFail("expected .chord, got \(ev)")
+        }
+        XCTAssertEqual(notes, [60, 64, 67])
+    }
+
+    // MARK: - Parsing: rejection (these inputs used to be coerced, dropped,
+    // or trap the playback task)
+
+    func testOutOfRangeNoteIsRejectedNotMasked() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "note", "note": 300], defaultChannel: 0))
+        XCTAssertThrowsError(try SequenceEvent(["type": "note", "note": 128], defaultChannel: 0))
+        XCTAssertThrowsError(try SequenceEvent(["type": "note", "note": -1], defaultChannel: 0))
+    }
+
+    func testMissingNoteIsRejectedNotDefaulted() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "note"], defaultChannel: 0))
+    }
+
+    func testChordWithInvalidMemberIsRejectedNotFiltered() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "chord", "notes": [60, 200, 64]], defaultChannel: 0))
+        XCTAssertThrowsError(try SequenceEvent(["type": "chord", "notes": []], defaultChannel: 0))
+    }
+
+    func testUnknownTypeIsRejectedNotSkipped() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "warp", "note": 60], defaultChannel: 0))
+    }
+
+    func testChannelAboveFifteenIsRejected() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "note", "note": 60, "channel": 16], defaultChannel: 0))
+    }
+
+    func testNegativeDurationIsRejected() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "note", "note": 60, "duration_ms": -5], defaultChannel: 0))
+    }
+
+    func testCCRequiresControllerAndValue() {
+        XCTAssertThrowsError(try SequenceEvent(["type": "cc", "controller": 7], defaultChannel: 0))
+        XCTAssertNoThrow(try SequenceEvent(["type": "cc", "controller": 7, "value": 90], defaultChannel: 0))
+    }
+
+    // MARK: - Scheduling: absolute time_ms must not be delayed by durations
+
+    func testOverlappingNotesKeepAbsoluteStarts() throws {
+        // CodeRabbit's example: notes at 0 ms and 500 ms, both 1000 ms long,
+        // must finish at 1500 ms -- not 2000 ms.
+        let events = [
+            try SequenceEvent(["type": "note", "note": 60, "time_ms": 0, "duration_ms": 1000], defaultChannel: 0),
+            try SequenceEvent(["type": "note", "note": 64, "time_ms": 500, "duration_ms": 1000], defaultChannel: 0),
+        ]
+        let scheduled = CoreMIDIChannel.schedule(events)
+        XCTAssertEqual(scheduled.map(\.startMs), [0, 500])
+        let end = scheduled.map { $0.event.endOffset(from: $0.startMs) }.max()
+        XCTAssertEqual(end, 1500)
+    }
+
+    func testUntimedEventsPlaySequentially() throws {
+        let events = [
+            try SequenceEvent(["type": "note", "note": 60, "duration_ms": 250], defaultChannel: 0),
+            try SequenceEvent(["type": "rest", "duration_ms": 100], defaultChannel: 0),
+            try SequenceEvent(["type": "note", "note": 62, "duration_ms": 250], defaultChannel: 0),
+        ]
+        let scheduled = CoreMIDIChannel.schedule(events)
+        XCTAssertEqual(scheduled.map(\.startMs), [0, 250, 350])
+    }
+
+    func testUntimedOrderIsStable() throws {
+        // All-untimed input must keep submitted order (the old unstable sort
+        // keyed on time_ms ?? 0 could scramble it).
+        let notes: [UInt8] = [60, 62, 64, 65, 67, 69, 71, 72]
+        let events = try notes.map {
+            try SequenceEvent(["type": "note", "note": Int($0), "duration_ms": 10], defaultChannel: 0)
+        }
+        let scheduled = CoreMIDIChannel.schedule(events)
+        let played: [UInt8] = scheduled.compactMap {
+            if case .note(_, _, let n, _, _) = $0.event { return n } else { return nil }
+        }
+        XCTAssertEqual(played, notes)
+    }
+
+    func testCCDoesNotAdvanceTimeline() throws {
+        let events = [
+            try SequenceEvent(["type": "cc", "controller": 7, "value": 100], defaultChannel: 0),
+            try SequenceEvent(["type": "note", "note": 60, "duration_ms": 250], defaultChannel: 0),
+        ]
+        let scheduled = CoreMIDIChannel.schedule(events)
+        XCTAssertEqual(scheduled.map(\.startMs), [0, 0])
+    }
+
+    // MARK: - Parameter helpers
+
+    func testParseChannelBounds() {
+        XCTAssertEqual(CoreMIDIChannel.parseChannel(nil, default: 5), 5)
+        XCTAssertEqual(CoreMIDIChannel.parseChannel("15", default: 0), 15)
+        XCTAssertNil(CoreMIDIChannel.parseChannel("16", default: 0))
+        XCTAssertNil(CoreMIDIChannel.parseChannel("abc", default: 0))
+    }
+
+    func testParse7BitBounds() {
+        XCTAssertEqual(CoreMIDIChannel.parse7Bit(nil, default: 100), 100)
+        XCTAssertEqual(CoreMIDIChannel.parse7Bit("127", default: 0), 127)
+        XCTAssertNil(CoreMIDIChannel.parse7Bit("128", default: 0))
+        XCTAssertNil(CoreMIDIChannel.parse7Bit("200", default: 0))
+    }
+}


### PR DESCRIPTION
## What this fixes

Logic Pro 12 changed its accessibility tree. The AX track, transport and control-bar
lookups on main were written against the pre-12 tree and return either nil or the
wrong element on 12, which leaves the Accessibility channel effectively dead for
track enumeration and transport state.

Three schema changes, found against a live Logic 12 session:

**1. Track headers.** Previously located via an AXList with identifier
"Track Headers", falling back to an AXScrollArea with identifier "Tracks", then a
bare AXOutline search. Logic 12 tags the container by description instead: an
AXGroup with AXDescription == "Tracks header", whose children are one AXLayoutItem
per track. The AXOutline fallback is the real trap - it silently returns the Region
Inspector outline instead of the track list, so callers get plausible-looking rows
that aren't tracks.

**2. Track controls.** Mute / Solo / Record Enable render as AXCheckBox on 12, not
AXButton, and are matched by AXDescription ("Mute", "Solo", "Record Enable").

**3. Transport.** The control bar is no longer an AXToolbar. On 12 it's an AXGroup
with AXDescription == "Control Bar" as a direct child of the main window, and its
toggles (Play, Record, Cycle, Metronome) are AXCheckBox rather than AXButton.
Tempo and position read as AXSlider.

All three are additive: the Logic 12 lookup is tried first, and the original
identifier/role paths are retained as fallbacks, so behaviour on pre-12 Logic is
unchanged.

## Also included: OSCClient continuation double-resume

OSCClient.start() wraps NWConnection.stateUpdateHandler in withCheckedContinuation
and calls continuation.resume(...) unguarded from .ready, .failed and .cancelled.
NWConnection can fire the handler more than once (.ready followed by .cancelled on
shutdown), which resumes a CheckedContinuation twice and traps at runtime. Guarded
with a small OnceFlag (Sources/LogicProMCP/Utilities/OnceFlag.swift); each case now
resumes only if it wins tryConsume().

This only fires on a shutdown/teardown path, which is why it doesn't show up in
ordinary use.

## Scope

The AX and OSC work is 92f2810. Also here: send_chord and send_sequence implemented
server-side in CoreMIDIChannel (5af0d09), and send_sequence made fire-and-forget
(766ef3a) so long sequences don't time out the MCP connection. It returns
immediately with an event count and estimated duration and plays in a detached task,
which also keeps the transport controllable while MIDI is playing.

send_chord addresses one item from #25. It does not address the dispatcher-side
operation-name or parameter aliases in that issue, and nothing here touches the
bundle-ID detection in #23.

I've left the fork-local commits out of this branch (.gitignore template, CI Node
bump, and a commit repointing install URLs at my own fork). Those aren't for
upstream.

## Relationship to #20

Since opening this I noticed #20 already adds send_chord (plus pitch bend, aftertouch,
sysex, virtual ports and the MMC aliases) on your own branch. I don't want to step on
that. The AX tree fix and the OSC OnceFlag guard in 92f2810 are the part I don't think
is duplicated anywhere - #20 doesn't touch the AX or OSC paths, and #19 found the AX
changes but not the OSC double-resume.

So my preference, if it's useful: take 92f2810 and drop my two MIDI commits (5af0d09,
766ef3a) in favour of your #20. I'm happy to force this branch down to just the AX/OSC
commit, or you can cherry-pick 92f2810 directly. The one piece that might still be worth
having after #20 lands is the fire-and-forget send_sequence (long timed sequences that
don't block the MCP connection); I can open that separately on top of #20 if you want it,
but it's not something to merge alongside a competing send_chord.

## Testing

AX changes verified against a live Logic Pro 12 session on macOS. send_chord and
send_sequence verified with arpeggios and a ii-V-I progression. I don't have a
pre-12 Logic install, so the legacy fallback paths are unexercised, worth a second
pair of eyes.

## Relationship to #19

#19 covers overlapping AX ground plus Creator Studio support, which this doesn't
touch. Happy to close this in favour of it, or rebase on top, whichever is less
work.

