### PR TITLE
Fix dead mixer/project resources and silently-dropped CGEvent keystrokes

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -119,26 +119,51 @@ enum AXLogicProElements {
         return pane
     }
 
-    /// Find a volume fader for a specific track index within the mixer.
-    static func findFader(trackIndex: Int) -> AXUIElement? {
-        guard let mixer = getMixerArea() else { return nil }
-        let strips = AXHelpers.getChildren(mixer)
-        guard trackIndex >= 0 && trackIndex < strips.count else { return nil }
-        let strip = strips[trackIndex]
-        // Fader is an AXSlider within the channel strip
-        return AXHelpers.findDescendant(of: strip, role: kAXSliderRole, maxDepth: 4)
+    /// AXDescription values Logic Pro uses for the controls inside a channel
+    /// strip. Strips are matched on these rather than on child order, because
+    /// aux, output and master strips expose different control sets — the master
+    /// strip has no pan control at all, so an ordinal lookup silently returns
+    /// some other slider.
+    enum StripControl {
+        static let volume = "volume fader"
+        static let pan = "pan"
+        static let eq = "EQ"
     }
 
-    /// Find the pan knob for a track in the mixer.
+    /// The channel strips, in mixer order.
+    static func mixerStrips() -> [AXUIElement] {
+        guard let mixer = getMixerArea() else { return [] }
+        return AXHelpers.getChildren(mixer)
+    }
+
+    /// One channel strip by its position in the mixer.
+    static func mixerStrip(at index: Int) -> AXUIElement? {
+        let strips = mixerStrips()
+        guard strips.indices.contains(index) else { return nil }
+        return strips[index]
+    }
+
+    /// Find a control inside a channel strip by its AXDescription.
+    /// Returns nil when the strip has no such control, which is a real and
+    /// expected outcome — callers must not fall back to a positional guess.
+    static func stripControl(
+        _ strip: AXUIElement,
+        role: String,
+        description: String
+    ) -> AXUIElement? {
+        AXHelpers.findDescendant(of: strip, role: role, description: description, maxDepth: 4)
+    }
+
+    /// Find a volume fader for a specific strip index within the mixer.
+    static func findFader(trackIndex: Int) -> AXUIElement? {
+        guard let strip = mixerStrip(at: trackIndex) else { return nil }
+        return stripControl(strip, role: kAXSliderRole, description: StripControl.volume)
+    }
+
+    /// Find the pan control for a strip in the mixer. Nil on strips that have none.
     static func findPanKnob(trackIndex: Int) -> AXUIElement? {
-        guard let mixer = getMixerArea() else { return nil }
-        let strips = AXHelpers.getChildren(mixer)
-        guard trackIndex >= 0 && trackIndex < strips.count else { return nil }
-        let strip = strips[trackIndex]
-        // Pan is typically the second slider or a knob-type element
-        let sliders = AXHelpers.findAllDescendants(of: strip, role: kAXSliderRole, maxDepth: 4)
-        // Convention: first slider = volume, second = pan (if present)
-        return sliders.count > 1 ? sliders[1] : nil
+        guard let strip = mixerStrip(at: trackIndex) else { return nil }
+        return stripControl(strip, role: kAXSliderRole, description: StripControl.pan)
     }
 
     // MARK: - Menu Bar

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -99,11 +99,24 @@ enum AXLogicProElements {
     /// Find the mixer area.
     static func getMixerArea() -> AXUIElement? {
         guard let window = mainWindow() else { return nil }
-        // The mixer typically appears as a distinct group/scroll area
-        if let mixer = AXHelpers.findDescendant(of: window, role: kAXGroupRole, identifier: "Mixer") {
-            return mixer
+        // Logic Pro leaves AXIdentifier empty on these containers, so the mixer
+        // has to be matched on AXDescription instead.
+        //
+        // Anchor on the window-level "Mixer" pane before descending: the
+        // Inspector holds its own AXLayoutArea also described "Mixer" (the
+        // single-channel strip), and a plain recursive search finds that one
+        // first and reports one or two strips instead of the full desk.
+        guard let pane = AXHelpers.findChild(
+            of: window, role: kAXGroupRole, description: "Mixer"
+        ) else { return nil }
+
+        // The channel strips live in an AXLayoutArea inside that pane.
+        if let area = AXHelpers.findDescendant(
+            of: pane, role: "AXLayoutArea", description: "Mixer", maxDepth: 3
+        ) {
+            return area
         }
-        return AXHelpers.findDescendant(of: window, role: kAXScrollAreaRole, identifier: "Mixer")
+        return pane
     }
 
     /// Find a volume fader for a specific track index within the mixer.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -263,29 +263,8 @@ actor AccessibilityChannel: Channel {
             return .error("Cannot locate mixer — is it visible?")
         }
         let strips = AXHelpers.getChildren(mixer)
-        var channelStrips: [ChannelStripState] = []
-
-        for (index, strip) in strips.enumerated() {
-            // Match the controls on their AXDescription rather than on slider
-            // order, which is not guaranteed across strip types (aux, output
-            // and master strips expose different control sets).
-            let fader = AXHelpers.findDescendant(
-                of: strip, role: kAXSliderRole, description: "volume fader", maxDepth: 4
-            )
-            let panKnob = AXHelpers.findDescendant(
-                of: strip, role: kAXSliderRole, description: "pan", maxDepth: 4
-            )
-            let eqButton = AXHelpers.findDescendant(
-                of: strip, role: kAXButtonRole, description: "EQ", maxDepth: 4
-            )
-
-            channelStrips.append(ChannelStripState(
-                trackIndex: index,
-                name: AXHelpers.getDescription(strip),
-                volume: fader.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
-                pan: panKnob.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
-                eqEnabled: eqButton.flatMap { AXHelpers.getAttribute($0, kAXValueAttribute) } == "on"
-            ))
+        let channelStrips = strips.enumerated().map { index, strip in
+            Self.channelStripState(for: strip, index: index)
         }
         return encodeResult(channelStrips)
     }
@@ -301,15 +280,28 @@ actor AccessibilityChannel: Channel {
         guard index >= 0 && index < strips.count else {
             return .error("Channel strip index \(index) out of range")
         }
-        let strip = strips[index]
-        let sliders = AXHelpers.findAllDescendants(of: strip, role: kAXSliderRole, maxDepth: 4)
-        let volume = sliders.first.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0
-        let pan = sliders.count > 1
-            ? AXValueExtractors.extractSliderValue(sliders[1]) ?? 0.0
-            : 0.0
+        return encodeResult(Self.channelStripState(for: strips[index], index: index))
+    }
 
-        let state = ChannelStripState(trackIndex: index, volume: volume, pan: pan)
-        return encodeResult(state)
+    /// Read one channel strip. Shared by mixer.get_state and
+    /// mixer.get_channel_strip so both resolve controls the same way.
+    private static func channelStripState(for strip: AXUIElement, index: Int) -> ChannelStripState {
+        let fader = AXLogicProElements.stripControl(
+            strip, role: kAXSliderRole, description: AXLogicProElements.StripControl.volume
+        )
+        let panKnob = AXLogicProElements.stripControl(
+            strip, role: kAXSliderRole, description: AXLogicProElements.StripControl.pan
+        )
+        let eqButton = AXLogicProElements.stripControl(
+            strip, role: kAXButtonRole, description: AXLogicProElements.StripControl.eq
+        )
+        return ChannelStripState(
+            trackIndex: index,
+            name: AXHelpers.getDescription(strip),
+            volume: fader.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
+            pan: panKnob.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
+            eqEnabled: eqButton.flatMap { AXHelpers.getAttribute($0, kAXValueAttribute) } == "on"
+        )
     }
 
     private func setMixerValue(params: [String: String], target: MixerTarget) -> ChannelResult {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -266,16 +266,25 @@ actor AccessibilityChannel: Channel {
         var channelStrips: [ChannelStripState] = []
 
         for (index, strip) in strips.enumerated() {
-            let sliders = AXHelpers.findAllDescendants(of: strip, role: kAXSliderRole, maxDepth: 4)
-            let volume = sliders.first.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0
-            let pan = sliders.count > 1
-                ? AXValueExtractors.extractSliderValue(sliders[1]) ?? 0.0
-                : 0.0
+            // Match the controls on their AXDescription rather than on slider
+            // order, which is not guaranteed across strip types (aux, output
+            // and master strips expose different control sets).
+            let fader = AXHelpers.findDescendant(
+                of: strip, role: kAXSliderRole, description: "volume fader", maxDepth: 4
+            )
+            let panKnob = AXHelpers.findDescendant(
+                of: strip, role: kAXSliderRole, description: "pan", maxDepth: 4
+            )
+            let eqButton = AXHelpers.findDescendant(
+                of: strip, role: kAXButtonRole, description: "EQ", maxDepth: 4
+            )
 
             channelStrips.append(ChannelStripState(
                 trackIndex: index,
-                volume: volume,
-                pan: pan
+                name: AXHelpers.getDescription(strip),
+                volume: fader.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
+                pan: panKnob.flatMap { AXValueExtractors.extractSliderValue($0) } ?? 0.0,
+                eqEnabled: eqButton.flatMap { AXHelpers.getAttribute($0, kAXValueAttribute) } == "on"
             ))
         }
         return encodeResult(channelStrips)

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -109,18 +109,23 @@ actor CGEventChannel: Channel {
             return .error("Logic Pro is not running")
         }
 
-        guard await ensureFrontmost() else {
-            return .error("Could not bring Logic Pro to the front; it would discard the keystroke")
-        }
-
         if operation == "transport.goto_position" {
             guard let position = params["position"] else {
                 return .error("Missing 'position' parameter")
             }
+            // Activate only once the request is known to be actionable, so an
+            // invalid call does not steal the user's active application.
+            guard await ensureFrontmost() else {
+                return .error("Could not bring Logic Pro to the front; it would discard the keystroke")
+            }
             guard postKeyEvent(keyCode: 44, flags: [], pid: pid) else {
                 return .error("Failed to open Go To Position")
             }
-            try? await Task.sleep(for: .milliseconds(100))
+            do {
+                try await Task.sleep(for: .milliseconds(100))
+            } catch {
+                return .error("Cancelled before entering the Go To Position value")
+            }
             guard postText(position, pid: pid), postKeyEvent(keyCode: 36, flags: [], pid: pid) else {
                 return .error("Failed to enter Go To Position value")
             }
@@ -129,6 +134,10 @@ actor CGEventChannel: Channel {
 
         guard let shortcut = Self.keyMap[operation] else {
             return .error("No keyboard shortcut mapped for: \(operation)")
+        }
+
+        guard await ensureFrontmost() else {
+            return .error("Could not bring Logic Pro to the front; it would discard the keystroke")
         }
 
         let sent = postKeyEvent(keyCode: shortcut.keyCode, flags: shortcut.flags, pid: pid)
@@ -155,6 +164,10 @@ actor CGEventChannel: Channel {
     /// Logic Pro ignores events posted via postToPid() while another app is
     /// active, so this is a precondition for delivery, not an optimisation.
     private func ensureFrontmost() async -> Bool {
+        // CallTool handlers run in cancellable tasks. Never report success once
+        // cancelled, or execute() would go on to post a keystroke the client no
+        // longer wants.
+        if Task.isCancelled { return false }
         if ProcessUtils.isLogicProFrontmost { return true }
         guard ProcessUtils.activateLogicPro() else {
             Log.error("activateLogicPro() failed", subsystem: "cgEvent")
@@ -162,7 +175,14 @@ actor CGEventChannel: Channel {
         }
         // Activation is asynchronous; poll briefly rather than sleeping blind.
         for _ in 0..<20 {
-            try? await Task.sleep(for: .milliseconds(25))
+            do {
+                try await Task.sleep(for: .milliseconds(25))
+            } catch {
+                // Cancelled mid-wait. `try?` here would swallow that and let a
+                // stale keystroke through.
+                Log.debug("Cancelled while waiting for Logic Pro to activate", subsystem: "cgEvent")
+                return false
+            }
             if ProcessUtils.isLogicProFrontmost { return true }
         }
         Log.warn("Logic Pro did not become frontmost within 500ms", subsystem: "cgEvent")

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -2,8 +2,12 @@ import CoreGraphics
 import Foundation
 
 /// Channel that sends keyboard shortcuts to Logic Pro via CGEvent.
-/// Uses CGEvent.postToPid() to deliver keystrokes directly without requiring window focus.
+/// Uses CGEvent.postToPid() to deliver keystrokes to the Logic Pro process.
 /// This is the primary channel for transport control and editing operations.
+///
+/// Logic Pro discards posted key events unless it is the frontmost application,
+/// so every send activates it first. Note that postToPid() returns no delivery
+/// receipt, so a successful result means "posted", not "acted upon".
 actor CGEventChannel: Channel {
     let id: ChannelID = .cgEvent
 
@@ -105,6 +109,10 @@ actor CGEventChannel: Channel {
             return .error("Logic Pro is not running")
         }
 
+        guard await ensureFrontmost() else {
+            return .error("Could not bring Logic Pro to the front; it would discard the keystroke")
+        }
+
         if operation == "transport.goto_position" {
             guard let position = params["position"] else {
                 return .error("Missing 'position' parameter")
@@ -142,6 +150,24 @@ actor CGEventChannel: Channel {
     }
 
     // MARK: - Event Posting
+
+    /// Bring Logic Pro to the front and wait for the activation to land.
+    /// Logic Pro ignores events posted via postToPid() while another app is
+    /// active, so this is a precondition for delivery, not an optimisation.
+    private func ensureFrontmost() async -> Bool {
+        if ProcessUtils.isLogicProFrontmost { return true }
+        guard ProcessUtils.activateLogicPro() else {
+            Log.error("activateLogicPro() failed", subsystem: "cgEvent")
+            return false
+        }
+        // Activation is asynchronous; poll briefly rather than sleeping blind.
+        for _ in 0..<20 {
+            try? await Task.sleep(for: .milliseconds(25))
+            if ProcessUtils.isLogicProFrontmost { return true }
+        }
+        Log.warn("Logic Pro did not become frontmost within 500ms", subsystem: "cgEvent")
+        return false
+    }
 
     /// Post a key-down/key-up pair to a specific PID.
     private func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, pid: pid_t) -> Bool {

--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -126,6 +126,12 @@ actor CGEventChannel: Channel {
             } catch {
                 return .error("Cancelled before entering the Go To Position value")
             }
+            // Focus can move during the 100ms wait, and Logic Pro would then
+            // discard the remaining events while postKeyEvent still reported
+            // success. Re-check rather than assume the earlier activation held.
+            guard await ensureFrontmost() else {
+                return .error("Could not bring Logic Pro to the front; it would discard the keystroke")
+            }
             guard postText(position, pid: pid), postKeyEvent(keyCode: 36, flags: [], pid: pid) else {
                 return .error("Failed to enter Go To Position value")
             }

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -43,6 +43,10 @@ struct TrackState: Sendable, Codable, Identifiable {
 /// Mixer channel strip state (extends track with routing info).
 struct ChannelStripState: Sendable, Codable {
     var trackIndex: Int
+    /// Strip name as shown in the mixer ("Basic", "Aux 1", "Stereo Out"...).
+    /// The mixer includes aux, output and master strips, so trackIndex is a
+    /// position in the mixer, not an index into the track list.
+    var name: String?
     var volume: Double = 0.0
     var pan: Double = 0.0
     var sends: [SendState] = []

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -61,11 +61,17 @@ actor StatePoller {
             }
 
             if shouldPollTracks {
-                await pollTracks(axChannel: axChannel, cache: cache)
+                let freshTrackCount = await pollTracks(axChannel: axChannel, cache: cache)
                 await pollMixer(axChannel: axChannel, cache: cache)
-                // Poll the project last so it can fold in the track/transport
-                // values refreshed above.
-                await pollProject(axChannel: axChannel, cache: cache)
+                // Only refresh the project when the track read in this same
+                // pass succeeded. Reading the cache instead would pair a newly
+                // opened project's name with the previous project's track
+                // count across a close/open.
+                if let freshTrackCount {
+                    await pollProject(
+                        axChannel: axChannel, cache: cache, trackCount: freshTrackCount
+                    )
+                }
             }
 
             // Sleep until next poll
@@ -99,20 +105,25 @@ actor StatePoller {
         }
     }
 
-    private func pollTracks(axChannel: AccessibilityChannel, cache: StateCache) async {
+    /// Refresh the track cache. Returns the number of tracks read, or nil if
+    /// the read failed — callers must not substitute the cached count, which may
+    /// belong to a previously open project.
+    private func pollTracks(axChannel: AccessibilityChannel, cache: StateCache) async -> Int? {
         let result = await axChannel.execute(operation: "track.get_tracks", params: [:])
         guard case .success(let json) = result else {
             Log.debug("Tracks poll failed: \(result.message)", subsystem: "poller")
-            return
+            return nil
         }
-        guard let data = json.data(using: .utf8) else { return }
+        guard let data = json.data(using: .utf8) else { return nil }
         do {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             let tracks = try decoder.decode([TrackState].self, from: data)
             await cache.updateTracks(tracks)
+            return tracks.count
         } catch {
             Log.debug("Tracks decode failed: \(error)", subsystem: "poller")
+            return nil
         }
     }
 
@@ -134,7 +145,9 @@ actor StatePoller {
         }
     }
 
-    private func pollProject(axChannel: AccessibilityChannel, cache: StateCache) async {
+    private func pollProject(
+        axChannel: AccessibilityChannel, cache: StateCache, trackCount: Int
+    ) async {
         let result = await axChannel.execute(operation: "project.get_info", params: [:])
         guard case .success(let json) = result else {
             Log.debug("Project poll failed: \(result.message)", subsystem: "poller")
@@ -146,10 +159,10 @@ actor StatePoller {
             decoder.dateDecodingStrategy = .iso8601
             var info = try decoder.decode(ProjectInfo.self, from: data)
             // project.get_info reads the window title only. Fill the remaining
-            // fields from state the poller already refreshed, so the resource
-            // reports a coherent snapshot instead of struct defaults.
+            // fields from this same pass, so the resource reports a coherent
+            // snapshot instead of struct defaults.
             let transport = await cache.getTransport()
-            info.trackCount = await cache.getTracks().count
+            info.trackCount = trackCount
             info.tempo = transport.tempo
             info.sampleRate = transport.sampleRate
             await cache.updateProject(info)

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -62,6 +62,10 @@ actor StatePoller {
 
             if shouldPollTracks {
                 await pollTracks(axChannel: axChannel, cache: cache)
+                await pollMixer(axChannel: axChannel, cache: cache)
+                // Poll the project last so it can fold in the track/transport
+                // values refreshed above.
+                await pollProject(axChannel: axChannel, cache: cache)
             }
 
             // Sleep until next poll
@@ -109,6 +113,48 @@ actor StatePoller {
             await cache.updateTracks(tracks)
         } catch {
             Log.debug("Tracks decode failed: \(error)", subsystem: "poller")
+        }
+    }
+
+    private func pollMixer(axChannel: AccessibilityChannel, cache: StateCache) async {
+        let result = await axChannel.execute(operation: "mixer.get_state", params: [:])
+        guard case .success(let json) = result else {
+            // Expected whenever the Mixer pane is hidden — AX can only read visible UI.
+            Log.debug("Mixer poll failed: \(result.message)", subsystem: "poller")
+            return
+        }
+        guard let data = json.data(using: .utf8) else { return }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let strips = try decoder.decode([ChannelStripState].self, from: data)
+            await cache.updateChannelStrips(strips)
+        } catch {
+            Log.debug("Mixer decode failed: \(error)", subsystem: "poller")
+        }
+    }
+
+    private func pollProject(axChannel: AccessibilityChannel, cache: StateCache) async {
+        let result = await axChannel.execute(operation: "project.get_info", params: [:])
+        guard case .success(let json) = result else {
+            Log.debug("Project poll failed: \(result.message)", subsystem: "poller")
+            return
+        }
+        guard let data = json.data(using: .utf8) else { return }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            var info = try decoder.decode(ProjectInfo.self, from: data)
+            // project.get_info reads the window title only. Fill the remaining
+            // fields from state the poller already refreshed, so the resource
+            // reports a coherent snapshot instead of struct defaults.
+            let transport = await cache.getTransport()
+            info.trackCount = await cache.getTracks().count
+            info.tempo = transport.tempo
+            info.sampleRate = transport.sampleRate
+            await cache.updateProject(info)
+        } catch {
+            Log.debug("Project decode failed: \(error)", subsystem: "poller")
         }
     }
 

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -46,7 +46,7 @@ actor StatePoller {
             let interval: PollInterval = Self.intervalForIdleTime(idle)
 
             // Always poll transport (it changes most frequently)
-            await pollTransport(axChannel: axChannel, cache: cache)
+            let transport = await pollTransport(axChannel: axChannel, cache: cache)
             transportCounter += 1
 
             // Poll tracks/mixer less frequently.
@@ -67,9 +67,15 @@ actor StatePoller {
                 // pass succeeded. Reading the cache instead would pair a newly
                 // opened project's name with the previous project's track
                 // count across a close/open.
-                if let freshTrackCount {
+                // Publish project state only when every field in it came from
+                // this pass. A stale tempo or sample rate would otherwise be
+                // attached to a freshly read project name.
+                if let freshTrackCount, let transport {
                     await pollProject(
-                        axChannel: axChannel, cache: cache, trackCount: freshTrackCount
+                        axChannel: axChannel,
+                        cache: cache,
+                        trackCount: freshTrackCount,
+                        transport: transport
                     )
                 }
             }
@@ -88,20 +94,27 @@ actor StatePoller {
 
     // MARK: - Individual pollers
 
-    private func pollTransport(axChannel: AccessibilityChannel, cache: StateCache) async {
+    /// Refresh the transport cache. Returns the state read in this cycle, or
+    /// nil if the read failed — callers must not fall back to the cached value,
+    /// which may predate a project change.
+    private func pollTransport(
+        axChannel: AccessibilityChannel, cache: StateCache
+    ) async -> TransportState? {
         let result = await axChannel.execute(operation: "transport.get_state", params: [:])
         guard case .success(let json) = result else {
             Log.debug("Transport poll failed: \(result.message)", subsystem: "poller")
-            return
+            return nil
         }
-        guard let data = json.data(using: .utf8) else { return }
+        guard let data = json.data(using: .utf8) else { return nil }
         do {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             let state = try decoder.decode(TransportState.self, from: data)
             await cache.updateTransport(state)
+            return state
         } catch {
             Log.debug("Transport decode failed: \(error)", subsystem: "poller")
+            return nil
         }
     }
 
@@ -146,7 +159,10 @@ actor StatePoller {
     }
 
     private func pollProject(
-        axChannel: AccessibilityChannel, cache: StateCache, trackCount: Int
+        axChannel: AccessibilityChannel,
+        cache: StateCache,
+        trackCount: Int,
+        transport: TransportState
     ) async {
         let result = await axChannel.execute(operation: "project.get_info", params: [:])
         guard case .success(let json) = result else {
@@ -161,7 +177,6 @@ actor StatePoller {
             // project.get_info reads the window title only. Fill the remaining
             // fields from this same pass, so the resource reports a coherent
             // snapshot instead of struct defaults.
-            let transport = await cache.getTransport()
             info.trackCount = trackCount
             info.tempo = transport.tempo
             info.sampleRate = transport.sampleRate

--- a/Sources/LogicProMCP/Utilities/ProcessUtils.swift
+++ b/Sources/LogicProMCP/Utilities/ProcessUtils.swift
@@ -41,7 +41,13 @@ enum ProcessUtils {
         logicProApp() != nil
     }
 
-    /// Bring Logic Pro to front (used sparingly — most operations don't need focus).
+    /// Whether Logic Pro is currently the frontmost application.
+    static var isLogicProFrontmost: Bool {
+        logicProApp()?.isActive ?? false
+    }
+
+    /// Bring Logic Pro to front. Required before posting CGEvents: Logic Pro
+    /// silently discards synthetic key events unless it is the active app.
     static func activateLogicPro() -> Bool {
         logicProApp()?.activate() ?? false
     }


### PR DESCRIPTION
Three related defects that each make an advertised feature a no-op. Found while setting the server up against Logic Pro 11 on macOS 15.

## 1. `StatePoller` never polled the mixer or the project

The poll loop calls only `pollTransport` and `pollTracks`, so `logic://mixer` always returns `[]` and `logic://project/info` always returns struct defaults with a `.distantPast` timestamp.

The supporting code is all present but orphaned — `mixer.get_state` and `project.get_info` are registered in `ChannelRouter` and implemented in `AccessibilityChannel`, and `StateCache.updateProject()` has no callers. The loop's own comment ("Poll tracks/mixer less frequently") anticipates the mixer half that was never written.

Adds `pollMixer` and `pollProject` on that existing slow-poll cadence. Since `project.get_info` only reads the window title, `pollProject` also fills `trackCount`, `tempo` and `sampleRate` from state refreshed earlier in the same pass, so the resource reports a coherent snapshot rather than a name beside defaults.

## 2. `getMixerArea()` matched on `AXIdentifier`, which Logic Pro leaves empty

It searched for a group or scroll area with **identifier** `"Mixer"`, which never matches — every identifier in Logic's window tree is empty. Mixer reads failed with `Cannot locate mixer — is it visible?` even with the mixer open.

Logic Pro identifies these containers by `AXDescription`. The channel strips are `AXLayoutItem` children of an `AXLayoutArea` described `"Mixer"`:

```
AXWindow "gratitude.logicx - Tracks"
  AXGroup desc="Mixer"                 <- window-level pane
    AXLayoutArea desc="Mixer"          <- strip container
      AXLayoutItem desc="Basic"
      AXLayoutItem desc="Aux 1"
      ...
      AXLayoutItem desc="Master"
```

Matching anchors on the window-level pane before descending, because the Inspector exposes its own `AXLayoutArea` with the same description; a plain recursive search finds that one first and reports one or two strips instead of the whole desk.

`getMixerState()` also selected volume and pan by slider *ordering*. Aux, output and master strips expose different control sets, so controls are now matched on their `AXDescription` (`"volume fader"`, `"pan"`, `"EQ"`).

Adds `ChannelStripState.name`, without which the strips are indistinguishable. Worth noting: the mixer includes aux, output and master strips, so `trackIndex` is a position in the mixer, not an index into the track list.

## 3. CGEvent keystrokes were silently dropped unless Logic Pro was frontmost

This is the one with the widest blast radius. Logic Pro discards events posted via `CGEvent.postToPid()` unless it is the active application, so **every** transport, edit and navigate command did nothing at all when another app held focus.

The failure was invisible: `postToPid()` returns `Void`, and `postKeyEvent()` returned `true` immediately afterwards, so the result was always `{"sent": true}` whether or not Logic received anything. From the client side a dead command and a working one are indistinguishable.

`execute()` now activates Logic Pro and waits for the activation to land before posting. The class documentation claimed `postToPid()` needs no window focus; corrected.

## Verification

Against Logic Pro 11 / macOS 15, driving the built binary over MCP stdio:

- `logic://project/info` reports the real project name, `tempo: 112` and `trackCount: 3` (previously empty name, `tempo: 120`, `trackCount: 0`).
- `logic://mixer` returns all 10 strips — `Basic`, `Aux 1`–`Aux 5`, `Studio Grand` ×2, `Stereo Out`, `Master` — with names matching the accessibility tree exactly. Fader and pan values were cross-checked against an independent AX read to confirm they are read per strip.
- `logic_navigate("toggle_view", {view: "mixer"})` now opens the Mixer with another app focused, which it previously did not.

Two things I deliberately left alone, both pre-existing and worth separate discussion:

- Fader values come back on Logic's raw AX slider scale (unity reads `173`), while `mixer.set_volume` takes a normalized `0.0–1.0`. Read and write use different units. I did not want to guess at the curve.
- `swift test` cannot run in my environment — `xcode-select` points at CommandLineTools, which ships no `XCTest` module. It fails identically on an unmodified checkout, so this is not a regression, but it does mean the suite is unverified here.