### PR TITLE
Query TCC for the Automation permission instead of reading bundle metadata

### DIFF
--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -125,7 +125,8 @@ struct ResourceHandlers {
               },
               "permissions": {
                 "accessibility": \(permissions.accessibility),
-                "automation": \(permissions.automationLogicPro)
+                "automation": \(permissions.automationLogicPro),
+                "automation_detail": "\(permissions.automation.describedStatus)"
               }
             }
             """

--- a/Sources/LogicProMCP/Utilities/PermissionChecker.swift
+++ b/Sources/LogicProMCP/Utilities/PermissionChecker.swift
@@ -1,24 +1,59 @@
 import Foundation
 import ApplicationServices
+import CoreServices
 
 /// Checks macOS permissions required for the server to operate.
 enum PermissionChecker {
 
+    /// Result of an Apple Events (Automation) permission query.
+    ///
+    /// TCC distinguishes "denied" from "never asked", and the two need
+    /// different advice, so this is deliberately not a Bool.
+    enum AutomationStatus: Sendable, Equatable {
+        case granted
+        case denied
+        case notYetRequested
+        case targetNotRunning
+        case unknown(OSStatus)
+
+        var isGranted: Bool { self == .granted }
+
+        var describedStatus: String {
+            switch self {
+            case .granted:          return "granted"
+            case .denied:           return "NOT GRANTED (denied)"
+            case .notYetRequested:  return "NOT GRANTED (not yet requested)"
+            case .targetNotRunning: return "unknown (Logic Pro is not running)"
+            case .unknown(let code): return "unknown (OSStatus \(code))"
+            }
+        }
+    }
+
     struct PermissionStatus: Sendable {
         let accessibility: Bool
-        let automationLogicPro: Bool
+        let automation: AutomationStatus
 
-        var allGranted: Bool { accessibility && automationLogicPro }
+        /// Kept for existing callers that only need a yes/no.
+        var automationLogicPro: Bool { automation.isGranted }
+
+        var allGranted: Bool { accessibility && automation.isGranted }
 
         var summary: String {
             var lines: [String] = []
             lines.append("Accessibility: \(accessibility ? "granted" : "NOT GRANTED")")
-            lines.append("Automation (Logic Pro): \(automationLogicPro ? "granted" : "NOT GRANTED")")
+            lines.append("Automation (Logic Pro): \(automation.describedStatus)")
             if !accessibility {
                 lines.append("  → System Settings > Privacy & Security > Accessibility → add your terminal app")
             }
-            if !automationLogicPro {
+            switch automation {
+            case .denied:
                 lines.append("  → System Settings > Privacy & Security > Automation → allow control of Logic Pro")
+            case .notYetRequested:
+                lines.append("  → macOS has not asked yet; it prompts on the first Apple Event to Logic Pro")
+            case .targetNotRunning:
+                lines.append("  → start Logic Pro to determine the Automation state")
+            case .granted, .unknown:
+                break
             }
             return lines.joined(separator: "\n")
         }
@@ -31,26 +66,55 @@ enum PermissionChecker {
         return AXIsProcessTrustedWithOptions(options)
     }
 
-    /// Check if Automation permission for Logic Pro is granted.
-    /// This attempts a lightweight AppleScript to test permission.
-    static func checkAutomation() -> Bool {
-        guard ProcessUtils.isLogicProRunning else {
-            // Can't test automation if Logic Pro isn't running
-            return false
+    /// Query the Apple Events (Automation) permission for Logic Pro.
+    ///
+    /// Asks TCC directly via AEDeterminePermissionToAutomateTarget, which
+    /// reports the real authorization state without dispatching an event.
+    ///
+    /// The previous implementation ran `tell application "Logic Pro" to return
+    /// name` and treated "no error" as granted. macOS answers `name` from the
+    /// target's bundle metadata without sending an Apple Event at all, so that
+    /// check succeeded even for apps that were not running and had never been
+    /// granted anything — it could never report a denial. Its only real signal
+    /// was whether Logic Pro was running.
+    ///
+    /// Pass `promptIfNeeded: true` to let macOS show its consent dialog; the
+    /// default queries silently.
+    static func checkAutomation(promptIfNeeded: Bool = false) -> AutomationStatus {
+        guard var pid = ProcessUtils.logicProPID() else { return .targetNotRunning }
+
+        var target = AEAddressDesc()
+        let createStatus = withUnsafePointer(to: &pid) { pidPtr in
+            AECreateDesc(typeKernelProcessID, pidPtr, MemoryLayout<pid_t>.size, &target)
         }
-        let script = NSAppleScript(source: """
-            tell \(ProcessUtils.logicProAppleScriptTarget) to return name
-        """)
-        var errorInfo: NSDictionary?
-        _ = script?.executeAndReturnError(&errorInfo)
-        return errorInfo == nil
+        guard createStatus == noErr else { return .unknown(OSStatus(createStatus)) }
+        defer { AEDisposeDesc(&target) }
+
+        // typeWildCard for class and ID asks about automating the target at all,
+        // rather than about one specific event.
+        let status = AEDeterminePermissionToAutomateTarget(
+            &target, typeWildCard, typeWildCard, promptIfNeeded
+        )
+
+        switch status {
+        case noErr:
+            return .granted
+        case OSStatus(errAEEventNotPermitted):
+            return .denied
+        case OSStatus(errAEEventWouldRequireUserConsent):
+            return .notYetRequested
+        case OSStatus(procNotFound):
+            return .targetNotRunning
+        default:
+            return .unknown(status)
+        }
     }
 
     /// Full permission check.
     static func check() -> PermissionStatus {
         PermissionStatus(
             accessibility: checkAccessibility(),
-            automationLogicPro: checkAutomation()
+            automation: checkAutomation()
         )
     }
 }


### PR DESCRIPTION
Independent of #32 — different file, no overlap, either can land first.

## The problem

`checkAutomation()` runs `tell application "Logic Pro" to return name` and treats "no AppleScript error" as granted. macOS answers `name` from the target's **bundle metadata**, without dispatching an Apple Event, so the check never reaches an authorization decision:

```
osascript -e 'tell application "Calculator" to return name'   →  Calculator
osascript -e 'tell application "TextEdit"   to return name'   →  TextEdit
```

Both succeed while **not running** and with no Automation grant of any kind.

So the only thing the check actually detected was whether Logic Pro was running — `false` when closed, and unconditionally `"granted"` once open. A genuinely missing grant was reported as present, which sends users off debugging the wrong thing. It cost me an hour before I read the source.

## The fix

Use `AEDeterminePermissionToAutomateTarget`, which consults TCC directly and reports the real state without sending an event and without prompting (`askUserIfNeeded: false`).

TCC distinguishes **denied** from **never asked**, and those need different advice, so the result is an enum rather than a `Bool`:

```swift
enum AutomationStatus {
    case granted, denied, notYetRequested, targetNotRunning, unknown(OSStatus)
}
```

`summary` now says which applies and tailors the remediation line. This matters in practice: on a fresh install the state is *not yet requested*, and the old message pointed users at System Settings → Automation, where **there is no row to toggle yet** — the entry only appears after the first Apple Event. Telling them macOS will prompt on first use is the actionable version. (That confusion is exactly what happened to me: a `-1744` state presented as a Settings problem.)

Also worth noting for anyone chasing this: the grant is attributed to the *responsible process* — the host app bundle — so it never appears under `LogicProMCP`'s own name.

## Compatibility

`PermissionStatus` keeps both `automationLogicPro: Bool` and `allGranted`, so the existing callers in `main.swift`, `SystemDispatcher` and `ResourceHandlers` need no changes. `logic://system/health` gains an additive `automation_detail` string:

```json
"permissions": {
  "accessibility": true,
  "automation": true,
  "automation_detail": "granted"
}
```

## Verification

macOS 15, Logic Pro 11 open. The new check discriminates where the old one could not:

| Target | New check | Old check |
|---|---|---|
| Logic Pro | `granted` | `granted` |
| Finder | `not yet requested (-1744)` | `granted` |

Both apps were running, so the old implementation called both granted.

Two honest caveats:

- The **denied** (`-1743`) branch is untested. Exercising it needs a revoked grant, and I was not willing to reset TCC state on a working machine.
- `swift test` does not run in my environment — `xcode-select` points at CommandLineTools, which ships no `XCTest` module. It fails identically on an unmodified checkout, so not a regression, but the suite is unverified here.