### PR TITLE
Report unverified Logic deliveries honestly

### DIFF
--- a/Sources/LogicProMCP/Channels/CGEventChannel.swift
+++ b/Sources/LogicProMCP/Channels/CGEventChannel.swift
@@ -135,7 +135,7 @@ actor CGEventChannel: Channel {
             guard postText(position, pid: pid), postKeyEvent(keyCode: 36, flags: [], pid: pid) else {
                 return .error("Failed to enter Go To Position value")
             }
-            return .success("{\"position\":\"\(position)\"}")
+            return .unverified("Go To Position was posted for \(position); Logic outcome is not verified")
         }
 
         guard let shortcut = Self.keyMap[operation] else {
@@ -148,7 +148,7 @@ actor CGEventChannel: Channel {
 
         let sent = postKeyEvent(keyCode: shortcut.keyCode, flags: shortcut.flags, pid: pid)
         if sent {
-            return .success("{\"operation\":\"\(operation)\",\"sent\":true}")
+            return .unverified("Keyboard shortcut posted for \(operation); Logic outcome is not verified")
         } else {
             return .error("Failed to post CGEvent for \(operation)")
         }

--- a/Sources/LogicProMCP/Channels/Channel.swift
+++ b/Sources/LogicProMCP/Channels/Channel.swift
@@ -6,9 +6,10 @@ enum ChannelResult: Sendable {
     case unverified(String)
     case error(String)
 
+    /// True when the channel accepted the operation, even if Logic cannot confirm the outcome.
     var isSuccess: Bool {
-        if case .success = self { return true }
-        return false
+        if case .error = self { return false }
+        return true
     }
 
     var message: String {

--- a/Sources/LogicProMCP/Channels/Channel.swift
+++ b/Sources/LogicProMCP/Channels/Channel.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Result of a channel operation.
 enum ChannelResult: Sendable {
     case success(String)
+    case unverified(String)
     case error(String)
 
     var isSuccess: Bool {
@@ -13,6 +14,7 @@ enum ChannelResult: Sendable {
     var message: String {
         switch self {
         case .success(let msg): return msg
+        case .unverified(let msg): return msg
         case .error(let msg): return msg
         }
     }

--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -66,7 +66,6 @@ actor ChannelRouter {
         "midi.send_aftertouch":       [.coreMIDI],
         "midi.send_sysex":            [.coreMIDI],
         "midi.list_ports":            [.coreMIDI],
-        "midi.get_input_state":       [.coreMIDI],
         "midi.create_virtual_port":   [.coreMIDI],
 
         // MMC
@@ -202,6 +201,9 @@ actor ChannelRouter {
             switch result {
             case .success:
                 Log.debug("\(operation) succeeded via \(channelID.rawValue)", subsystem: "router")
+                return result
+            case .unverified:
+                Log.debug("\(operation) was sent via \(channelID.rawValue) without Logic readback", subsystem: "router")
                 return result
             case .error(let msg):
                 Log.debug("\(operation) failed via \(channelID.rawValue): \(msg), trying next", subsystem: "router")

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -24,45 +24,41 @@ actor CoreMIDIChannel: Channel {
         // MARK: - Transport (MMC)
 
         case "transport.play", "mmc.play":
-            await engine.sendSysEx(MMCCommands.play())
-            return .unverified("MMC play sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.play()), "MMC play")
 
         case "transport.stop", "mmc.stop":
-            await engine.sendSysEx(MMCCommands.stop())
-            return .unverified("MMC stop sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.stop()), "MMC stop")
 
         case "transport.pause", "mmc.pause":
-            await engine.sendSysEx(MMCCommands.pause())
-            return .unverified("MMC pause sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.pause()), "MMC pause")
 
         case "transport.record", "transport.record_strobe", "mmc.record_strobe":
-            await engine.sendSysEx(MMCCommands.recordStrobe())
-            return .unverified("MMC record strobe sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.recordStrobe()), "MMC record strobe")
 
         case "transport.record_exit", "mmc.record_exit":
-            await engine.sendSysEx(MMCCommands.recordExit())
-            return .unverified("MMC record exit sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.recordExit()), "MMC record exit")
 
         case "transport.fast_forward":
-            await engine.sendSysEx(MMCCommands.fastForward())
-            return .unverified("MMC fast forward sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.fastForward()), "MMC fast forward")
 
         case "transport.rewind":
-            await engine.sendSysEx(MMCCommands.rewind())
-            return .unverified("MMC rewind sent; Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(MMCCommands.rewind()), "MMC rewind")
 
         case "transport.locate", "mmc.locate":
             guard let time = Self.parseSMPTETime(params) else {
                 return .error("locate requires 'time' (HH:MM:SS:FF) or hours, minutes, seconds, frames")
             }
-            await engine.sendSysEx(MMCCommands.locate(
+            let accepted = await engine.sendSysEx(MMCCommands.locate(
                 hours: time.hours,
                 minutes: time.minutes,
                 seconds: time.seconds,
                 frames: time.frames,
                 subframes: time.subframes
             ))
-            return .unverified("MMC locate sent to \(time.hours):\(time.minutes):\(time.seconds):\(time.frames).\(time.subframes); Logic delivery is not verified")
+            return Self.delivery(
+                accepted,
+                "MMC locate to \(time.hours):\(time.minutes):\(time.seconds):\(time.frames).\(time.subframes)"
+            )
 
         // MARK: - Note Send
 
@@ -73,9 +69,18 @@ actor CoreMIDIChannel: Channel {
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
             let durationMs = params["duration_ms"].flatMap(UInt64.init) ?? 250
-            await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
-            try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
-            await engine.sendNoteOff(channel: channel, note: note)
+            guard await engine.sendNoteOn(channel: channel, note: note, velocity: velocity) else {
+                return .error("CoreMIDI rejected note on \(note)")
+            }
+            do {
+                try await Task.sleep(nanoseconds: durationMs * 1_000_000)
+            } catch {
+                _ = await engine.sendNoteOff(channel: channel, note: note)
+                return .error("Note \(note) was cancelled; note off was attempted")
+            }
+            guard await engine.sendNoteOff(channel: channel, note: note) else {
+                return .error("CoreMIDI rejected note off \(note)")
+            }
             return .unverified("Note \(note) sent to the virtual MIDI port; Logic delivery is not verified")
 
         case "midi.note_on":
@@ -84,16 +89,20 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
-            await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
-            return .unverified("Note on \(note) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendNoteOn(channel: channel, note: note, velocity: velocity),
+                "Note on \(note)"
+            )
 
         case "midi.note_off":
             guard let note = params["note"].flatMap(UInt8.init) else {
                 return .error("note_off requires 'note' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendNoteOff(channel: channel, note: note)
-            return .unverified("Note off \(note) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendNoteOff(channel: channel, note: note),
+                "Note off \(note)"
+            )
 
         // MARK: - CC
 
@@ -115,12 +124,32 @@ actor CoreMIDIChannel: Channel {
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
             let durationMs = params["duration_ms"].flatMap(UInt64.init) ?? 250
+            var sounding: [UInt8] = []
             for note in notes {
-                await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
+                guard await engine.sendNoteOn(channel: channel, note: note, velocity: velocity) else {
+                    for soundingNote in sounding {
+                        _ = await engine.sendNoteOff(channel: channel, note: soundingNote)
+                    }
+                    return .error("CoreMIDI rejected chord note \(note); note off was attempted for earlier notes")
+                }
+                sounding.append(note)
             }
-            try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
-            for note in notes {
-                await engine.sendNoteOff(channel: channel, note: note)
+            do {
+                try await Task.sleep(nanoseconds: durationMs * 1_000_000)
+            } catch {
+                for note in sounding {
+                    _ = await engine.sendNoteOff(channel: channel, note: note)
+                }
+                return .error("Chord was cancelled; note off was attempted for every note")
+            }
+            var released = true
+            for note in sounding {
+                if !(await engine.sendNoteOff(channel: channel, note: note)) {
+                    released = false
+                }
+            }
+            guard released else {
+                return .error("CoreMIDI rejected at least one chord note off")
             }
             return .unverified("Chord \(notes.map(String.init).joined(separator: ",")) sent to the virtual MIDI port; Logic delivery is not verified")
 
@@ -130,8 +159,10 @@ actor CoreMIDIChannel: Channel {
                 return .error("send_cc requires 'controller' and 'value' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendCC(channel: channel, controller: controller, value: value)
-            return .unverified("CC \(controller)=\(value) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendCC(channel: channel, controller: controller, value: value),
+                "CC \(controller)=\(value)"
+            )
 
         // MARK: - Program Change
 
@@ -140,8 +171,10 @@ actor CoreMIDIChannel: Channel {
                 return .error("program_change requires 'program' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendProgramChange(channel: channel, program: program)
-            return .unverified("Program change \(program) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendProgramChange(channel: channel, program: program),
+                "Program change \(program)"
+            )
 
         // MARK: - Pitch Bend
 
@@ -150,16 +183,20 @@ actor CoreMIDIChannel: Channel {
                 return .error("pitch_bend requires 'value' (0-16383, center=8192)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendPitchBend(channel: channel, value: value)
-            return .unverified("Pitch bend \(value) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendPitchBend(channel: channel, value: value),
+                "Pitch bend \(value)"
+            )
 
         case "midi.send_pitch_bend":
             guard let value = Self.parseSignedPitchBend(params["value"]) else {
                 return .error("send_pitch_bend requires 'value' (-8192...8191)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendPitchBend(channel: channel, value: value)
-            return .unverified("Pitch bend \(value) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendPitchBend(channel: channel, value: value),
+                "Pitch bend \(value)"
+            )
 
         // MARK: - Aftertouch
 
@@ -168,8 +205,10 @@ actor CoreMIDIChannel: Channel {
                 return .error("aftertouch requires 'pressure' or 'value' (0-127)")
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
-            await engine.sendAftertouch(channel: channel, pressure: pressure)
-            return .unverified("Aftertouch \(pressure) sent to the virtual MIDI port; Logic delivery is not verified")
+            return Self.delivery(
+                await engine.sendAftertouch(channel: channel, pressure: pressure),
+                "Aftertouch \(pressure)"
+            )
 
         // MARK: - Raw SysEx
 
@@ -187,8 +226,7 @@ actor CoreMIDIChannel: Channel {
             guard bytes.first == 0xF0, bytes.last == 0xF7 else {
                 return .error("SysEx must start with F0 and end with F7")
             }
-            await engine.sendSysEx(bytes)
-            return .unverified("SysEx sent to the virtual MIDI port (\(bytes.count) bytes); Logic delivery is not verified")
+            return Self.delivery(await engine.sendSysEx(bytes), "SysEx (\(bytes.count) bytes)")
 
         case "midi.list_ports":
             return .success(await engine.portListJSON())
@@ -214,6 +252,12 @@ actor CoreMIDIChannel: Channel {
         } else {
             return .unavailable("CoreMIDI client not initialized")
         }
+    }
+
+    private static func delivery(_ accepted: Bool, _ description: String) -> ChannelResult {
+        accepted
+            ? .unverified("\(description) sent to CoreMIDI; Logic delivery is not verified")
+            : .error("CoreMIDI rejected \(description)")
     }
 
     private static func parseSignedPitchBend(_ rawValue: String?) -> UInt16? {

--- a/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
+++ b/Sources/LogicProMCP/Channels/CoreMIDIChannel.swift
@@ -25,31 +25,31 @@ actor CoreMIDIChannel: Channel {
 
         case "transport.play", "mmc.play":
             await engine.sendSysEx(MMCCommands.play())
-            return .success("MMC play sent")
+            return .unverified("MMC play sent; Logic delivery is not verified")
 
         case "transport.stop", "mmc.stop":
             await engine.sendSysEx(MMCCommands.stop())
-            return .success("MMC stop sent")
+            return .unverified("MMC stop sent; Logic delivery is not verified")
 
         case "transport.pause", "mmc.pause":
             await engine.sendSysEx(MMCCommands.pause())
-            return .success("MMC pause sent")
+            return .unverified("MMC pause sent; Logic delivery is not verified")
 
         case "transport.record", "transport.record_strobe", "mmc.record_strobe":
             await engine.sendSysEx(MMCCommands.recordStrobe())
-            return .success("MMC record strobe sent")
+            return .unverified("MMC record strobe sent; Logic delivery is not verified")
 
         case "transport.record_exit", "mmc.record_exit":
             await engine.sendSysEx(MMCCommands.recordExit())
-            return .success("MMC record exit sent")
+            return .unverified("MMC record exit sent; Logic delivery is not verified")
 
         case "transport.fast_forward":
             await engine.sendSysEx(MMCCommands.fastForward())
-            return .success("MMC fast forward sent")
+            return .unverified("MMC fast forward sent; Logic delivery is not verified")
 
         case "transport.rewind":
             await engine.sendSysEx(MMCCommands.rewind())
-            return .success("MMC rewind sent")
+            return .unverified("MMC rewind sent; Logic delivery is not verified")
 
         case "transport.locate", "mmc.locate":
             guard let time = Self.parseSMPTETime(params) else {
@@ -62,7 +62,7 @@ actor CoreMIDIChannel: Channel {
                 frames: time.frames,
                 subframes: time.subframes
             ))
-            return .success("MMC locate sent to \(time.hours):\(time.minutes):\(time.seconds):\(time.frames).\(time.subframes)")
+            return .unverified("MMC locate sent to \(time.hours):\(time.minutes):\(time.seconds):\(time.frames).\(time.subframes); Logic delivery is not verified")
 
         // MARK: - Note Send
 
@@ -76,7 +76,7 @@ actor CoreMIDIChannel: Channel {
             await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
             try? await Task.sleep(nanoseconds: durationMs * 1_000_000)
             await engine.sendNoteOff(channel: channel, note: note)
-            return .success("Note \(note) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
+            return .unverified("Note \(note) sent to the virtual MIDI port; Logic delivery is not verified")
 
         case "midi.note_on":
             guard let note = params["note"].flatMap(UInt8.init) else {
@@ -85,7 +85,7 @@ actor CoreMIDIChannel: Channel {
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             let velocity = params["velocity"].flatMap(UInt8.init) ?? 100
             await engine.sendNoteOn(channel: channel, note: note, velocity: velocity)
-            return .success("Note on \(note) ch \(channel) vel \(velocity)")
+            return .unverified("Note on \(note) sent to the virtual MIDI port; Logic delivery is not verified")
 
         case "midi.note_off":
             guard let note = params["note"].flatMap(UInt8.init) else {
@@ -93,7 +93,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendNoteOff(channel: channel, note: note)
-            return .success("Note off \(note) ch \(channel)")
+            return .unverified("Note off \(note) sent to the virtual MIDI port; Logic delivery is not verified")
 
         // MARK: - CC
 
@@ -122,7 +122,7 @@ actor CoreMIDIChannel: Channel {
             for note in notes {
                 await engine.sendNoteOff(channel: channel, note: note)
             }
-            return .success("Chord \(notes.map(String.init).joined(separator: ",")) on ch \(channel) vel \(velocity) dur \(durationMs)ms")
+            return .unverified("Chord \(notes.map(String.init).joined(separator: ",")) sent to the virtual MIDI port; Logic delivery is not verified")
 
         case "midi.send_cc":
             guard let controller = params["controller"].flatMap(UInt8.init),
@@ -131,7 +131,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendCC(channel: channel, controller: controller, value: value)
-            return .success("CC \(controller)=\(value) on ch \(channel)")
+            return .unverified("CC \(controller)=\(value) sent to the virtual MIDI port; Logic delivery is not verified")
 
         // MARK: - Program Change
 
@@ -141,7 +141,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendProgramChange(channel: channel, program: program)
-            return .success("Program change \(program) on ch \(channel)")
+            return .unverified("Program change \(program) sent to the virtual MIDI port; Logic delivery is not verified")
 
         // MARK: - Pitch Bend
 
@@ -151,7 +151,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendPitchBend(channel: channel, value: value)
-            return .success("Pitch bend \(value) on ch \(channel)")
+            return .unverified("Pitch bend \(value) sent to the virtual MIDI port; Logic delivery is not verified")
 
         case "midi.send_pitch_bend":
             guard let value = Self.parseSignedPitchBend(params["value"]) else {
@@ -159,7 +159,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendPitchBend(channel: channel, value: value)
-            return .success("Pitch bend \(value) on ch \(channel)")
+            return .unverified("Pitch bend \(value) sent to the virtual MIDI port; Logic delivery is not verified")
 
         // MARK: - Aftertouch
 
@@ -169,7 +169,7 @@ actor CoreMIDIChannel: Channel {
             }
             let channel = params["channel"].flatMap(UInt8.init) ?? 0
             await engine.sendAftertouch(channel: channel, pressure: pressure)
-            return .success("Aftertouch \(pressure) on ch \(channel)")
+            return .unverified("Aftertouch \(pressure) sent to the virtual MIDI port; Logic delivery is not verified")
 
         // MARK: - Raw SysEx
 
@@ -188,7 +188,10 @@ actor CoreMIDIChannel: Channel {
                 return .error("SysEx must start with F0 and end with F7")
             }
             await engine.sendSysEx(bytes)
-            return .success("SysEx sent (\(bytes.count) bytes)")
+            return .unverified("SysEx sent to the virtual MIDI port (\(bytes.count) bytes); Logic delivery is not verified")
+
+        case "midi.list_ports":
+            return .success(await engine.portListJSON())
 
         case "midi.create_virtual_port":
             let name = params["name"] ?? "LogicProMCP-Virtual"

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -235,7 +235,7 @@ actor MIDIEngine {
 
             let packetList = storage.bindMemory(to: MIDIPacketList.self, capacity: 1)
             let packet = MIDIPacketListInit(packetList)
-            _ = MIDIPacketListAdd(
+            let added = MIDIPacketListAdd(
                 packetList,
                 packetListSize,
                 packet,
@@ -243,6 +243,10 @@ actor MIDIEngine {
                 bytes.count,
                 baseAddress
             )
+            guard Int(bitPattern: added) != 0 else {
+                Log.error("Failed to create MIDI packet for \(bytes.count) bytes", subsystem: "midi")
+                return false
+            }
 
             let sources = ([virtualSource] + additionalVirtualSources).filter { $0 != 0 }
             guard !sources.isEmpty else {

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -253,12 +253,13 @@ actor MIDIEngine {
                 Log.error("No MIDI sources available", subsystem: "midi")
                 return false
             }
-            var accepted = true
+            var accepted = false
             for source in sources {
                 let status = MIDIReceived(source, packetList)
                 if status != noErr {
                     Log.error("MIDIReceived failed with status \(status)", subsystem: "midi")
-                    accepted = false
+                } else {
+                    accepted = true
                 }
             }
             return accepted

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -147,76 +147,85 @@ actor MIDIEngine {
 
     // MARK: - Send: Notes
 
-    func sendNoteOn(channel: UInt8 = 0, note: UInt8, velocity: UInt8 = 100) {
+    @discardableResult
+    func sendNoteOn(channel: UInt8 = 0, note: UInt8, velocity: UInt8 = 100) -> Bool {
         let status: UInt8 = 0x90 | (channel & 0x0F)
-        sendShortMessage([status, note & 0x7F, velocity & 0x7F])
+        return sendShortMessage([status, note & 0x7F, velocity & 0x7F])
     }
 
-    func sendNoteOff(channel: UInt8 = 0, note: UInt8, velocity: UInt8 = 0) {
+    @discardableResult
+    func sendNoteOff(channel: UInt8 = 0, note: UInt8, velocity: UInt8 = 0) -> Bool {
         let status: UInt8 = 0x80 | (channel & 0x0F)
-        sendShortMessage([status, note & 0x7F, velocity & 0x7F])
+        return sendShortMessage([status, note & 0x7F, velocity & 0x7F])
     }
 
     // MARK: - Send: Control Change
 
-    func sendCC(channel: UInt8 = 0, controller: UInt8, value: UInt8) {
+    @discardableResult
+    func sendCC(channel: UInt8 = 0, controller: UInt8, value: UInt8) -> Bool {
         let status: UInt8 = 0xB0 | (channel & 0x0F)
-        sendShortMessage([status, controller & 0x7F, value & 0x7F])
+        return sendShortMessage([status, controller & 0x7F, value & 0x7F])
     }
 
     // MARK: - Send: Program Change
 
-    func sendProgramChange(channel: UInt8 = 0, program: UInt8) {
+    @discardableResult
+    func sendProgramChange(channel: UInt8 = 0, program: UInt8) -> Bool {
         let status: UInt8 = 0xC0 | (channel & 0x0F)
-        sendShortMessage([status, program & 0x7F])
+        return sendShortMessage([status, program & 0x7F])
     }
 
     // MARK: - Send: Pitch Bend
 
     /// Send pitch bend. `value` is 14-bit (0-16383), center = 8192.
-    func sendPitchBend(channel: UInt8 = 0, value: UInt16 = 8192) {
+    @discardableResult
+    func sendPitchBend(channel: UInt8 = 0, value: UInt16 = 8192) -> Bool {
         let clamped = min(value, 16383)
         let lsb = UInt8(clamped & 0x7F)
         let msb = UInt8((clamped >> 7) & 0x7F)
         let status: UInt8 = 0xE0 | (channel & 0x0F)
-        sendShortMessage([status, lsb, msb])
+        return sendShortMessage([status, lsb, msb])
     }
 
     // MARK: - Send: Aftertouch
 
     /// Channel pressure (mono aftertouch).
-    func sendAftertouch(channel: UInt8 = 0, pressure: UInt8) {
+    @discardableResult
+    func sendAftertouch(channel: UInt8 = 0, pressure: UInt8) -> Bool {
         let status: UInt8 = 0xD0 | (channel & 0x0F)
-        sendShortMessage([status, pressure & 0x7F])
+        return sendShortMessage([status, pressure & 0x7F])
     }
 
     /// Polyphonic key pressure.
-    func sendPolyAftertouch(channel: UInt8 = 0, note: UInt8, pressure: UInt8) {
+    @discardableResult
+    func sendPolyAftertouch(channel: UInt8 = 0, note: UInt8, pressure: UInt8) -> Bool {
         let status: UInt8 = 0xA0 | (channel & 0x0F)
-        sendShortMessage([status, note & 0x7F, pressure & 0x7F])
+        return sendShortMessage([status, note & 0x7F, pressure & 0x7F])
     }
 
     // MARK: - Send: SysEx
 
     /// Send a complete SysEx message (must start with 0xF0 and end with 0xF7).
-    func sendSysEx(_ bytes: [UInt8]) {
+    @discardableResult
+    func sendSysEx(_ bytes: [UInt8]) -> Bool {
         guard bytes.first == 0xF0, bytes.last == 0xF7 else {
             Log.error("Invalid SysEx: must start with F0 and end with F7", subsystem: "midi")
-            return
+            return false
         }
-        sendRawBytes(bytes)
+        return sendRawBytes(bytes)
     }
 
     // MARK: - Send: Raw
 
     /// Send arbitrary MIDI bytes through the virtual source.
-    func sendRawBytes(_ bytes: [UInt8]) {
+    @discardableResult
+    func sendRawBytes(_ bytes: [UInt8]) -> Bool {
         guard isRunning else {
             Log.warn("MIDIEngine not running — dropping message", subsystem: "midi")
-            return
+            return false
         }
-        bytes.withUnsafeBufferPointer { buffer in
-            guard let baseAddress = buffer.baseAddress else { return }
+        return bytes.withUnsafeBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else { return false }
             let packetListSize = MemoryLayout<MIDIPacketList>.size + bytes.count
             let storage = UnsafeMutableRawPointer.allocate(
                 byteCount: packetListSize,
@@ -226,33 +235,40 @@ actor MIDIEngine {
 
             let packetList = storage.bindMemory(to: MIDIPacketList.self, capacity: 1)
             let packet = MIDIPacketListInit(packetList)
-            guard MIDIPacketListAdd(
+            _ = MIDIPacketListAdd(
                 packetList,
                 packetListSize,
                 packet,
                 0,
                 bytes.count,
                 baseAddress
-            ) != nil else {
-                Log.error("Failed to create MIDI packet for \(bytes.count) bytes", subsystem: "midi")
-                return
-            }
+            )
 
             let sources = ([virtualSource] + additionalVirtualSources).filter { $0 != 0 }
+            guard !sources.isEmpty else {
+                Log.error("No MIDI sources available", subsystem: "midi")
+                return false
+            }
+            var accepted = true
             for source in sources {
                 let status = MIDIReceived(source, packetList)
                 if status != noErr {
                     Log.error("MIDIReceived failed with status \(status)", subsystem: "midi")
+                    accepted = false
                 }
             }
+            return accepted
         }
     }
 
     // MARK: - Private
 
-    private func sendShortMessage(_ bytes: [UInt8]) {
-        sendRawBytes(bytes)
-        Log.debug("MIDI out: \(bytes.map { String(format: "%02X", $0) }.joined(separator: " "))", subsystem: "midi")
+    private func sendShortMessage(_ bytes: [UInt8]) -> Bool {
+        let accepted = sendRawBytes(bytes)
+        if accepted {
+            Log.debug("MIDI out: \(bytes.map { String(format: "%02X", $0) }.joined(separator: " "))", subsystem: "midi")
+        }
+        return accepted
     }
 
     private nonisolated func handleMIDINotification(_ notification: UnsafePointer<MIDINotification>) {

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -90,6 +90,26 @@ actor MIDIEngine {
 
     var isActive: Bool { isRunning && client != 0 }
 
+    func portListJSON() -> String {
+        let sources = (0..<MIDIGetNumberOfSources()).compactMap { endpointName(MIDIGetSource($0)) }
+        let destinations = (0..<MIDIGetNumberOfDestinations()).compactMap { endpointName(MIDIGetDestination($0)) }
+        let data = try? JSONSerialization.data(withJSONObject: [
+            "sources": sources,
+            "destinations": destinations,
+        ])
+        return data.flatMap { String(data: $0, encoding: .utf8) }
+            ?? "{\"sources\":[],\"destinations\":[]}"
+    }
+
+    private func endpointName(_ endpoint: MIDIEndpointRef) -> String? {
+        guard endpoint != 0 else { return nil }
+        var value: Unmanaged<CFString>?
+        guard MIDIObjectGetStringProperty(endpoint, kMIDIPropertyDisplayName, &value) == noErr else {
+            return nil
+        }
+        return value?.takeRetainedValue() as String?
+    }
+
     /// Create an additional virtual source/destination pair.
     func createVirtualPort(named name: String) throws {
         if !isRunning {

--- a/Sources/LogicProMCP/Resources/ResourceHandlers.swift
+++ b/Sources/LogicProMCP/Resources/ResourceHandlers.swift
@@ -90,8 +90,11 @@ struct ResourceHandlers {
 
     private static func readMIDIPorts(router: ChannelRouter, uri: String) async throws -> ReadResource.Result {
         let result = await router.route(operation: "midi.list_ports")
+        guard case .success(let json) = result else {
+            throw MCPError.internalError("Could not list MIDI ports: \(result.message)")
+        }
         return ReadResource.Result(
-            contents: [.text(result.message, uri: uri, mimeType: "application/json")]
+            contents: [.text(json, uri: uri, mimeType: "application/json")]
         )
     }
 

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -23,6 +23,7 @@ final class CoreMIDIChannelTests: XCTestCase {
             guard case .unverified = result else {
                 return XCTFail("\(testCase.operation) should be unverified, got: \(result.message)")
             }
+            XCTAssertTrue(result.isSuccess, "\(testCase.operation) should be accepted as successful")
         }
 
         let ports = await channel.execute(operation: "midi.list_ports", params: [:])

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -31,8 +31,8 @@ final class CoreMIDIChannelTests: XCTestCase {
               let object = try JSONSerialization.jsonObject(with: data) as? [String: [String]] else {
             return XCTFail("midi.list_ports should return JSON")
         }
-        XCTAssertNotNil(object["sources"])
-        XCTAssertNotNil(object["destinations"])
+        XCTAssertTrue(object["sources"]?.contains(ServerConfig.virtualMIDISourceName) == true)
+        XCTAssertTrue(object["destinations"]?.contains(ServerConfig.virtualMIDISinkName) == true)
 
         let virtualPort = await channel.execute(
             operation: "midi.create_virtual_port",
@@ -100,12 +100,19 @@ final class CoreMIDIChannelTests: XCTestCase {
 
         for testCase in cases {
             let result = await channel.execute(operation: testCase.operation, params: testCase.params)
-            XCTAssertFalse(
-                result.isSuccess,
-                "\(testCase.operation) should reject malformed params, got: \(result.message)"
-            )
+            guard case .error = result else {
+                return XCTFail("\(testCase.operation) should reject malformed params, got: \(result.message)")
+            }
         }
 
         await channel.stop()
+    }
+
+    func testCoreMIDIReportsDroppedMessages() async {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+        let result = await channel.execute(operation: "mmc.play", params: [:])
+        guard case .error = result else {
+            return XCTFail("A stopped MIDI engine must report an error")
+        }
     }
 }

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -16,16 +16,29 @@ final class CoreMIDIChannelTests: XCTestCase {
             ("midi.send_aftertouch", ["pressure": "64", "channel": "1"]),
             ("midi.send_sysex", ["data": "F0 7F 7F 06 02 F7"]),
             ("midi.send_sysex", ["bytes": "F0 7F 7F 06 02 F7"]),
-            ("midi.create_virtual_port", ["name": "Test Port"]),
         ]
 
         for testCase in cases {
             let result = await channel.execute(operation: testCase.operation, params: testCase.params)
-            XCTAssertTrue(
-                result.isSuccess,
-                "\(testCase.operation) should be handled, got: \(result.message)"
-            )
+            guard case .unverified = result else {
+                return XCTFail("\(testCase.operation) should be unverified, got: \(result.message)")
+            }
         }
+
+        let ports = await channel.execute(operation: "midi.list_ports", params: [:])
+        guard case .success(let json) = ports,
+              let data = json.data(using: .utf8),
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: [String]] else {
+            return XCTFail("midi.list_ports should return JSON")
+        }
+        XCTAssertNotNil(object["sources"])
+        XCTAssertNotNil(object["destinations"])
+
+        let virtualPort = await channel.execute(
+            operation: "midi.create_virtual_port",
+            params: ["name": "Test Port"]
+        )
+        XCTAssertTrue(virtualPort.isSuccess)
 
         await channel.stop()
     }
@@ -39,7 +52,9 @@ final class CoreMIDIChannelTests: XCTestCase {
             params: ["value": "0", "channel": "1"]
         )
 
-        XCTAssertTrue(result.isSuccess, "midi.pitch_bend should keep accepting raw 14-bit values")
+        guard case .unverified = result else {
+            return XCTFail("midi.pitch_bend should be accepted as unverified")
+        }
 
         await channel.stop()
     }
@@ -60,10 +75,9 @@ final class CoreMIDIChannelTests: XCTestCase {
 
         for testCase in cases {
             let result = await channel.execute(operation: testCase.operation, params: testCase.params)
-            XCTAssertTrue(
-                result.isSuccess,
-                "\(testCase.operation) should be handled, got: \(result.message)"
-            )
+            guard case .unverified = result else {
+                return XCTFail("\(testCase.operation) should be unverified, got: \(result.message)")
+            }
         }
 
         await channel.stop()

--- a/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
+++ b/Tests/LogicProMCPTests/CoreMIDIChannelTests.swift
@@ -1,3 +1,4 @@
+import CoreMIDI
 import XCTest
 @testable import LogicProMCP
 
@@ -115,5 +116,38 @@ final class CoreMIDIChannelTests: XCTestCase {
         guard case .error = result else {
             return XCTFail("A stopped MIDI engine must report an error")
         }
+    }
+
+    func testCoreMIDIReportsPartialFanOutAsAccepted() async throws {
+        let channel = CoreMIDIChannel(engine: MIDIEngine())
+        try await channel.start()
+
+        let portName = "Stale Test Port"
+        let created = await channel.execute(
+            operation: "midi.create_virtual_port",
+            params: ["name": portName]
+        )
+        XCTAssertTrue(created.isSuccess)
+
+        let source = try XCTUnwrap((0..<MIDIGetNumberOfSources())
+            .map(MIDIGetSource)
+            .first { endpointName($0) == "\(portName)-Out" })
+        XCTAssertEqual(MIDIEndpointDispose(source), noErr)
+
+        let result = await channel.execute(operation: "transport.play", params: [:])
+        guard case .unverified = result else {
+            await channel.stop()
+            return XCTFail("A send accepted by the primary source must remain accepted")
+        }
+
+        await channel.stop()
+    }
+
+    private func endpointName(_ endpoint: MIDIEndpointRef) -> String? {
+        var value: Unmanaged<CFString>?
+        guard MIDIObjectGetStringProperty(endpoint, kMIDIPropertyDisplayName, &value) == noErr else {
+            return nil
+        }
+        return value?.takeRetainedValue() as String?
     }
 }

--- a/Tests/LogicProMCPTests/PlaceholderTests.swift
+++ b/Tests/LogicProMCPTests/PlaceholderTests.swift
@@ -18,4 +18,10 @@ final class PlaceholderTests: XCTestCase {
         XCTAssertFalse(denied.allGranted)
         XCTAssertTrue(denied.summary.contains("Automation (Logic Pro): NOT GRANTED (denied)"))
     }
+
+    func testUnverifiedDeliveryIsAcceptedWithoutClaimingVerification() {
+        let result = ChannelResult.unverified("sent, not verified")
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.message, "sent, not verified")
+    }
 }

--- a/Tests/LogicProMCPTests/PlaceholderTests.swift
+++ b/Tests/LogicProMCPTests/PlaceholderTests.swift
@@ -1,8 +1,21 @@
 import XCTest
+@testable import LogicProMCP
 
 final class PlaceholderTests: XCTestCase {
-    func testBinaryExists() throws {
-        // Placeholder — real tests require Logic Pro to be running
-        XCTAssertTrue(true)
+    func testAutomationPermissionStatus() {
+        let granted = PermissionChecker.PermissionStatus(
+            accessibility: true,
+            automation: .granted
+        )
+        XCTAssertTrue(granted.automationLogicPro)
+        XCTAssertTrue(granted.allGranted)
+
+        let denied = PermissionChecker.PermissionStatus(
+            accessibility: true,
+            automation: .denied
+        )
+        XCTAssertFalse(denied.automationLogicPro)
+        XCTAssertFalse(denied.allGranted)
+        XCTAssertTrue(denied.summary.contains("Automation (Logic Pro): NOT GRANTED (denied)"))
     }
 }


### PR DESCRIPTION
## What changed
- Distinguish commands that CoreMIDI or macOS accepted from outcomes verified inside Logic Pro.
- Stop fallback routing after an accepted send so one request cannot trigger twice.
- Return real CoreMIDI send failures and clean up sounding notes after cancellation.
- Make the advertised MIDI port resource return real ports and fail as an error, never fake JSON.
- Remove the dead input-state route and add focused checks.

## Validation
- `swift test` — 12 tests passed
- `swift build -c release` — passed
- `git diff --check origin/main...HEAD` — passed

Logic Pro was not running locally, so this does not claim a live DAW outcome.