### PR TITLE
Route the Accessibility check through PermissionChecker

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -10,7 +10,7 @@ actor AccessibilityChannel: Channel {
     func start() async throws {
         // Verify AX trust. If not trusted, the process needs to be added to
         // System Preferences > Privacy & Security > Accessibility.
-        let trusted = AXIsProcessTrusted()
+        let trusted = PermissionChecker.checkAccessibility()
         guard trusted else {
             throw AccessibilityError.notTrusted
         }
@@ -117,7 +117,7 @@ actor AccessibilityChannel: Channel {
     }
 
     func healthCheck() async -> ChannelHealth {
-        guard AXIsProcessTrusted() else {
+        guard PermissionChecker.checkAccessibility() else {
             return .unavailable("Accessibility not trusted — add this process in System Preferences")
         }
         guard ProcessUtils.isLogicProRunning else {


### PR DESCRIPTION
`AccessibilityChannel` asks whether Accessibility is granted twice — `start()` at line 13 and `healthCheck()` at line 120 — and both call `AXIsProcessTrusted()` directly, bypassing `PermissionChecker.checkAccessibility()`.

That helper already exists and already wraps `AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": false])`, and it's what `PermissionChecker.report()` uses to print the Accessibility line. So today the server can answer the same question through two different APIs depending on who asks: the channel uses the legacy call, the permission report uses the options call.

This routes both channel call sites through the helper, so there's a single authority for "is Accessibility granted" — the same consolidation #33 did for the Automation permission.

**No intended behaviour change.** `checkAccessibility(prompt:)` defaults to `false`, so this does not introduce a system dialog on startup.

Verified: `swift build` clean, `swift test --no-parallel` → 13/13 pass on `origin/main` + this commit (macOS 26.7, Swift toolchain from Xcode, Logic Pro 12.3.1).

Two lines, no new API surface. Happy to drop it if you'd rather keep the channel independent of `PermissionChecker`.
